### PR TITLE
test(just): enable --all-features in test recipes so gated tests run

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,31 +36,31 @@ fmt-all: pre-commit
 
 # ─── Test ────────────────────────────────────────────────────────────────────
 
-# Run all workspace tests
+# Run all workspace tests (all features — matches `just clippy`)
 test:
-    cargo test --workspace -j4
+    cargo test --workspace --all-features -j4
 
 # Run tests with output visible
 test-verbose:
-    cargo test --workspace -j4 -- --nocapture
+    cargo test --workspace --all-features -j4 -- --nocapture
 
 # Run tests for the octarine crate only
 test-octarine:
-    cargo test -p octarine -j4
+    cargo test -p octarine --all-features -j4
 
 # Run performance/timing tests (ignored by default, run before releases)
 test-perf:
-    cargo test -p octarine -j4 test_perf_ -- --ignored
-    cargo test -p octarine -j4 test_adversarial_ -- --ignored
-    cargo test -p octarine -j4 test_batch_processor_time_flush -- --ignored
+    cargo test -p octarine --all-features -j4 test_perf_ -- --ignored
+    cargo test -p octarine --all-features -j4 test_adversarial_ -- --ignored
+    cargo test -p octarine --all-features -j4 test_batch_processor_time_flush -- --ignored
 
-# Run tests with the testing feature enabled
+# Run tests with the testing feature enabled (kept for explicit minimal-feature runs)
 test-with-fixtures:
     cargo test -p octarine -j4 --features testing
 
 # Run a specific test by name pattern
 test-filter PATTERN:
-    cargo test --workspace -j4 -- {{PATTERN}}
+    cargo test --workspace --all-features -j4 -- {{PATTERN}}
 
 # Run lib unit tests in octarine by module path, optionally enabling features.
 # Examples:


### PR DESCRIPTION
## Summary

`just test` ran `cargo test --workspace -j4` with default features only, so every test file with a top-level `#![cfg(feature = "...")]` gate compiled to zero tests. This silently skipped ~100 tests in CI:

- `tests/proptest_security.rs` — **0 → 7** property tests (path traversal, command injection, SSRF, SQL injection — this is the specific finding in #180)
- `tests/auth_integration.rs` — **0 → 33** tests (gated on `auth`)
- `tests/http_integration.rs` — **0 → 51** tests (gated on `http`)
- `tests/config_derive_integration.rs` — **0 → 9** tests (gated on `derive`)

`.github/workflows/ci.yml` runs `just test`, so those tests had not actually been executed in CI.

Add `--all-features` to `test`, `test-verbose`, `test-octarine`, `test-filter`, and `test-perf`. Matches the convention already used by `just clippy`. `test-with-fixtures` is preserved for explicit minimal-feature runs.

### Note on scope

#180 proposed removing the inner `#[cfg(feature = "database")]` gate on the `sql_injection_tests` module as the preferred fix. That approach does **not** compile: `pub mod queries` in `src/security/mod.rs:81` is itself `#[cfg(feature = "database")]`-gated, so removing the test's gate without adopting option 3 leaves the `octarine::security::queries` import unresolved when `testing` is on but `database` is off. The audit's option 3 ("ensure `just test` and CI `--all-features` always include `database`") is the right lever — and it also un-silences the three unrelated integration-test files that have the same pattern.

## Test plan

- [x] `just preflight` — green (fmt, clippy, shellcheck, arch-check, test)
- [x] `cargo test --workspace --all-features -j4 --test proptest_security` — 7 tests pass including `sql_injection_tests::sql_injection_detected`
- [x] Verified previously-silent binaries now run: `auth_integration` (33), `http_integration` (51), `config_derive_integration` (9)

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)