### PR TITLE
fix(auth): redact plaintext tokens from Debug impls

### DIFF
--- a/crates/octarine/src/primitives/auth/remember/token.rs
+++ b/crates/octarine/src/primitives/auth/remember/token.rs
@@ -274,12 +274,26 @@ impl std::fmt::Display for RememberToken {
 ///
 /// This is what gets sent to the client in the cookie.
 /// The format is `selector:validator` (both base64 encoded).
-#[derive(Debug, Clone)]
+///
+/// `Debug` is implemented manually to redact the plaintext `validator` —
+/// derived `Debug` would leak the secret via logs, panics, or test output.
+#[derive(Clone)]
 pub struct RememberTokenPair {
     /// The stored token (with hashed validator)
     token: RememberToken,
     /// The plaintext validator (only available at generation time)
     validator: String,
+}
+
+impl std::fmt::Debug for RememberTokenPair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `token` contains only a validator_hash (SHA-256), not plaintext —
+        // safe to print via its derived Debug. Only `validator` is secret.
+        f.debug_struct("RememberTokenPair")
+            .field("token", &self.token)
+            .field("validator", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl RememberTokenPair {
@@ -689,6 +703,24 @@ mod tests {
         let display = pair.token().to_string();
 
         assert!(display.contains("..."));
+    }
+
+    #[test]
+    fn test_pair_debug_redacts_validator() {
+        let config = RememberConfig::default();
+        let pair = generate_remember_token("user123", &config, None);
+        let debug_str = format!("{pair:?}");
+
+        // Plaintext validator must not appear anywhere in Debug output.
+        assert!(
+            !debug_str.contains(pair.validator()),
+            "Debug output leaked plaintext validator: {debug_str}"
+        );
+        // Redaction marker is present.
+        assert!(debug_str.contains("[REDACTED]"));
+        // Selector (not a secret) still visible for diagnostics.
+        assert!(debug_str.contains(pair.selector()));
+        assert!(debug_str.contains("RememberTokenPair"));
     }
 
     #[test]

--- a/crates/octarine/src/primitives/auth/reset/token.rs
+++ b/crates/octarine/src/primitives/auth/reset/token.rs
@@ -105,7 +105,10 @@ impl ResetConfigBuilder {
 ///
 /// Reset tokens are secure, time-limited, single-use tokens for password
 /// reset flows. Each token has 256 bits of entropy by default.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is implemented manually to mask the plaintext `token` field —
+/// derived `Debug` would leak the secret via logs, panics, or test output.
+#[derive(Clone)]
 pub struct ResetToken {
     /// The token value (URL-safe base64)
     token: String,
@@ -213,6 +216,23 @@ impl std::fmt::Display for ResetToken {
         } else {
             write!(f, "{}", &self.token)
         }
+    }
+}
+
+impl std::fmt::Debug for ResetToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Mask the plaintext token — same first-8-char scheme as Display.
+        let masked = self
+            .token
+            .get(..8)
+            .map_or_else(|| self.token.clone(), |prefix| format!("{prefix}..."));
+        f.debug_struct("ResetToken")
+            .field("token", &masked)
+            .field("user_id", &self.user_id)
+            .field("created_at", &self.created_at)
+            .field("lifetime", &self.lifetime)
+            .field("used", &self.used)
+            .finish()
     }
 }
 
@@ -571,6 +591,24 @@ mod tests {
 
         assert!(display.contains("..."));
         assert!(!display.contains(token.value()));
+    }
+
+    #[test]
+    fn test_debug_redacts_token() {
+        let config = ResetConfig::default();
+        let token = generate_reset_token("user123", &config);
+        let debug_str = format!("{token:?}");
+
+        // Full plaintext token must not appear anywhere in Debug output.
+        assert!(
+            !debug_str.contains(token.value()),
+            "Debug output leaked plaintext token: {debug_str}"
+        );
+        // Masked form is present.
+        assert!(debug_str.contains("..."));
+        // Non-secret fields still visible for diagnostics.
+        assert!(debug_str.contains("user123"));
+        assert!(debug_str.contains("ResetToken"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `ResetToken` and `RememberTokenPair` derived `Debug`, which printed plaintext secret fields verbatim. A single `tracing::debug!("{:?}", token)` call, panic backtrace, or failed test assertion would leak a usable password-reset link or remember-me validator.
- Drop `Debug` from the derives on both types and implement `fmt::Debug` manually.
- `ResetToken`: masks the `token` field to first 8 chars + `...` (matches existing `Display` impl).
- `RememberTokenPair`: redacts the plaintext `validator` as `[REDACTED]`. The inner `RememberToken` keeps its derived `Debug` — its `validator_hash` field is a SHA-256 hash, not plaintext.
- Pattern mirrors `primitives/crypto/secrets/env.rs` `PrimitiveSecureEnv` Debug impl.

## Scope note
`Zeroize` on the backing `String` buffers (mentioned as "also consider" in the audit) is **out of scope**. Proper zeroization of `String` requires wrapping in `SecretCore<String>` — a larger refactor touching generation, storage, and all consumers. Best filed as a follow-up issue after this ships.

## Test plan
- [x] Added `test_debug_redacts_token` — verifies `{:?}` on `ResetToken` does not contain the plaintext token, does contain `...`, and still shows non-secret fields (`user_id`, `ResetToken` struct name).
- [x] Added `test_pair_debug_redacts_validator` — verifies `{:?}` on `RememberTokenPair` does not contain the plaintext validator, does contain `[REDACTED]`, and still shows the public selector.
- [x] `just test-mod "primitives::auth::reset::token" "auth"` — 24/24 pass
- [x] `just test-mod "primitives::auth::remember::token" "auth"` — 24/24 pass
- [x] `just preflight` — fmt + clippy + arch-check + full test suite all pass

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)