### PR TITLE
refactor(identifiers): rename find_biometric_identifier to detect_biometric_identifier

### DIFF
--- a/crates/octarine/src/primitives/identifiers/biometric/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/biometric/builder.rs
@@ -59,7 +59,7 @@ impl BiometricIdentifierBuilder {
     /// Find the type of biometric identifier
     #[must_use]
     pub fn find(&self, value: &str) -> Option<IdentifierType> {
-        detection::find_biometric_identifier(value)
+        detection::detect_biometric_identifier(value)
     }
 
     /// Check if value is any biometric identifier

--- a/crates/octarine/src/primitives/identifiers/biometric/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/biometric/detection.rs
@@ -244,9 +244,9 @@ pub fn is_test_biometric_id(id: &str) -> bool {
     false
 }
 
-/// Find the type of biometric identifier
+/// Detect the type of biometric identifier
 #[must_use]
-pub fn find_biometric_identifier(value: &str) -> Option<IdentifierType> {
+pub fn detect_biometric_identifier(value: &str) -> Option<IdentifierType> {
     if is_fingerprint(value) {
         Some(IdentifierType::Fingerprint)
     } else if is_facial_recognition(value) {
@@ -521,18 +521,18 @@ mod tests {
     }
 
     #[test]
-    fn test_find_biometric_identifier() {
+    fn test_detect_biometric_identifier() {
         assert_eq!(
-            find_biometric_identifier(
+            detect_biometric_identifier(
                 "fingerprint: a1b2c3d4e5f6789012345678901234567890123456789012345678901234"
             ),
             Some(IdentifierType::Fingerprint)
         );
         assert_eq!(
-            find_biometric_identifier("ATCGATCGATCGATCGATCG"),
+            detect_biometric_identifier("ATCGATCGATCGATCGATCG"),
             Some(IdentifierType::DNASequence)
         );
-        assert_eq!(find_biometric_identifier("not biometric"), None);
+        assert_eq!(detect_biometric_identifier("not biometric"), None);
     }
 
     // ===== Text Scanning Tests =====
@@ -882,7 +882,7 @@ mod tests {
         // Test detection priority when value could match multiple types
         let fingerprint =
             "fingerprint: a1b2c3d4e5f6789012345678901234567890123456789012345678901234";
-        let detected = find_biometric_identifier(fingerprint);
+        let detected = detect_biometric_identifier(fingerprint);
         assert_eq!(detected, Some(IdentifierType::Fingerprint));
     }
 }


### PR DESCRIPTION
## Summary

- Renames `find_biometric_identifier` → `detect_biometric_identifier` in `primitives/identifiers/biometric/detection.rs` to satisfy the skill contract requiring every domain to expose a paired `is_{domain}_identifier` / `detect_{domain}_identifier` dispatcher.
- Brings biometric in line with government, medical, location, and network domains.
- Updates the sole internal caller in `biometric/builder.rs` and the four test usages in `biometric/detection.rs`.
- No deprecated shim — the free function is only reachable within the `biometric/` module (`mod detection` is private), so an alias would be dead code.
- `BiometricIdentifierBuilder::find()` method name is unchanged (builder-method naming is out of scope for this audit finding).

`docs/security/patterns/detection-validation-sanitization.md` already referenced the canonical name; this fix brings the code in line with the docs.

Note: `find_personal_identifier` and `find_financial_identifier` share the same anti-pattern but are out of scope for this issue — no audit finding has been filed against them.

## Test plan

- [x] `cargo test --package octarine --all-features --lib` — 6215 passed, 0 failed
- [x] `just test-mod "biometric"` — 118 biometric tests pass
- [x] `just clippy` — clean
- [x] `just arch-check` — exit 0
- [x] `just fmt-check` — clean
- [x] `grep -r find_biometric_identifier crates/ docs/` — no remaining references

Closes #159