### PR TITLE
fix(observe): parameterize audit writer WHERE clauses

### DIFF
--- a/crates/octarine/src/observe/writers/database/postgres.rs
+++ b/crates/octarine/src/observe/writers/database/postgres.rs
@@ -195,7 +195,6 @@ impl PostgresBackend {
         if let Some(ref resource_id) = query.resource_id {
             conditions.push(format!("resource_id = ${param_idx}"));
             params.push(resource_id.clone());
-            let _ = param_idx; // Explicitly mark as intentionally unused after last use
         }
 
         if query.security_relevant_only {
@@ -395,7 +394,7 @@ impl DatabaseBackend for PostgresBackend {
     }
 
     async fn query_events(&self, query: &AuditQuery) -> Result<QueryResult, WriterError> {
-        let (where_clause, _params) = Self::build_where_clause(query);
+        let (where_clause, params) = Self::build_where_clause(query);
 
         let order = if query.ascending { "ASC" } else { "DESC" };
         let limit_clause = query
@@ -407,17 +406,15 @@ impl DatabaseBackend for PostgresBackend {
             .map(|o| format!("OFFSET {o}"))
             .unwrap_or_default();
 
-        // Build the full query
-        // Note: We're using string interpolation for the dynamic parts since sqlx
-        // doesn't support dynamic WHERE clauses easily. The values are sanitized
-        // through the query builder.
         let sql = format!(
             "SELECT * FROM audit_events {where_clause} ORDER BY timestamp {order} {limit_clause} {offset_clause}"
         );
 
-        // For simplicity, we'll execute without dynamic binding for now
-        // In production, you'd want to use sqlx's query builder or raw bindings
-        let rows: Vec<PgRow> = sqlx::query(&sql)
+        let mut stmt = sqlx::query(&sql);
+        for p in &params {
+            stmt = stmt.bind(p);
+        }
+        let rows: Vec<PgRow> = stmt
             .fetch_all(&self.pool)
             .await
             .map_err(|e| WriterError::Other(format!("Failed to query events: {e}")))?;
@@ -427,10 +424,11 @@ impl DatabaseBackend for PostgresBackend {
 
         // Get total count
         let count_sql = format!("SELECT COUNT(*) as count FROM audit_events {where_clause}");
-        let total_count: i64 = sqlx::query_scalar(&count_sql)
-            .fetch_one(&self.pool)
-            .await
-            .unwrap_or(0);
+        let mut count_stmt = sqlx::query_scalar(&count_sql);
+        for p in &params {
+            count_stmt = count_stmt.bind(p);
+        }
+        let total_count: i64 = count_stmt.fetch_one(&self.pool).await.unwrap_or(0);
 
         let has_more = query.limit.is_some_and(|l| events.len() >= l);
 

--- a/crates/octarine/src/observe/writers/database/sqlite.rs
+++ b/crates/octarine/src/observe/writers/database/sqlite.rs
@@ -138,21 +138,33 @@ impl SqliteBackend {
         &self.pool
     }
 
-    /// Build the WHERE clause from a query
-    fn build_where_clause(query: &AuditQuery) -> String {
+    /// Build the WHERE clause and bind values from a query
+    ///
+    /// Returns a `(sql, params)` tuple. The SQL uses `?` positional
+    /// placeholders for every caller-supplied value; the caller must chain
+    /// `.bind()` over `params` in the same order before executing. Enum- and
+    /// boolean-constrained conditions are interpolated directly because they
+    /// are not attacker-influenced.
+    fn build_where_clause(query: &AuditQuery) -> (String, Vec<String>) {
         let mut conditions = Vec::new();
+        let mut params: Vec<String> = Vec::new();
 
         if let Some(since) = query.since {
-            conditions.push(format!("timestamp >= '{}'", since.to_rfc3339()));
+            conditions.push("timestamp >= ?".to_string());
+            params.push(since.to_rfc3339());
         }
 
         if let Some(until) = query.until {
-            conditions.push(format!("timestamp < '{}'", until.to_rfc3339()));
+            conditions.push("timestamp < ?".to_string());
+            params.push(until.to_rfc3339());
         }
 
         if let Some(ref types) = query.event_types {
-            let type_list: Vec<String> = types.iter().map(|t| format!("'{t:?}'")).collect();
-            conditions.push(format!("event_type IN ({})", type_list.join(", ")));
+            let placeholders: Vec<&str> = types.iter().map(|_| "?").collect();
+            conditions.push(format!("event_type IN ({})", placeholders.join(", ")));
+            for t in types {
+                params.push(format!("{t:?}"));
+            }
         }
 
         if let Some(min_severity) = query.min_severity {
@@ -176,23 +188,28 @@ impl SqliteBackend {
         }
 
         if let Some(ref tenant) = query.tenant_id {
-            conditions.push(format!("tenant_id = '{tenant}'"));
+            conditions.push("tenant_id = ?".to_string());
+            params.push(tenant.clone());
         }
 
         if let Some(ref user) = query.user_id {
-            conditions.push(format!("user_id = '{user}'"));
+            conditions.push("user_id = ?".to_string());
+            params.push(user.clone());
         }
 
         if let Some(corr) = query.correlation_id {
-            conditions.push(format!("correlation_id = '{corr}'"));
+            conditions.push("correlation_id = ?".to_string());
+            params.push(corr.to_string());
         }
 
         if let Some(ref resource_type) = query.resource_type {
-            conditions.push(format!("resource_type = '{resource_type}'"));
+            conditions.push("resource_type = ?".to_string());
+            params.push(resource_type.clone());
         }
 
         if let Some(ref resource_id) = query.resource_id {
-            conditions.push(format!("resource_id = '{resource_id}'"));
+            conditions.push("resource_id = ?".to_string());
+            params.push(resource_id.clone());
         }
 
         if query.security_relevant_only {
@@ -207,11 +224,13 @@ impl SqliteBackend {
             conditions.push("contains_phi = 1".to_string());
         }
 
-        if conditions.is_empty() {
+        let where_clause = if conditions.is_empty() {
             String::new()
         } else {
             format!("WHERE {}", conditions.join(" AND "))
-        }
+        };
+
+        (where_clause, params)
     }
 
     /// Parse a database row into an Event
@@ -405,7 +424,7 @@ impl DatabaseBackend for SqliteBackend {
     }
 
     async fn query_events(&self, query: &AuditQuery) -> Result<QueryResult, WriterError> {
-        let where_clause = Self::build_where_clause(query);
+        let (where_clause, params) = Self::build_where_clause(query);
 
         let order = if query.ascending { "ASC" } else { "DESC" };
         let limit_clause = query
@@ -421,7 +440,11 @@ impl DatabaseBackend for SqliteBackend {
             "SELECT * FROM audit_events {where_clause} ORDER BY timestamp {order} {limit_clause} {offset_clause}"
         );
 
-        let rows: Vec<SqliteRow> = sqlx::query(&sql)
+        let mut stmt = sqlx::query(&sql);
+        for p in &params {
+            stmt = stmt.bind(p);
+        }
+        let rows: Vec<SqliteRow> = stmt
             .fetch_all(&self.pool)
             .await
             .map_err(|e| WriterError::Other(format!("Failed to query events: {e}")))?;
@@ -431,10 +454,11 @@ impl DatabaseBackend for SqliteBackend {
 
         // Get total count
         let count_sql = format!("SELECT COUNT(*) as count FROM audit_events {where_clause}");
-        let total_count: i32 = sqlx::query_scalar(&count_sql)
-            .fetch_one(&self.pool)
-            .await
-            .unwrap_or(0);
+        let mut count_stmt = sqlx::query_scalar(&count_sql);
+        for p in &params {
+            count_stmt = count_stmt.bind(p);
+        }
+        let total_count: i64 = count_stmt.fetch_one(&self.pool).await.unwrap_or(0);
 
         let has_more = query.limit.is_some_and(|l| events.len() >= l);
 
@@ -709,5 +733,152 @@ mod tests {
             SqliteBackend::parse_severity("Unknown"),
             Severity::Info
         ));
+    }
+
+    // ===== SQL Injection Regression Tests =====
+
+    /// Classic SQL injection payload targeting the audit table.
+    const INJECTION_PAYLOAD: &str = "'; DROP TABLE audit_events; --";
+
+    /// Build an event with a fully populated context so filter tests have
+    /// known values to match against.
+    fn event_with_context(
+        tenant: Option<&str>,
+        user: Option<&str>,
+        resource_type: Option<&str>,
+        resource_id: Option<&str>,
+    ) -> Event {
+        let ctx = EventContext {
+            tenant_id: tenant.map(|t| TenantId::new(t).expect("valid tenant id")),
+            user_id: user.map(|u| UserId::new(u).expect("valid user id")),
+            resource_type: resource_type.map(str::to_string),
+            resource_id: resource_id.map(str::to_string),
+            ..EventContext::default()
+        };
+        Event::new(EventType::Info, "Test event").with_context(ctx)
+    }
+
+    /// Assert that the `audit_events` table is intact and contains the
+    /// expected number of rows after a query with a malicious filter.
+    async fn assert_table_intact(backend: &SqliteBackend, expected_rows: usize) {
+        let result = backend
+            .query_events(&AuditQuery::default())
+            .await
+            .expect("baseline query must still succeed — table likely dropped");
+        assert_eq!(
+            result.events.len(),
+            expected_rows,
+            "audit_events table rows missing after injection attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_injection_tenant_id() {
+        let backend = SqliteBackend::in_memory()
+            .await
+            .expect("in_memory should succeed");
+        backend.migrate().await.expect("migration should succeed");
+        backend
+            .store_events(&[test_event(), test_event()])
+            .await
+            .expect("store should succeed");
+
+        let malicious = AuditQuery::builder().tenant_id(INJECTION_PAYLOAD).build();
+        let result = backend
+            .query_events(&malicious)
+            .await
+            .expect("query must treat payload as a literal, not execute it");
+        assert_eq!(result.events.len(), 0);
+        assert_table_intact(&backend, 2).await;
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_injection_user_id() {
+        let backend = SqliteBackend::in_memory()
+            .await
+            .expect("in_memory should succeed");
+        backend.migrate().await.expect("migration should succeed");
+        backend
+            .store_events(&[test_event(), test_event()])
+            .await
+            .expect("store should succeed");
+
+        let malicious = AuditQuery::builder().user_id(INJECTION_PAYLOAD).build();
+        let result = backend
+            .query_events(&malicious)
+            .await
+            .expect("query must treat payload as a literal, not execute it");
+        assert_eq!(result.events.len(), 0);
+        assert_table_intact(&backend, 2).await;
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_injection_resource_type() {
+        let backend = SqliteBackend::in_memory()
+            .await
+            .expect("in_memory should succeed");
+        backend.migrate().await.expect("migration should succeed");
+        backend
+            .store_events(&[test_event(), test_event()])
+            .await
+            .expect("store should succeed");
+
+        let malicious = AuditQuery::builder()
+            .resource_type(INJECTION_PAYLOAD)
+            .build();
+        let result = backend
+            .query_events(&malicious)
+            .await
+            .expect("query must treat payload as a literal, not execute it");
+        assert_eq!(result.events.len(), 0);
+        assert_table_intact(&backend, 2).await;
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_injection_resource_id() {
+        let backend = SqliteBackend::in_memory()
+            .await
+            .expect("in_memory should succeed");
+        backend.migrate().await.expect("migration should succeed");
+        backend
+            .store_events(&[test_event(), test_event()])
+            .await
+            .expect("store should succeed");
+
+        let malicious = AuditQuery::builder().resource_id(INJECTION_PAYLOAD).build();
+        let result = backend
+            .query_events(&malicious)
+            .await
+            .expect("query must treat payload as a literal, not execute it");
+        assert_eq!(result.events.len(), 0);
+        assert_table_intact(&backend, 2).await;
+    }
+
+    /// Positive case: confirm that parameterized binding hasn't regressed the
+    /// happy path — a legitimate tenant filter matches the right row.
+    #[tokio::test]
+    async fn test_sqlite_filter_by_tenant_id_matches() {
+        let backend = SqliteBackend::in_memory()
+            .await
+            .expect("in_memory should succeed");
+        backend.migrate().await.expect("migration should succeed");
+
+        let events = vec![
+            event_with_context(Some("tenant-a"), None, None, None),
+            event_with_context(Some("tenant-b"), None, None, None),
+            event_with_context(Some("tenant-a"), None, None, None),
+        ];
+        backend
+            .store_events(&events)
+            .await
+            .expect("store should succeed");
+
+        let query = AuditQuery::builder().tenant_id("tenant-a").build();
+        let result = backend
+            .query_events(&query)
+            .await
+            .expect("query should succeed");
+        assert_eq!(result.events.len(), 2);
+        assert_eq!(result.total_count, Some(2));
     }
 }

--- a/justfile
+++ b/justfile
@@ -31,6 +31,9 @@ fmt-check:
 fmt:
     cargo fmt --all
 
+# Run all formatters and file fixers via pre-commit on every file in the repo
+fmt-all: pre-commit
+
 # ─── Test ────────────────────────────────────────────────────────────────────
 
 # Run all workspace tests
@@ -59,9 +62,12 @@ test-with-fixtures:
 test-filter PATTERN:
     cargo test --workspace -j4 -- {{PATTERN}}
 
-# Run lib unit tests in octarine by module path (e.g., `just test-mod correlation::proximity`)
-test-mod PATTERN:
-    cargo test -p octarine --lib -j4 -- {{PATTERN}}
+# Run lib unit tests in octarine by module path, optionally enabling features.
+# Examples:
+#   just test-mod correlation::proximity
+#   just test-mod observe::writers::database sqlite,postgres
+test-mod PATTERN FEATURES='':
+    cargo test -p octarine --lib -j4 --features "{{FEATURES}}" -- {{PATTERN}}
 
 # ─── Architecture ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes a **critical SQL injection** in the SQLite audit writer's
`build_where_clause` (`observe/writers/database/sqlite.rs:142-215`), where
caller-supplied `tenant_id`, `user_id`, `resource_type`, and `resource_id`
strings from `AuditQuery` were interpolated directly into SQL via `format!`
and then passed to `sqlx::query(&sql).fetch_all(...)`.

Investigation turned up a **parallel bug in the Postgres writer**: its
`build_where_clause` already produced `$N` placeholders and a `Vec<String>`
of params, but `query_events` discarded them via
`let (where_clause, _params) = ...` and ran `sqlx::query(&sql)` with zero
`.bind()` calls. Postgres rejects missing-parameter queries at the protocol
layer — so filtered Postgres queries were silently broken today rather than
injectable — but the fix is the same shape. Both writers now correctly
bind caller-supplied values.

The commit `chore(just): add fmt-all recipe and feature-aware test-mod` is
an unrelated workflow improvement surfaced during verification (needed to
test feature-gated modules through a `just` recipe instead of raw cargo).

### What changed

- `sqlite.rs` — `build_where_clause` returns `(String, Vec<String>)`;
  `query_events` folds `.bind()` over params for both the SELECT and the
  COUNT query. Enum-constrained conditions (`event_type` Debug, severity
  numeric, booleans) remain interpolated since they are not attacker
  influenced. Also flips `total_count` from `i32` to `i64` for parity with
  Postgres.
- `postgres.rs` — renames `_params` → `params`, folds `.bind()` over both
  queries, removes the `let _ = param_idx;` hack and the misleading
  "we'll execute without dynamic binding for now" comment.
- `justfile` — adds `just fmt-all` alias (runs `pre-commit run --all-files`)
  and makes `just test-mod` accept an optional `FEATURES` argument so
  feature-gated modules can be exercised through the recipe.

### Test plan

- [x] `just clippy` — clean
- [x] `just arch-check` — clean
- [x] `cargo test -p octarine --features "sqlite,postgres" -j4` —
      **5457 passed, 0 failed, 25 ignored** (Postgres live-DB tests remain
      `#[ignore]`'d and are out of scope for CI; manual smoke is optional
      pre-merge)
- [x] New regression tests under `observe::writers::database::sqlite::tests`:
  - `test_sqlite_injection_tenant_id` — `'; DROP TABLE audit_events; --`
    as filter returns 0 matches; table still contains all rows
  - `test_sqlite_injection_user_id` — same, via `user_id`
  - `test_sqlite_injection_resource_type` — same, via `resource_type`
  - `test_sqlite_injection_resource_id` — same, via `resource_id`
  - `test_sqlite_filter_by_tenant_id_matches` — positive case: legitimate
    `tenant_id` filter matches the right rows after parameterization
- [x] All existing tests continue to pass unchanged
  (`test_sqlite_store_and_query`, `test_sqlite_query_filters`,
  `test_sqlite_pagination`, `test_sqlite_delete_before`,
  `test_sqlite_idempotent_insert`)

### Non-goals

- Does not restructure `AuditQuery` or add input validation.
  Defense-in-depth (e.g., newtype-validating `tenant_id` / `user_id` in
  `AuditQuery` the way `EventContext` already does) belongs in a follow-up.
- Does not parameterize `LIMIT` / `OFFSET` / `ORDER BY` — those are
  `usize` and `"ASC"/"DESC"` literals, not attacker influenced.
- Does not touch INSERT paths or `delete_before` — already parameterized.

Closes #153