### PR TITLE
docs: update README version, layer list, and switch docs/index to just

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-octarine = { git = "https://github.com/joshjhall/octarine", tag = "v0.2.0" }
+octarine = { git = "https://github.com/joshjhall/octarine", tag = "v0.3.0-beta.1" }
 ```
 
 Enable only the features you need:
 
 ```toml
 [dependencies]
-octarine = { git = "https://github.com/joshjhall/octarine", tag = "v0.2.0", default-features = false, features = ["observe", "security"] }
+octarine = { git = "https://github.com/joshjhall/octarine", tag = "v0.3.0-beta.1", default-features = false, features = ["observe", "security"] }
 ```
 
 ## Feature Flags
@@ -74,7 +74,7 @@ Three-layer architecture preventing circular dependencies:
 ```text
 Layer 1: primitives/  — Pure functions, no side effects
 Layer 2: observe/     — Observability, uses primitives only
-Layer 3: data/, runtime/, crypto/  — Uses primitives + observe
+Layer 3: data/, security/, identifiers/, runtime/, crypto/, io/, auth/, http/  — Uses primitives + observe
 ```
 
 See [`docs/`](docs/) for detailed documentation and [`crates/octarine/examples/`](crates/octarine/examples/) for runnable examples.

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,14 +73,14 @@ git clone <repository>
 cd octarine
 
 # Build and test
-make build
-make test
+just build
+just test
 
 # Run security checks
-make security
+just deps-audit
 
 # See all commands
-make help
+just --list
 ```
 
 ## Project Links


### PR DESCRIPTION
## Summary

Fixes three stale documentation findings from the `audit-docs` scanner:

- **README Quick Start version tag** — both `[dependencies]` examples now
  pin `tag = "v0.3.0-beta.1"` (was `v0.2.0`, ~6 months behind).
- **README Architecture Layer 3 list** — now enumerates all eight Layer 3
  modules: `data/`, `security/`, `identifiers/`, `runtime/`, `crypto/`,
  `io/`, `auth/`, `http/`. Previously only `data/, runtime/, crypto/` were
  listed, which undercounted the surface area a new contributor sees on
  the landing README.
- **docs/index.md Quick Start** — switched `make build/test/security/help`
  to `just build/test/deps-audit/--list`. No `Makefile` exists in the repo;
  the previous snippet failed immediately for anyone who copy-pasted it.
  Recipe choices verified against `just --list`; `deps-audit` is the
  closest 1:1 for "security checks" since no `just security` exists.

A broader `grep` sweep across `README.md`, `docs/`, and `CLAUDE.md`
confirmed no other stale `v0.2.0` or `make …` references remain.

## Test plan

- [x] `grep -n "v0.2.0" README.md` → no matches after fix.
- [x] `grep -n "^make " docs/index.md` → no matches after fix.
- [x] Visually re-read all three changed regions to confirm fenced-block
      formatting preserved.
- [x] `pre-commit run --files README.md docs/index.md` — all configured
      hooks pass (trim trailing whitespace, end-of-file, secrets, etc.).
- [x] No Rust code touched → full test suite not run; no behavior changes
      possible from this diff.

Closes #182