### PR TITLE
test(security): add shortcut coverage for 41 untested functions

### DIFF
--- a/crates/octarine/src/security/commands/shortcuts.rs
+++ b/crates/octarine/src/security/commands/shortcuts.rs
@@ -252,4 +252,89 @@ mod tests {
     fn test_escape_shell_arg_windows() {
         assert_eq!(escape_shell_arg_windows("simple"), "\"simple\"");
     }
+
+    #[test]
+    fn test_is_any_chain_present() {
+        assert!(is_any_chain_present("ls; rm -rf /"));
+        assert!(is_any_chain_present("a && b"));
+        assert!(!is_any_chain_present("safe-arg"));
+    }
+
+    #[test]
+    fn test_is_shell_expansion_present() {
+        assert!(is_shell_expansion_present("${HOME}"));
+        assert!(is_shell_expansion_present("$(whoami)"));
+        assert!(!is_shell_expansion_present("plain"));
+    }
+
+    #[test]
+    fn test_is_command_substitution_present() {
+        assert!(is_command_substitution_present("$(whoami)"));
+        assert!(is_command_substitution_present("`id`"));
+        assert!(!is_command_substitution_present("plain"));
+    }
+
+    #[test]
+    fn test_is_variable_expansion_present() {
+        assert!(is_variable_expansion_present("${VAR}"));
+        assert!(is_variable_expansion_present("$HOME"));
+        assert!(!is_variable_expansion_present("plain"));
+    }
+
+    #[test]
+    fn test_is_redirection_present() {
+        assert!(is_redirection_present("cmd > /etc/x"));
+        assert!(is_redirection_present("cmd < input"));
+        assert!(!is_redirection_present("plain"));
+    }
+
+    #[test]
+    fn test_is_glob_present() {
+        assert!(is_glob_present("*.txt"));
+        assert!(is_glob_present("file?.log"));
+        assert!(!is_glob_present("plain.txt"));
+    }
+
+    #[test]
+    fn test_validate_command_name() {
+        assert!(validate_command_name("git").is_ok());
+        // Path traversal is rejected.
+        assert!(validate_command_name("../bin/sh").is_err());
+        // Empty command is rejected.
+        assert!(validate_command_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_env() {
+        assert!(validate_env("MY_VAR", "safe value").is_ok());
+        // Dangerous name (contains `=`).
+        assert!(validate_env("BAD=NAME", "value").is_err());
+        // Dangerous value (command substitution).
+        assert!(validate_env("MY_VAR", "$(whoami)").is_err());
+    }
+
+    #[test]
+    fn test_validate_args() {
+        assert!(validate_args(["ls", "-la"]).is_ok());
+        assert!(validate_args(["ls", "$(whoami)"]).is_err());
+    }
+
+    #[test]
+    fn test_escape_shell_args() {
+        let escaped = escape_shell_args(["ls", "-la"]).expect("valid");
+        assert_eq!(escaped.len(), 2);
+        assert!(!escaped.first().expect("at least one arg").is_empty());
+        // Null bytes cannot be safely escaped.
+        assert!(escape_shell_args(["ls", "bad\0arg"]).is_err());
+    }
+
+    #[test]
+    fn test_join_shell_args() {
+        let joined = join_shell_args(["echo", "hello"]).expect("valid");
+        assert!(joined.contains("echo"));
+        assert!(joined.contains("hello"));
+        assert!(joined.contains(' '));
+        // Null bytes propagate the error.
+        assert!(join_shell_args(["echo", "bad\0arg"]).is_err());
+    }
 }

--- a/crates/octarine/src/security/network/shortcuts.rs
+++ b/crates/octarine/src/security/network/shortcuts.rs
@@ -223,4 +223,78 @@ mod tests {
         assert!(validate_port(80).is_ok());
         assert!(validate_port(0).is_err());
     }
+
+    #[test]
+    fn test_is_dangerous_scheme() {
+        assert!(is_dangerous_scheme("file:///etc/passwd"));
+        assert!(!is_dangerous_scheme("https://example.com"));
+    }
+
+    #[test]
+    fn test_is_cloud_metadata_endpoint() {
+        assert!(is_cloud_metadata_endpoint("169.254.169.254"));
+        assert!(!is_cloud_metadata_endpoint("example.com"));
+    }
+
+    #[test]
+    fn test_is_internal_host() {
+        assert!(is_internal_host("localhost"));
+        assert!(is_internal_host("10.0.0.1"));
+        assert!(!is_internal_host("example.com"));
+    }
+
+    #[test]
+    fn test_is_url_shortener() {
+        // Takes a host, not a URL.
+        assert!(is_url_shortener("bit.ly"));
+        assert!(!is_url_shortener("example.com"));
+    }
+
+    #[test]
+    fn test_validate_not_internal() {
+        // Takes a host, not a URL.
+        assert!(validate_not_internal("example.com").is_ok());
+        assert!(validate_not_internal("localhost").is_err());
+    }
+
+    #[test]
+    fn test_validate_safe_scheme() {
+        assert!(validate_safe_scheme("https://example.com").is_ok());
+        assert!(validate_safe_scheme("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_validate_not_cloud_metadata() {
+        // Takes a host, not a URL.
+        assert!(validate_not_cloud_metadata("example.com").is_ok());
+        assert!(validate_not_cloud_metadata("169.254.169.254").is_err());
+    }
+
+    #[test]
+    fn test_validate_not_url_shortener() {
+        // Takes a host, not a URL.
+        assert!(validate_not_url_shortener("example.com").is_ok());
+        assert!(validate_not_url_shortener("bit.ly").is_err());
+    }
+
+    #[test]
+    fn test_validate_https_required() {
+        assert!(validate_https_required("https://example.com").is_ok());
+        assert!(validate_https_required("http://example.com").is_err());
+    }
+
+    #[test]
+    fn test_validate_hostname_lenient() {
+        // Strict rejects underscores; lenient allows them.
+        assert!(validate_hostname("my_server.com").is_err());
+        assert!(validate_hostname_lenient("my_server.com").is_ok());
+        assert!(validate_hostname_lenient("-bad.com").is_err());
+    }
+
+    #[test]
+    fn test_parse_port() {
+        assert!(matches!(parse_port("80"), Ok(80)));
+        assert!(parse_port("not-a-number").is_err());
+        assert!(parse_port("0").is_err());
+    }
 }

--- a/crates/octarine/src/security/paths/shortcuts.rs
+++ b/crates/octarine/src/security/paths/shortcuts.rs
@@ -160,4 +160,84 @@ mod tests {
         let clean = sanitize_path("../etc/passwd").expect("should sanitize");
         assert!(!clean.contains(".."));
     }
+
+    #[test]
+    fn test_detect_threats() {
+        let threats = detect_threats("../etc/$(whoami)");
+        assert!(!threats.is_empty());
+
+        let safe_threats = detect_threats("safe/path.txt");
+        assert!(safe_threats.is_empty());
+    }
+
+    #[test]
+    fn test_is_path_traversal_present() {
+        assert!(is_path_traversal_present("../etc/passwd"));
+        assert!(!is_path_traversal_present("safe/path.txt"));
+    }
+
+    #[test]
+    fn test_is_encoded_traversal_present() {
+        assert!(is_encoded_traversal_present("%2e%2e/secret"));
+        assert!(!is_encoded_traversal_present("safe/path.txt"));
+    }
+
+    #[test]
+    fn test_is_command_injection_present() {
+        // Detects $(, `, ${ — not `;` (that's a shell metacharacter).
+        assert!(is_command_injection_present("file$(whoami).txt"));
+        assert!(!is_command_injection_present("safe.txt"));
+    }
+
+    #[test]
+    fn test_is_variable_expansion_present() {
+        assert!(is_variable_expansion_present("$HOME/secret"));
+        assert!(!is_variable_expansion_present("safe.txt"));
+    }
+
+    #[test]
+    fn test_is_shell_metacharacters_present() {
+        assert!(is_shell_metacharacters_present("a|b"));
+        assert!(!is_shell_metacharacters_present("safe.txt"));
+    }
+
+    #[test]
+    fn test_is_null_bytes_present() {
+        assert!(is_null_bytes_present("file\0name"));
+        assert!(!is_null_bytes_present("safe.txt"));
+    }
+
+    #[test]
+    fn test_is_injection_present() {
+        assert!(is_injection_present("$(whoami)"));
+        assert!(!is_injection_present("safe.txt"));
+    }
+
+    #[test]
+    fn test_validate_no_traversal() {
+        assert!(validate_no_traversal("safe/path.txt").is_ok());
+        assert!(validate_no_traversal("../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_validate_no_injection() {
+        assert!(validate_no_injection("safe.txt").is_ok());
+        assert!(validate_no_injection("$(whoami)").is_err());
+    }
+
+    #[test]
+    fn test_strip_traversal() {
+        let cleaned = strip_traversal("../etc/passwd");
+        assert!(!cleaned.contains(".."));
+        // Safe paths are preserved.
+        assert_eq!(strip_traversal("safe/path.txt"), "safe/path.txt");
+    }
+
+    #[test]
+    fn test_strip_null_bytes() {
+        let cleaned = strip_null_bytes("file\0name");
+        assert!(!cleaned.contains('\0'));
+        // Safe paths are preserved.
+        assert_eq!(strip_null_bytes("safe.txt"), "safe.txt");
+    }
 }

--- a/crates/octarine/src/security/queries/shortcuts.rs
+++ b/crates/octarine/src/security/queries/shortcuts.rs
@@ -255,4 +255,65 @@ mod tests {
         let sql_threats = detect_threats("' OR 1=1 --", QueryType::Sql);
         assert!(!sql_threats.is_empty());
     }
+
+    #[test]
+    fn test_escape_sql_identifier() {
+        // Plain identifier gets wrapped in double quotes.
+        assert_eq!(escape_sql_identifier("users"), "\"users\"");
+        // Embedded double quotes are doubled.
+        assert_eq!(escape_sql_identifier("u\"ser"), "\"u\"\"ser\"");
+    }
+
+    #[test]
+    fn test_escape_nosql_path() {
+        // Leading `$` on a path segment is replaced with `_`.
+        assert_eq!(escape_nosql_path("$set.value"), "_set.value");
+        // Paths without operators pass through.
+        assert_eq!(escape_nosql_path("user.name"), "user.name");
+    }
+
+    #[test]
+    fn test_sanitize_nosql_value() {
+        // Operator `$gt` has the `$` stripped.
+        assert_eq!(sanitize_nosql_value("$gt"), "gt");
+        // Prototype pollution key gets mangled.
+        assert_eq!(sanitize_nosql_value("__proto__"), "_proto_");
+        // Safe values pass through.
+        assert_eq!(sanitize_nosql_value("hello"), "hello");
+    }
+
+    #[test]
+    fn test_strip_nosql_operators() {
+        // Known operator is stripped.
+        assert_eq!(strip_nosql_operators("$gt"), "gt");
+        // Non-operators pass through.
+        assert_eq!(strip_nosql_operators("hello"), "hello");
+        assert_eq!(strip_nosql_operators("$100"), "$100");
+    }
+
+    #[test]
+    fn test_detect_ldap_threats() {
+        let threats = detect_ldap_threats("admin)(");
+        assert!(!threats.is_empty());
+
+        let safe = detect_ldap_threats("admin");
+        assert!(safe.is_empty());
+    }
+
+    #[test]
+    fn test_escape_ldap_dn() {
+        // Commas in DN are escaped with backslash.
+        assert_eq!(escape_ldap_dn("user,name"), "user\\,name");
+        // Plain strings pass through.
+        assert_eq!(escape_ldap_dn("plain"), "plain");
+    }
+
+    #[test]
+    fn test_detect_graphql_threats() {
+        let threats = detect_graphql_threats("{ __schema { types { name } } }");
+        assert!(!threats.is_empty());
+
+        let safe = detect_graphql_threats("{ user { name } }");
+        assert!(safe.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds positive + negative unit tests for 41 security shortcut functions across `network`, `paths`, `commands`, and `queries`, per audit finding `test-gaps-001..004`.
- Breakdown: +11 network, +12 paths, +11 commands, +7 queries.
- Each test exercises the shortcut with one dangerous/invalid input and one safe/valid input, confirming delegation to the underlying builder works for consumers of the `security::*::shortcuts` free-function API.

## Scope note

`validate_graphql_query` is listed in the issue body but is not a shortcut — it exists only on `QueryBuilder` (requires `GraphqlSchema` + `GraphqlConfig`). Skipped here; exposing it would be a separate API-surface decision, not a test gap.

## Test plan

- [x] `just test-mod "security::network::shortcuts"` — 13 passed
- [x] `just test-mod "security::paths::shortcuts"` — 16 passed
- [x] `just test-mod "security::commands::shortcuts"` — 18 passed
- [x] `just test-mod "security::queries::shortcuts" database` — 12 passed
- [x] `just preflight` — fmt, clippy, arch-check, full workspace tests all green

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)