### PR TITLE
ci: skip workflow on docs-only changes via paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE*'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Adds `paths-ignore` to both `push:` and `pull_request:` triggers so the
Rust CI matrix is skipped when a push or PR only touches documentation:

```yaml
paths-ignore:
  - '**.md'
  - 'docs/**'
  - 'LICENSE*'
```

## Motivation

Issue #182 shipped today as a pure docs fix (three markdown edits, zero
Rust touched) and paid ~10 minutes waiting for the full 12-check matrix
(Clippy, Test, Test nightly, Doc, Cargo Deny, Architecture, Check Windows,
Check macOS, Format, plus CodeQL on actions + Rust) to go green before
merge. Every future `audit/docs`, README tweak, or CHANGELOG bump would
have paid the same tax.

Native `paths-ignore` is zero new deps, zero new jobs, zero third-party
actions. GitHub's behavior: the workflow is skipped only when **every**
changed path matches an ignore pattern, so mixed PRs (code + docs) still
run the full matrix — no regression risk.

## What stays gated

Intentionally **not** in `paths-ignore`:
- `.github/workflows/**` — changing CI itself must run CI.
- `Cargo.toml`, `Cargo.lock`, `justfile`, `rust-toolchain.toml` — build
  config.
- Any `.rs` file anywhere.
- Any non-`.md` file at repo root not matching `LICENSE*`.

## Future-compatibility note

This is safe today because the repo has no branch protection. If/when
required status checks are added, skipped workflows could be flagged as
missing checks on docs-only PRs; that will need a per-job conditional
pattern or split workflows at that point. Out of scope here.

## Test plan

- [x] `pre-commit run check-yaml --files .github/workflows/ci.yml` — passes.
- [x] This PR itself touches `.github/workflows/ci.yml` (not in ignore
      list), so CI should run the full matrix as normal — confirming
      non-docs changes are unaffected.
- [ ] Post-merge: open a tiny docs-only test PR, confirm zero checks run.
- [ ] Post-merge: open a mixed (code + docs) PR, confirm full matrix runs.