### PR TITLE
test(observe): add unit tests for Problem and Event shortcuts

### DIFF
--- a/crates/octarine/src/observe/event/shortcuts.rs
+++ b/crates/octarine/src/observe/event/shortcuts.rs
@@ -82,3 +82,145 @@ pub fn auth_failure(user: &str, _reason: &str) {
         .with_context(context_shortcuts::authentication(user))
         .auth_failure();
 }
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    //! Tests for the event shortcuts.
+    //!
+    //! # Why not MemoryWriter capture?
+    //!
+    //! The audit finding (`test-gaps-007`) suggested using `MemoryWriter`
+    //! to capture events and assert on `EventType` (e.g. `auth_failure` →
+    //! `EventType::LoginFailure`). That approach is not currently feasible:
+    //! `writers::dispatch_to_writers_sync` calls
+    //! `tokio::runtime::Builder::new_current_thread().build().block_on(...)`
+    //! from within the async dispatcher's existing runtime, which panics
+    //! with "Cannot start a runtime from within a runtime". The panic is
+    //! swallowed, so registered writers silently never receive dispatched
+    //! events. (Verified empirically: events DO queue —
+    //! `dispatcher_stats()` increments — but never reach the writer.)
+    //!
+    //! Until that pre-existing dispatcher bug is fixed, the best coverage
+    //! we can give these shortcuts is:
+    //!
+    //! 1. **Smoke tests** — call the shortcut, assert no panic. Covers the
+    //!    full synchronous call path up to the queue enqueue.
+    //! 2. **Queue assertion** — verify `dispatcher_stats()` increments
+    //!    after the shortcut is called, proving the event reaches the
+    //!    dispatcher boundary (the last point we can observe it).
+    //!
+    //! EventType assertions remain the subject of a follow-up issue on
+    //! the dispatcher runtime-in-runtime panic.
+
+    use super::*;
+    use crate::observe::writers::dispatcher_stats;
+    use std::time::Duration;
+
+    // ==========================================
+    // Smoke tests — no panic across shortcut call paths
+    // ==========================================
+
+    #[test]
+    fn debug_smoke() {
+        debug("debug message");
+    }
+
+    #[test]
+    fn info_smoke() {
+        info("info message");
+    }
+
+    #[test]
+    fn warn_smoke() {
+        warn("warn message");
+    }
+
+    #[test]
+    fn error_smoke() {
+        error("error message");
+    }
+
+    #[test]
+    fn critical_smoke() {
+        critical("critical message");
+    }
+
+    #[test]
+    fn success_smoke() {
+        success("success message");
+    }
+
+    #[test]
+    fn trace_smoke() {
+        trace("trace message");
+    }
+
+    #[test]
+    fn auth_success_smoke() {
+        auth_success("alice");
+    }
+
+    #[test]
+    fn auth_failure_smoke() {
+        auth_failure("alice", "bad password");
+    }
+
+    // ==========================================
+    // Queue assertions — shortcut reaches dispatcher
+    // ==========================================
+    //
+    // These are `#[tokio::test]` because the dispatcher stats are backed by
+    // atomics that may not be immediately visible after the enqueue
+    // returns; a brief yield + sleep lets the background thread update the
+    // counter. `#[serial]` is used because `dispatcher_stats()` reads a
+    // global — parallel callers would interfere with the before/after
+    // delta.
+
+    async fn yield_to_dispatcher() {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn info_increments_dispatcher_queue() {
+        let before = dispatcher_stats().total_written;
+        info("queue-assertion-info");
+        yield_to_dispatcher().await;
+        let after = dispatcher_stats().total_written;
+        assert!(
+            after > before,
+            "info() should enqueue at least one event (before={before}, after={after})"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn critical_increments_dispatcher_queue() {
+        let before = dispatcher_stats().total_written;
+        critical("queue-assertion-critical");
+        yield_to_dispatcher().await;
+        let after = dispatcher_stats().total_written;
+        assert!(
+            after > before,
+            "critical() should enqueue at least one event (before={before}, after={after})"
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn auth_failure_increments_dispatcher_queue() {
+        // Load-bearing: regressions that silently no-op this shortcut would
+        // break security monitoring — the queue delta is the strongest
+        // observable signal until the dispatcher runtime-in-runtime bug is
+        // fixed and we can assert on EventType::LoginFailure.
+        let before = dispatcher_stats().total_written;
+        auth_failure("alice", "invalid credentials");
+        yield_to_dispatcher().await;
+        let after = dispatcher_stats().total_written;
+        assert!(
+            after > before,
+            "auth_failure() should enqueue at least one event for audit (before={before}, after={after})"
+        );
+    }
+}

--- a/crates/octarine/src/observe/problem/builder/create_shortcuts.rs
+++ b/crates/octarine/src/observe/problem/builder/create_shortcuts.rs
@@ -181,3 +181,120 @@ pub fn operation_failed(message: impl Into<String>) -> Problem {
 pub fn other(message: impl Into<String>) -> Problem {
     ProblemBuilder::new(message).other()
 }
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // Note on surprising mappings verified against observe/problem/create.rs:
+    //   security() and security_audit() → Problem::PermissionDenied
+    //     (the Problem enum has no Security variant; create_security wraps in
+    //      PermissionDenied and emits a critical audit event as a side effect).
+    //   system() → Problem::Other
+    //     (per create_shortcuts.rs note: "system() doesn't exist, use other() for now").
+
+    #[test]
+    fn validation_returns_validation_variant() {
+        let p = validation("bad input");
+        assert!(matches!(&p, Problem::Validation(m) if m == "bad input"));
+    }
+
+    #[test]
+    fn validation_minimal_returns_validation_variant() {
+        let p = validation_minimal("bad input");
+        assert!(matches!(&p, Problem::Validation(m) if m == "bad input"));
+    }
+
+    #[test]
+    fn conversion_returns_conversion_variant() {
+        let p = conversion("cannot convert");
+        assert!(matches!(&p, Problem::Conversion(m) if m == "cannot convert"));
+    }
+
+    #[test]
+    fn sanitization_returns_sanitization_variant() {
+        let p = sanitization("contains shell meta");
+        assert!(matches!(&p, Problem::Sanitization(m) if m == "contains shell meta"));
+    }
+
+    #[test]
+    fn permission_denied_returns_permission_denied_variant() {
+        let p = permission_denied("access denied");
+        assert!(matches!(&p, Problem::PermissionDenied(m) if m == "access denied"));
+    }
+
+    #[test]
+    fn security_returns_permission_denied_variant() {
+        // NOTE: shortcut is named `security` but wraps in PermissionDenied — see module comment.
+        let p = security("SQL injection attempt");
+        assert!(matches!(&p, Problem::PermissionDenied(m) if m == "SQL injection attempt"));
+    }
+
+    #[test]
+    fn security_audit_returns_permission_denied_variant() {
+        let p = security_audit("privilege escalation", "alice");
+        assert!(matches!(&p, Problem::PermissionDenied(m) if m == "privilege escalation"));
+    }
+
+    #[test]
+    fn system_returns_other_variant() {
+        // NOTE: shortcut is named `system` but returns Problem::Other — see module comment.
+        let p = system("disk full");
+        assert!(matches!(&p, Problem::Other(m) if m == "disk full"));
+    }
+
+    #[test]
+    fn config_returns_config_variant() {
+        let p = config("missing API key");
+        assert!(matches!(&p, Problem::Config(m) if m == "missing API key"));
+    }
+
+    #[test]
+    fn not_found_returns_not_found_variant() {
+        let p = not_found("user#42");
+        assert!(matches!(&p, Problem::NotFound(m) if m == "user#42"));
+    }
+
+    #[test]
+    fn auth_returns_auth_variant() {
+        let p = auth("invalid token");
+        assert!(matches!(&p, Problem::Auth(m) if m == "invalid token"));
+    }
+
+    #[test]
+    fn network_returns_network_variant() {
+        let p = network("connection refused");
+        assert!(matches!(&p, Problem::Network(m) if m == "connection refused"));
+    }
+
+    #[test]
+    fn database_returns_database_variant() {
+        let p = database("deadlock detected");
+        assert!(matches!(&p, Problem::Database(m) if m == "deadlock detected"));
+    }
+
+    #[test]
+    fn parse_returns_parse_variant() {
+        let p = parse("unexpected token");
+        assert!(matches!(&p, Problem::Parse(m) if m == "unexpected token"));
+    }
+
+    #[test]
+    fn timeout_returns_timeout_variant() {
+        let p = timeout("request timed out after 30s");
+        assert!(matches!(&p, Problem::Timeout(m) if m == "request timed out after 30s"));
+    }
+
+    #[test]
+    fn operation_failed_returns_operation_failed_variant() {
+        let p = operation_failed("retry budget exhausted");
+        assert!(matches!(&p, Problem::OperationFailed(m) if m == "retry budget exhausted"));
+    }
+
+    #[test]
+    fn other_returns_other_variant() {
+        let p = other("unclassified error");
+        assert!(matches!(&p, Problem::Other(m) if m == "unclassified error"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds inline `#[cfg(test)] mod tests` blocks to the two shortcut layers flagged by audit finding `test-gaps-006/007`.

- **`observe/problem/builder/create_shortcuts.rs`** — 17 `matches!()` tests, one per shortcut. Documents non-obvious mappings:
  - `security()` → `Problem::PermissionDenied` (no `Security` variant exists)
  - `security_audit()` → `Problem::PermissionDenied`
  - `system()` → `Problem::Other`
- **`observe/event/shortcuts.rs`** — 9 smoke tests (no panic) covering every shortcut + 3 `#[serial]` queue-delta tests on load-bearing paths (`info`, `critical`, `auth_failure`). The rustdoc explains why `EventType`-level assertions aren't here.

## Why not full `MemoryWriter` capture?

The audit's suggested approach (register a `MemoryWriter`, call the shortcut, assert `EventType`) is not currently feasible. Empirically verified: events **do** queue on the dispatcher (`dispatcher_stats` increments), but registered writers never see them. Root cause is `dispatch_to_writers_sync` calling `tokio::runtime::Builder::new_current_thread().build().block_on(...)` from inside the async dispatcher's own runtime — panics with "Cannot start a runtime from within a runtime", panic swallowed by `let _ = ...`. Downgraded to queue-delta assertions (the strongest observable signal) and filed as follow-up #210.

## Test plan

- [x] `just test-mod "observe::problem::builder::create_shortcuts"` — 17 pass
- [x] `just test-mod "observe::event::shortcuts"` — 12 pass (9 smoke + 3 queue-delta)
- [x] `just preflight` — green (6244 workspace tests passing)

Closes #178