### PR TITLE
fix(identifiers): move SSA helpers out of validation to break inheritance arrow

### DIFF
--- a/crates/octarine/src/primitives/identifiers/government/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder.rs
@@ -33,6 +33,7 @@ use super::super::types::IdentifierMatch;
 use crate::primitives::Problem;
 use crate::primitives::collections::CacheStats;
 
+use super::common;
 use super::conversion;
 use super::detection;
 use super::redaction::TextRedactionPolicy;
@@ -95,7 +96,7 @@ impl GovernmentIdentifierBuilder {
     /// Check if SSN area code indicates ITIN
     #[must_use]
     pub fn is_itin_area(&self, ssn: &str) -> bool {
-        validation::is_itin_area(ssn)
+        common::is_itin_area(ssn)
     }
 
     /// Redact SSN with explicit strategy
@@ -1123,7 +1124,7 @@ impl GovernmentIdentifierBuilder {
     /// ```
     #[must_use]
     pub fn is_test_ssn(&self, ssn: &str) -> bool {
-        validation::is_test_ssn(ssn)
+        common::is_test_ssn(ssn)
     }
 
     /// Check if passport number is a known test/sample pattern

--- a/crates/octarine/src/primitives/identifiers/government/common.rs
+++ b/crates/octarine/src/primitives/identifiers/government/common.rs
@@ -1,0 +1,186 @@
+//! Shared SSA-rule helpers used by both detection and validation.
+//!
+//! These are pure pattern-matching boolean helpers — no `Result`, no observe
+//! dependencies. They live here (not under `detection/` or `validation/`)
+//! because both layers consult them and the inheritance arrow forbids
+//! `detection` from importing `validation`.
+
+/// Check if SSN area code indicates ITIN
+///
+/// ITINs use area codes 900-999.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::common;
+///
+/// assert!(common::is_itin_area("912-34-5678"));
+/// assert!(!common::is_itin_area("123-45-6789"));
+/// ```
+#[must_use]
+pub(super) fn is_itin_area(ssn: &str) -> bool {
+    let cleaned: String = ssn.chars().filter(|c| c.is_numeric()).collect();
+    if cleaned.len() >= 3 {
+        cleaned.starts_with('9')
+    } else {
+        false
+    }
+}
+
+/// Check if an SSN is a known test/sample SSN
+///
+/// Test SSNs are commonly used in documentation, testing, and examples.
+/// These should not be treated as real Social Security Numbers.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::common;
+///
+/// assert!(common::is_test_ssn("123-45-6789"));
+/// assert!(common::is_test_ssn("078-05-1120")); // Woolworth's Wallet SSN
+/// assert!(common::is_test_ssn("555-55-5555")); // All fives
+/// assert!(!common::is_test_ssn("142-58-3697")); // Not a test pattern
+/// ```
+#[must_use]
+pub(super) fn is_test_ssn(ssn: &str) -> bool {
+    // Normalize: remove hyphens and spaces
+    let cleaned: String = ssn.chars().filter(|c| c.is_ascii_digit()).collect();
+
+    // Must be exactly 9 digits to be a valid SSN format
+    if cleaned.len() != 9 {
+        return false;
+    }
+
+    // Well-known test SSNs
+    let test_ssns = [
+        "078051120", // Woolworth's Wallet SSN (most famous invalid SSN)
+        "123456789", // Sequential pattern
+        "987654321", // Reverse sequential
+        "111111111", // All ones (often used in testing)
+        "222222222", // All twos
+        "333333333", // All threes
+        "444444444", // All fours
+        "555555555", // All fives (common test pattern)
+        "666666666", // All sixes
+        "777777777", // All sevens
+        "888888888", // All eights
+        "999999999", // All nines
+        "000000000", // All zeros
+        // SSA and IRS example SSNs
+        "219099999", // Used in some SSA examples
+        "457555462", // Used in IRS examples
+        // Credit card test patterns that look like SSNs
+        "424242424", // Stripe test card fragment
+        "401288888", // Visa test card fragment
+        "401200000", // Visa test card fragment
+        // Medical record test patterns
+        "000000001", // Common placeholder
+        "999999999", // Max value placeholder
+    ];
+
+    if test_ssns.contains(&cleaned.as_str()) {
+        return true;
+    }
+
+    // Check for repeating digit patterns (all same digit)
+    let chars: Vec<char> = cleaned.chars().collect();
+    let first_char = chars.first().copied();
+    if first_char.is_some() && chars.iter().all(|&c| Some(c) == first_char) {
+        return true;
+    }
+
+    // Check for ascending sequential pattern (012345678, 123456789, etc.)
+    // Note: char arithmetic is safe here as we're only dealing with ASCII digits
+    #[allow(clippy::arithmetic_side_effects)]
+    let is_ascending = chars.windows(2).all(|w| match (w.first(), w.get(1)) {
+        (Some(&a), Some(&b)) => b as u8 == (a as u8).saturating_add(1) || (a == '9' && b == '0'),
+        _ => false,
+    });
+    if is_ascending {
+        return true;
+    }
+
+    // Check for descending sequential pattern (987654321, 876543210, etc.)
+    // Note: char arithmetic is safe here as we're only dealing with ASCII digits
+    #[allow(clippy::arithmetic_side_effects)]
+    let is_descending = chars.windows(2).all(|w| match (w.first(), w.get(1)) {
+        (Some(&a), Some(&b)) => a as u8 == (b as u8).saturating_add(1) || (b == '9' && a == '0'),
+        _ => false,
+    });
+    if is_descending {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_is_itin_area() {
+        assert!(is_itin_area("912-34-5678"));
+        assert!(is_itin_area("900-70-1234"));
+        assert!(is_itin_area("999-88-7654"));
+        assert!(!is_itin_area("123-45-6789"));
+        assert!(!is_itin_area("517-29-8346"));
+        // Too short to determine area
+        assert!(!is_itin_area("12"));
+        assert!(!is_itin_area(""));
+    }
+
+    #[test]
+    fn test_is_test_ssn_known_patterns() {
+        // Well-known test SSNs
+        assert!(is_test_ssn("123-45-6789")); // Sequential
+        assert!(is_test_ssn("123456789")); // Sequential without hyphens
+        assert!(is_test_ssn("078-05-1120")); // Woolworth's Wallet SSN
+        assert!(is_test_ssn("987-65-4321")); // Reverse sequential
+        assert!(is_test_ssn("219-09-9999")); // SSA example
+        assert!(is_test_ssn("457-55-5462")); // IRS example
+    }
+
+    #[test]
+    fn test_is_test_ssn_repeating_patterns() {
+        // All same digit patterns
+        assert!(is_test_ssn("111-11-1111"));
+        assert!(is_test_ssn("222-22-2222"));
+        assert!(is_test_ssn("333-33-3333"));
+        assert!(is_test_ssn("444-44-4444"));
+        assert!(is_test_ssn("555-55-5555"));
+        assert!(is_test_ssn("666-66-6666"));
+        assert!(is_test_ssn("777-77-7777"));
+        assert!(is_test_ssn("888-88-8888"));
+        assert!(is_test_ssn("999-99-9999"));
+        assert!(is_test_ssn("000-00-0000"));
+    }
+
+    #[test]
+    fn test_is_test_ssn_not_test_patterns() {
+        // Valid-looking SSNs that are NOT test patterns
+        // (non-sequential, non-repeating, not in known test list)
+        assert!(!is_test_ssn("142-58-3697")); // Random-looking pattern
+        assert!(!is_test_ssn("903-75-2841")); // Random-looking pattern
+        assert!(!is_test_ssn("517-29-8346")); // Random-looking pattern
+        assert!(!is_test_ssn("628-41-9053")); // Random-looking pattern
+        assert!(!is_test_ssn("900-01-0001")); // ITIN-like but not test pattern
+    }
+
+    #[test]
+    fn test_is_test_ssn_invalid_format() {
+        // Invalid format should return false (not a test SSN, not any SSN)
+        assert!(!is_test_ssn("123-45-678")); // Too short
+        assert!(!is_test_ssn("123-45-67890")); // Too long
+        assert!(!is_test_ssn("abc-de-fghi")); // Letters
+        assert!(!is_test_ssn("")); // Empty
+    }
+
+    #[test]
+    fn test_is_test_ssn_credit_card_patterns() {
+        // Credit card test patterns that look like SSNs
+        assert!(is_test_ssn("424-24-2424")); // Stripe test card fragment
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection.rs
@@ -26,7 +26,7 @@
 
 use super::super::common::patterns;
 use super::super::types::{DetectionConfidence, IdentifierMatch, IdentifierType};
-use super::validation::{is_itin_area, is_test_ssn};
+use super::common::{is_itin_area, is_test_ssn};
 
 // ============================================================================
 // Constants

--- a/crates/octarine/src/primitives/identifiers/government/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/mod.rs
@@ -99,6 +99,7 @@ pub(crate) mod licenses;
 pub(crate) mod redaction;
 
 // Internal modules - not directly accessible outside government/
+mod common;
 mod conversion;
 mod detection;
 mod sanitization;

--- a/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
@@ -56,7 +56,7 @@ mod vin;
 pub use cache::{clear_government_caches, ssn_cache_stats, vin_cache_stats};
 
 // Re-export SSN functions
-pub use ssn::{is_itin_area, is_test_ssn, validate_ssn};
+pub use ssn::validate_ssn;
 
 // Re-export EIN functions
 pub use ein::{is_test_ein, is_valid_ein_prefix, validate_ein};

--- a/crates/octarine/src/primitives/identifiers/government/validation/ssn.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/ssn.rs
@@ -159,120 +159,6 @@ fn validate_ssn_uncached(ssn: &str) -> Result<(), Problem> {
     Ok(())
 }
 
-/// Check if SSN area code indicates ITIN
-///
-/// ITINs use area codes 900-999.
-///
-/// # Examples
-///
-/// ```ignore
-/// use crate::primitives::identifiers::government::validation;
-///
-/// assert!(validation::is_itin_area("912-34-5678"));
-/// assert!(!validation::is_itin_area("123-45-6789"));
-/// ```
-#[must_use]
-pub fn is_itin_area(ssn: &str) -> bool {
-    let cleaned: String = ssn.chars().filter(|c| c.is_numeric()).collect();
-    if cleaned.len() >= 3 {
-        cleaned.starts_with('9')
-    } else {
-        false
-    }
-}
-
-// ============================================================================
-// Test Pattern Detection
-// ============================================================================
-
-/// Check if an SSN is a known test/sample SSN
-///
-/// Test SSNs are commonly used in documentation, testing, and examples.
-/// These should not be treated as real Social Security Numbers.
-///
-/// # Examples
-///
-/// ```ignore
-/// use crate::primitives::identifiers::government::validation;
-///
-/// assert!(validation::is_test_ssn("123-45-6789"));
-/// assert!(validation::is_test_ssn("078-05-1120")); // Woolworth's Wallet SSN
-/// assert!(validation::is_test_ssn("555-55-5555")); // All fives
-/// assert!(!validation::is_test_ssn("142-58-3697")); // Not a test pattern
-/// ```
-#[must_use]
-pub fn is_test_ssn(ssn: &str) -> bool {
-    // Normalize: remove hyphens and spaces
-    let cleaned: String = ssn.chars().filter(|c| c.is_ascii_digit()).collect();
-
-    // Must be exactly 9 digits to be a valid SSN format
-    if cleaned.len() != 9 {
-        return false;
-    }
-
-    // Well-known test SSNs
-    let test_ssns = [
-        "078051120", // Woolworth's Wallet SSN (most famous invalid SSN)
-        "123456789", // Sequential pattern
-        "987654321", // Reverse sequential
-        "111111111", // All ones (often used in testing)
-        "222222222", // All twos
-        "333333333", // All threes
-        "444444444", // All fours
-        "555555555", // All fives (common test pattern)
-        "666666666", // All sixes
-        "777777777", // All sevens
-        "888888888", // All eights
-        "999999999", // All nines
-        "000000000", // All zeros
-        // SSA and IRS example SSNs
-        "219099999", // Used in some SSA examples
-        "457555462", // Used in IRS examples
-        // Credit card test patterns that look like SSNs
-        "424242424", // Stripe test card fragment
-        "401288888", // Visa test card fragment
-        "401200000", // Visa test card fragment
-        // Medical record test patterns
-        "000000001", // Common placeholder
-        "999999999", // Max value placeholder
-    ];
-
-    if test_ssns.contains(&cleaned.as_str()) {
-        return true;
-    }
-
-    // Check for repeating digit patterns (all same digit)
-    let chars: Vec<char> = cleaned.chars().collect();
-    let first_char = chars.first().copied();
-    if first_char.is_some() && chars.iter().all(|&c| Some(c) == first_char) {
-        return true;
-    }
-
-    // Check for ascending sequential pattern (012345678, 123456789, etc.)
-    // Note: char arithmetic is safe here as we're only dealing with ASCII digits
-    #[allow(clippy::arithmetic_side_effects)]
-    let is_ascending = chars.windows(2).all(|w| match (w.first(), w.get(1)) {
-        (Some(&a), Some(&b)) => b as u8 == (a as u8).saturating_add(1) || (a == '9' && b == '0'),
-        _ => false,
-    });
-    if is_ascending {
-        return true;
-    }
-
-    // Check for descending sequential pattern (987654321, 876543210, etc.)
-    // Note: char arithmetic is safe here as we're only dealing with ASCII digits
-    #[allow(clippy::arithmetic_side_effects)]
-    let is_descending = chars.windows(2).all(|w| match (w.first(), w.get(1)) {
-        (Some(&a), Some(&b)) => a as u8 == (b as u8).saturating_add(1) || (b == '9' && a == '0'),
-        _ => false,
-    });
-    if is_descending {
-        return true;
-    }
-
-    false
-}
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
@@ -346,10 +232,6 @@ mod tests {
         // ITINs use 9xx area codes - we warn but don't reject
         assert!(validate_ssn("912-34-5678").is_ok());
         assert!(validate_ssn("987-12-3456").is_ok());
-
-        // Check ITIN detection
-        assert!(is_itin_area("912-34-5678"));
-        assert!(!is_itin_area("123-45-6789"));
     }
 
     #[test]
@@ -503,57 +385,5 @@ mod tests {
         assert!(validate_ssn("123/45/6789").is_err()); // Slashes
         assert!(validate_ssn("123_45_6789").is_err()); // Underscores
         assert!(validate_ssn("123 45 6789").is_err()); // Spaces (invalid without hyphens)
-    }
-
-    #[test]
-    fn test_is_test_ssn_known_patterns() {
-        // Well-known test SSNs
-        assert!(is_test_ssn("123-45-6789")); // Sequential
-        assert!(is_test_ssn("123456789")); // Sequential without hyphens
-        assert!(is_test_ssn("078-05-1120")); // Woolworth's Wallet SSN
-        assert!(is_test_ssn("987-65-4321")); // Reverse sequential
-        assert!(is_test_ssn("219-09-9999")); // SSA example
-        assert!(is_test_ssn("457-55-5462")); // IRS example
-    }
-
-    #[test]
-    fn test_is_test_ssn_repeating_patterns() {
-        // All same digit patterns
-        assert!(is_test_ssn("111-11-1111"));
-        assert!(is_test_ssn("222-22-2222"));
-        assert!(is_test_ssn("333-33-3333"));
-        assert!(is_test_ssn("444-44-4444"));
-        assert!(is_test_ssn("555-55-5555"));
-        assert!(is_test_ssn("666-66-6666"));
-        assert!(is_test_ssn("777-77-7777"));
-        assert!(is_test_ssn("888-88-8888"));
-        assert!(is_test_ssn("999-99-9999"));
-        assert!(is_test_ssn("000-00-0000"));
-    }
-
-    #[test]
-    fn test_is_test_ssn_not_test_patterns() {
-        // Valid-looking SSNs that are NOT test patterns
-        // (non-sequential, non-repeating, not in known test list)
-        assert!(!is_test_ssn("142-58-3697")); // Random-looking pattern
-        assert!(!is_test_ssn("903-75-2841")); // Random-looking pattern
-        assert!(!is_test_ssn("517-29-8346")); // Random-looking pattern
-        assert!(!is_test_ssn("628-41-9053")); // Random-looking pattern
-        assert!(!is_test_ssn("900-01-0001")); // ITIN-like but not test pattern
-    }
-
-    #[test]
-    fn test_is_test_ssn_invalid_format() {
-        // Invalid format should return false (not a test SSN, not any SSN)
-        assert!(!is_test_ssn("123-45-678")); // Too short
-        assert!(!is_test_ssn("123-45-67890")); // Too long
-        assert!(!is_test_ssn("abc-de-fghi")); // Letters
-        assert!(!is_test_ssn("")); // Empty
-    }
-
-    #[test]
-    fn test_is_test_ssn_credit_card_patterns() {
-        // Credit card test patterns that look like SSNs
-        assert!(is_test_ssn("424-24-2424")); // Stripe test card fragment
     }
 }


### PR DESCRIPTION
## Summary

- `government/detection.rs:29` imported `is_itin_area` and `is_test_ssn` from `super::validation::ssn`, reversing the project's `detection → validation` inheritance arrow (flagged HIGH by `audit-octarine-identifiers`).
- Both helpers are pure pattern-matching `bool` checks with no `Result` or observe deps — they don't belong in `validation/`.
- Moved them to a new `government/common.rs` (`pub(super)`) sibling to `detection/` and `validation/`. `detection.rs` and `builder.rs` now import from `super::common`. The validation module's re-exports of these two functions are removed.

## Test plan

- [x] `just clippy` — clean
- [x] `just test-mod "primitives::identifiers::government"` — 346 pass
- [x] `just test-filter is_test_ssn` — all 5 moved tests pass under `common::tests::*`
- [x] `just arch-check` — exit 0
- [x] `just test-octarine` — workspace tests pass

## Pre-review findings

- 2x missing-test-file (`government/mod.rs`, `government/validation/mod.rs`) — false positives; both are re-export-only modules per project convention (CLAUDE.md: "`mod.rs` - Re-exports only, minimal logic").

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)