### PR TITLE
docs(architecture): make refactor-plan self-contained; drop dead src/refactor-plan.md links

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -10,8 +10,7 @@ This section covers the system design, patterns, and architectural decisions for
 - **Testing Patterns**: [`testing-patterns.md`](./testing-patterns.md) - Shared test infrastructure
 - **Data Module Architecture**: [`../security/data-module-architecture.md`](../security/data-module-architecture.md) - Security/data module design
 - **Async + Observability Integration**: [`async-observability-integration.md`](./async-observability-integration.md) - Comprehensive async runtime instrumentation
-- **Refactor Plan**: [`refactor-plan.md`](./refactor-plan.md) - Current status and roadmap
-- **Full Plan**: [`../../src/refactor-plan.md`](../../src/refactor-plan.md) - Detailed refactor plan
+- **Refactor Status**: [`refactor-plan.md`](./refactor-plan.md) - Completed refactor summary (v0.3.0-beta.1)
 
 ## In This Section
 
@@ -46,14 +45,13 @@ Comprehensive data security operations architecture:
 - Integration with observe module for automatic auditing
 - Migration guide from old input module
 
-### [Refactor Plan](./refactor-plan.md)
+### [Refactor Status](./refactor-plan.md)
 
-Current refactoring status with:
+Summary of the completed v0.3.0 refactor:
 
-- Module completion tracking
-- Phase-based implementation strategy
-- Links to detailed plan in source tree
-- Contributing guidelines
+- Three-layer architecture rationale
+- Per-module completion status
+- Links to live architecture docs
 
 ## Key Architectural Principles
 

--- a/docs/architecture/refactor-plan.md
+++ b/docs/architecture/refactor-plan.md
@@ -1,111 +1,136 @@
-# Refactor Plan
+# Refactor Status
+
+> **Status:** Complete as of v0.3.0-beta.1.
+>
+> The refactor described on this page delivered octarine's three-layer
+> architecture, unified observability, and the orthogonal
+> data/security/identifiers split. This page is retained as a summary of
+> what shipped; live architecture documentation is referenced at the
+> bottom.
 
 ## Overview
 
-The octarine library is undergoing a comprehensive refactor to implement consistent patterns, improve security, and enhance observability. The complete plan is maintained in the source tree.
+Octarine's v0.3.0 refactor rebuilt the crate around a three-layer
+architecture that prevents circular dependencies and separates concerns
+cleanly:
 
-## Current Plan
+```text
+Layer 1: primitives/    (pub(crate))  Pure functions, no observe dependency
+            ↓
+Layer 2: observe/       (pub)         Observability; uses primitives only
+            ↓
+Layer 3: data/, security/, identifiers/, runtime/,
+         crypto/, io/, auth/, http/   (pub)   Uses primitives + observe
+```
 
-📄 **[View the Unified Refactor Plan](../../src/refactor-plan.md)**
+Layer 1 is further split into three orthogonal concerns that answer
+distinct questions:
 
-## Key Objectives
+| Concern | Purpose | Question |
+| --- | --- | --- |
+| `data/` | FORMAT | "How should this be structured?" |
+| `security/` | THREATS | "Is this dangerous?" |
+| `identifiers/` | CLASSIFICATION | "What is it? Is it PII?" |
 
-### 1. Clean API First
+## Objectives (all delivered)
 
-- No backward compatibility layers
-- Fresh, modern API design
-- Consistent patterns throughout
+### Clean API
 
-### 2. Three-Layer Architecture
+- No backward-compatibility layers
+- Consistent naming conventions (prefix indicates return type)
+- Builder + shortcut pattern across every Layer 3 module
 
-- Core implementation (business logic)
-- Builder pattern (configuration)
-- Simple functions (convenience)
+### Three-layer architecture
 
-### 3. Nine Security Contexts
+- Layer 1 primitives are `pub(crate)` — pure, observe-free
+- Layer 2 observe depends only on primitives
+- Layer 3 wraps primitives with automatic instrumentation
 
-Organize all input handling into:
+### Unified observability
 
-- paths, network, authentication
-- formats, text, commands
-- queries, crypto, identifiers
+- Automatic WHO/WHAT/WHEN/WHERE context capture
+- 30+ PII types detected and redacted
+- SOC2, HIPAA, GDPR, PCI-DSS compliance mappings
+- Multi-writer output (console, file/JSONL, SQLite, PostgreSQL)
 
-### 4. Unified Observability
+### Orthogonal concerns
 
