### PR TITLE
fix(observe): add PiiType::BiometricTemplate variant to close pii-sync gap

### DIFF
--- a/crates/octarine/src/observe/pii/redactor/biometric.rs
+++ b/crates/octarine/src/observe/pii/redactor/biometric.rs
@@ -82,3 +82,17 @@ pub(super) fn redact_dna_sequences(text: &str, profile: RedactionProfile) -> Str
         RedactionProfile::Development | RedactionProfile::Testing => text.to_string(),
     }
 }
+
+/// Redact biometric templates based on profile
+pub(super) fn redact_biometric_templates(text: &str, profile: RedactionProfile) -> String {
+    match profile {
+        RedactionProfile::ProductionStrict | RedactionProfile::ProductionLenient => {
+            let builder = BiometricIdentifierBuilder::new();
+            let policy = policy_from_profile(profile);
+            builder
+                .redact_biometric_templates_in_text(text, policy)
+                .into_owned()
+        }
+        RedactionProfile::Development | RedactionProfile::Testing => text.to_string(),
+    }
+}

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -154,6 +154,7 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             PiiType::VoiceId => redact_voice_prints(&result, profile),
             PiiType::IrisId => redact_iris_scans(&result, profile),
             PiiType::DnaId => redact_dna_sequences(&result, profile),
+            PiiType::BiometricTemplate => redact_biometric_templates(&result, profile),
             // Location
             PiiType::GpsCoordinates => redact_gps_coordinates(&result, profile),
             PiiType::Address => redact_addresses(&result, profile),

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -123,6 +123,12 @@ pub(super) fn scan_biometric(text: &str, pii_types: &mut Vec<PiiType>) {
         if !biometric.detect_dna_sequences_in_text(text).is_empty() {
             pii_types.push(PiiType::DnaId);
         }
+        if !biometric
+            .detect_biometric_templates_in_text(text)
+            .is_empty()
+        {
+            pii_types.push(PiiType::BiometricTemplate);
+        }
     }
 }
 