-- Automatic event generation
-- Context propagation
-- Comprehensive audit trails
-
-## Current Status
-
-### ✅ Completed
-
-- **paths module** - Reference implementation for other modules
-- **Problem type** - Unified error handling with events
-- **Event system** - Business, security, system events
-- **Context propagation** - Automatic context capture
-
-### 🚧 In Progress
-
-- Security input module refactoring
-- Observe module enhancements
-- Documentation updates
-
-### 📋 Planned
-
-- Remaining security contexts
-- Performance optimizations
-- Integration examples
+- Each domain (paths, network, text) can have FORMAT + THREATS +
+  CLASSIFICATION modules independently
 
 ## Module Status
 
+### Layer 1 — `primitives/` (pub(crate))
+
 | Module | Status | Notes |
-|--------|--------|-------|
-| **security/data/paths** | ✅ Complete | Reference implementation |
-| **security/data/network** | 🚧 In Progress | URLs, IPs, ports |
-| **security/data/authentication** | 📋 Planned | Passwords, tokens |
-| **security/data/formats** | 📋 Planned | JSON, XML, dates |
-| **security/data/text** | 📋 Planned | Unicode, encoding |
-| **security/data/commands** | 📋 Planned | Shell commands |
-| **security/data/queries** | 📋 Planned | SQL, GraphQL |
-| **security/data/crypto** | 📋 Planned | Keys, certificates |
-| **security/data/identifiers** | 📋 Planned | Email, PII |
-| **observe/event** | ✅ Complete | Event generation |
-| **observe/problem** | ✅ Complete | Error handling |
-| **observe/context** | ✅ Complete | Context capture |
-| **observe/writers** | 🚧 In Progress | Output destinations |
+| --- | --- | --- |
+| `primitives/types` | ✅ | `Problem`, `Result`, shared types |
+| `primitives/data/paths` | ✅ | Path normalization |
+| `primitives/data/network` | ✅ | URL/hostname formatting |
+| `primitives/data/text` | ✅ | Text normalization, encoding |
+| `primitives/security/paths` | ✅ | Traversal, injection detection |
+| `primitives/security/network` | ✅ | SSRF, encoding attacks |
+| `primitives/security/commands` | ✅ | Command injection detection |
+| `primitives/security/queries` | ✅ | Query injection detection |
+| `primitives/security/formats` | ✅ | Format-based attacks |
+| `primitives/security/crypto` | ✅ | Cryptographic threat detection |
+| `primitives/identifiers/network` | ✅ | IP, MAC, URL, UUID |
+| `primitives/identifiers/personal` | ✅ | SSN, email, phone, names |
+| `primitives/identifiers/financial` | ✅ | Credit cards, bank accounts |
+| `primitives/identifiers/*` | ✅ | credentials, medical, government, etc. |
+| `primitives/crypto` | ✅ | Cryptographic primitives |
+| `primitives/io` | ✅ | File operations |
+| `primitives/runtime` | ✅ | Async utilities |
 
-## Implementation Strategy
+### Layer 2 — `observe/` (pub)
 
-### Phase 1: Core Infrastructure (Current)
+| Module | Status | Notes |
+| --- | --- | --- |
+| `observe/event` | ✅ | Event generation |
+| `observe/problem` | ✅ | Error handling with audit trails |
+| `observe/context` | ✅ | Automatic context capture |
+| `observe/audit` | ✅ | Audit trail generation |
+| `observe/builder` | ✅ | Observe builder patterns |
+| `observe/compliance` | ✅ | SOC2, HIPAA, GDPR, PCI-DSS mappings |
+| `observe/metrics` | ✅ | Metrics collection |
+| `observe/pii` | ✅ | PII detection and redaction |
+| `observe/tracing` | ✅ | Distributed tracing |
+| `observe/writers` | ✅ | Console, file, SQLite, PostgreSQL |
+| `observe/aggregate` | ✅ | Aggregation helpers |
 
-1. Establish patterns with paths module
-1. Implement observe module foundation
-1. Create comprehensive documentation
+### Layer 3 — domain modules (pub)
 
-### Phase 2: Security Contexts
+| Module | Status | Notes |
+| --- | --- | --- |
+| `data/` | ✅ | `paths`, `network`, `text`, `formats`, `tokens` |
+| `security/` | ✅ | `paths`, `network`, `commands`, `queries`, `formats` |
+| `identifiers/` | ✅ | Classification with observe instrumentation |
+| `runtime/` | ✅ | Async runtime operations |
+| `crypto/` | ✅ | Crypto operations |
+| `io/` | ✅ | I/O operations |
+| `auth/` | ✅ | Auth operations |
+| `http/` | ✅ | HTTP operations |
 