--- a/crates/octarine/src/observe/pii/scanner/mod.rs
+++ b/crates/octarine/src/observe/pii/scanner/mod.rs
@@ -253,6 +253,20 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_for_pii_biometric_template_iso_19794() {
+        // ISO/IEC 19794 template with FMR header marker and 54 base64-like chars.
+        // scan_biometric is off by default; enable it explicitly.
+        let text = "fmr: QUJDRFBCQ0RCQ0RCQ0RCQ0RCQ0RCQ0RCQ0RCQ0RCQ0RBQkNERkJDRA";
+        let config = PiiScannerConfig::none().with_biometric(true);
+        let types = scan_for_pii_with_config(text, &config);
+        assert!(
+            types.contains(&PiiType::BiometricTemplate),
+            "Should detect ISO/IEC 19794 FMR template, got {:?}",
+            types
+        );
+    }
+
+    #[test]
     fn test_scan_for_pii_ip_address() {
         let text = "Server: 192.168.1.1";
         let config = PiiScannerConfig::default().with_network(true);

--- a/crates/octarine/src/observe/pii/types.rs
+++ b/crates/octarine/src/observe/pii/types.rs
@@ -92,6 +92,8 @@ pub enum PiiType {
     IrisId,
     /// DNA profile ID
     DnaId,
+    /// Biometric template (ISO/IEC 19794 FMR/FIR/FTR/IIR formats)
+    BiometricTemplate,
 
     // =========================================================================
     // Location Domain
@@ -210,6 +212,7 @@ impl PiiType {
             Self::VoiceId => "voice_id",
             Self::IrisId => "iris_id",
             Self::DnaId => "dna_id",
+            Self::BiometricTemplate => "biometric_template",
             // Location
             Self::GpsCoordinates => "gps_coordinates",
             Self::Address => "address",
@@ -267,9 +270,12 @@ impl PiiType {
             | Self::IcdCode
             | Self::PrescriptionNumber
             | Self::DeaNumber => "medical",
-            Self::FingerprintId | Self::FaceId | Self::VoiceId | Self::IrisId | Self::DnaId => {
-                "biometric"
-            }
+            Self::FingerprintId
+            | Self::FaceId
+            | Self::VoiceId
+            | Self::IrisId
+            | Self::DnaId
+            | Self::BiometricTemplate => "biometric",
             Self::GpsCoordinates | Self::Address | Self::PostalCode => "location",
             Self::EmployeeId | Self::StudentId | Self::BadgeNumber => "organizational",
             Self::IpAddress
@@ -308,7 +314,7 @@ impl PiiType {
             // Medical (HIPAA)
             Self::Mrn | Self::Npi | Self::InsuranceNumber | Self::DeaNumber | Self::IcdCode | Self::PrescriptionNumber |
             // Biometric (irreplaceable)
-            Self::FingerprintId | Self::FaceId | Self::VoiceId | Self::IrisId | Self::DnaId |
+            Self::FingerprintId | Self::FaceId | Self::VoiceId | Self::IrisId | Self::DnaId | Self::BiometricTemplate |
             // Authentication (security breach)
             Self::Password | Self::Pin | Self::SecurityAnswer | Self::Passphrase |
             Self::ApiKey | Self::Jwt | Self::SessionId | Self::OAuthToken | Self::SshKey |
@@ -328,7 +334,7 @@ impl PiiType {
             // Location
             Self::IpAddress | Self::GpsCoordinates | Self::Address | Self::PostalCode |
             // Biometric
-            Self::FingerprintId | Self::FaceId | Self::VoiceId | Self::IrisId | Self::DnaId |
+            Self::FingerprintId | Self::FaceId | Self::VoiceId | Self::IrisId | Self::DnaId | Self::BiometricTemplate |
             // Medical
             Self::Mrn | Self::InsuranceNumber
         )
@@ -358,6 +364,7 @@ impl PiiType {
                 | Self::Address // Address in medical context
                 | Self::Phone // Phone in medical context
                 | Self::Email // Email in medical context
+                | Self::BiometricTemplate // Biometric identifiers are PHI under HIPAA
         )
     }
 
@@ -566,6 +573,17 @@ mod tests {
         assert!(!PiiType::PaymentToken.is_gdpr_protected());
         assert!(PiiType::PaymentToken.is_pci_protected());
         assert!(PiiType::PaymentToken.is_secret());
+    }
+
+    #[test]
+    fn test_biometric_template_classifications() {
+        assert_eq!(PiiType::BiometricTemplate.name(), "biometric_template");
+        assert_eq!(PiiType::BiometricTemplate.domain(), "biometric");
+        assert!(PiiType::BiometricTemplate.is_high_risk());
+        assert!(PiiType::BiometricTemplate.is_gdpr_protected());
+        assert!(PiiType::BiometricTemplate.is_hipaa_protected());
+        assert!(!PiiType::BiometricTemplate.is_pci_protected());
+        assert!(!PiiType::BiometricTemplate.is_secret());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bridge `IdentifierType::BiometricTemplate` (ISO/IEC 19794 FMR/FIR/FTR/IIR) into the observe layer. Previously detected by primitives but invisible to the PII scanner, redactor, and compliance classifiers.
- Add `PiiType::BiometricTemplate` with `is_high_risk`, `is_gdpr_protected` (Article 9 special-category), and `is_hipaa_protected`.
- Extend `scan_biometric` to dispatch `detect_biometric_templates_in_text`.
- Add `redact_biometric_templates` in the redactor submodule and wire the exhaustive `PiiType` match arm.

## Test plan

- `just clippy` — clean
- `just fmt-check` — clean
- `just arch-check` — clean
- `just test-mod "pii"` — 83 passed, 0 failed (includes new `test_biometric_template_classifications` and `test_scan_for_pii_biometric_template_iso_19794`)
- `just test-mod "biometric"` — 120 passed, 0 failed
- `just preflight` — 241 passed, 0 failed

The new `test_scan_for_pii_biometric_template_iso_19794` test exercises the `FMR` header-byte detection path against the `BIOMETRIC_TEMPLATE_ISO` regex.

## Pre-review findings

- 2x missing-test-file (`observe/pii/redactor/biometric.rs`, `observe/pii/scanner/domains.rs`) — false positives for this repo's Rust inline-test convention. Redactor siblings have no inline tests; scanner tests live in `scanner/mod.rs`.

Closes #161