-1. Implement remaining input contexts
-1. Add validation and sanitization
-1. Create integration tests
+### Test infrastructure
 
-### Phase 3: Integration & Polish
+| Module | Status | Notes |
+| --- | --- | --- |
+| `testing/` | ✅ | Feature-gated; API helpers, assertions, fixtures, generators |
 
-1. Add practical examples
-1. Performance optimization
-1. Publish to crates.io
+## Follow-on work (tracked separately)
 
-## Contributing
+Work not part of the original refactor scope, tracked via the issue
+backlog:
 
-See the [Unified Refactor Plan](../../src/refactor-plan.md) for:
-
-- Detailed implementation guidelines
-- Code organization rules
-- Testing requirements
-- Documentation standards
+- Performance tuning and benchmarking
+- Additional integration examples
+- Documentation refinements and API reference polish
 
 ## Related Documentation
 
-- [Module Patterns](./module-patterns.md) - Three-layer architecture
-- [System Design](./system-design.md) - Overall architecture
-- [Input Architecture](../security/patterns/input-architecture.md) - Security design
+- [Layer Architecture](./layer-architecture.md) — Authoritative layer
+  boundary specification (start here)
+- [Module Patterns](./module-patterns.md) — Three-layer pattern and builder
+  pattern
+- [System Design](./system-design.md) — Overall library architecture
+- [Naming Conventions](../api/naming-conventions.md) — API naming rules

--- a/docs/architecture/security/identifiers.md
+++ b/docs/architecture/security/identifiers.md
@@ -879,7 +879,7 @@ ______________________________________________________________________
 
 ### Internal Documentation
 
-- `src/refactor-plan.md`: Module refactoring roadmap
+- `docs/architecture/refactor-plan.md`: Refactor status summary (v0.3.0-beta.1)
 - `src/security/data/MODULE_QUALITY_SCORECARD.md`: Quality metrics framework
 - `CLAUDE.md`: Zero-trust security philosophy
 - `docs/security/patterns/detection-validation-sanitization.md`: Layer separation philosophy

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,14 +88,14 @@ just --list
 - **Main README**: [`../README.md`](../README.md)
 - **Security Policy**: [`../SECURITY.md`](../SECURITY.md)
 - **Changelog**: [`../CHANGELOG.md`](../CHANGELOG.md)
-- **Refactor Plan**: [`../src/refactor-plan.md`](../src/refactor-plan.md)
+- **Refactor Status**: [`./architecture/refactor-plan.md`](./architecture/refactor-plan.md)
 
 ## For AI Assistants
 
 When working with this codebase, start with:
 
 1. [`../CLAUDE.md`](../CLAUDE.md) - Project-specific AI instructions
-1. [`../src/refactor-plan.md`](../src/refactor-plan.md) - Current refactor plan
+1. [`./architecture/layer-architecture.md`](./architecture/layer-architecture.md) - Layer boundaries and dependency rules
 1. [`./structure.md`](./structure.md) - Documentation organization
 1. Relevant section index for the task at hand
 


### PR DESCRIPTION
## Summary

`docs/architecture/refactor-plan.md` was stale in two ways at v0.3.0-beta.1:

- The module status table listed `security/data/{formats,commands,queries,crypto,text,authentication,identifiers}` as *Planned* when all of them (and the rest of the three-layer architecture) are shipped. `observe/writers` was marked *In Progress*; Phase 1 was marked *Current*.
- The page pointed twice at `../../src/refactor-plan.md` as the "Unified Refactor Plan". That file does not exist — sources live under `crates/octarine/src/`, and no such plan file is present there either.

Changes:

- Rewrite `refactor-plan.md` as a self-contained refactor-status summary. Status table now reflects the actual `primitives/` + `observe/` + Layer 3 (`data/`, `security/`, `identifiers/`, `runtime/`, `crypto/`, `io/`, `auth/`, `http/`) tree, all ✅. Three-phase strategy removed (all phases complete).
- Purge the dead `src/refactor-plan.md` path from the four other docs that referenced it: `docs/architecture/index.md`, `docs/index.md` (x2), `docs/architecture/security/identifiers.md`. Each reference is either dropped (when redundant) or repointed at a real doc (`architecture/refactor-plan.md` or `layer-architecture.md`).

## Test plan

- [x] `grep -rn "src/refactor-plan" docs/ README.md` returns zero matches
- [x] Remaining `refactor-plan.md` references all resolve (verified against filesystem)
- [x] `pre-commit` passes on the four modified files
- [x] Pre-push `cargo clippy` + `cargo test` pass (docs-only change — no code affected)

Closes #183