### PR TITLE
fix(observe): dispatch writers async-natively from dispatcher runtime

### DIFF
--- a/crates/octarine/src/observe/writers/async_dispatch.rs
+++ b/crates/octarine/src/observe/writers/async_dispatch.rs
@@ -327,7 +327,10 @@ impl EventDispatcher {
             {
                 Ok(rt) => rt,
                 Err(_) => {
-                    // Runtime creation failed - fall back to blocking receive
+                    // Runtime unavailable: console-only fallback dispatch.
+                    // Registered writers (file, database, memory, custom) are
+                    // skipped because there is no runtime to host their
+                    // async `Writer::write` implementations.
                     let writer = ProtectedWriter::new();
                     while let Some(event) = rx.blocking_recv() {
                         queue_size_clone.fetch_sub(1, Ordering::Relaxed);
@@ -352,7 +355,7 @@ impl EventDispatcher {
                                 let events = batch.take();
                                 let count = events.len();
                                 for event in events {
-                                    writer.write_sync(&event);
+                                    writer.write_event(&event).await;
                                 }
                                 processed_clone.fetch_add(count as u64, Ordering::Relaxed);
                             }
@@ -363,7 +366,7 @@ impl EventDispatcher {
                                 let events = batch.take();
                                 let count = events.len();
                                 for event in events {
-                                    writer.write_sync(&event);
+                                    writer.write_event(&event).await;
                                 }
                                 processed_clone.fetch_add(count as u64, Ordering::Relaxed);
                             }

--- a/crates/octarine/src/observe/writers/mod.rs
+++ b/crates/octarine/src/observe/writers/mod.rs
@@ -110,7 +110,7 @@ use crate::observe::pii::{RedactionProfile, redact_pii_with_profile};
 use crate::observe::types::Event;
 use async_trait::async_trait;
 use std::collections::HashMap;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 // =============================================================================
 // Writer Trait - Public API for implementing writers
@@ -208,7 +208,7 @@ pub trait Writer: Send + Sync {
 
 /// Named writer for registration
 struct RegisteredWriter {
-    writer: Box<dyn Writer>,
+    writer: Arc<dyn Writer>,
     enabled: bool,
 }
 
@@ -249,6 +249,10 @@ fn ensure_registry() {
 pub fn register_writer(writer: Box<dyn Writer>) {
     ensure_registry();
     let name = writer.name();
+    // Store as Arc so we can clone handles out of the registry and drop the
+    // lock guard before awaiting `Writer::write` in `dispatch_to_writers`.
+    // Holding `std::sync::RwLockReadGuard` across `.await` is unsound.
+    let writer: Arc<dyn Writer> = Arc::from(writer);
     let mut registry = WRITER_REGISTRY.write().unwrap_or_else(|e| e.into_inner());
     if let Some(ref mut map) = *registry {
         map.insert(
@@ -321,26 +325,49 @@ pub fn is_writer_enabled(name: &str) -> bool {
     }
 }
 
-/// Dispatch an event to all enabled registered writers (sync version)
+/// Dispatch an event to all enabled registered writers.
 ///
-/// This is called by the async dispatch background thread.
-/// Writers that fail are logged but don't stop other writers.
-pub(super) fn dispatch_to_writers_sync(event: &Event) {
-    let registry = WRITER_REGISTRY.read().unwrap_or_else(|e| e.into_inner());
-    if let Some(ref map) = *registry {
-        for rw in map.values() {
-            if rw.enabled && rw.writer.should_write(event) {
-                // Use tokio's blocking runtime to call async write
-                // This is safe because we're already in a dedicated dispatch thread
-                let writer = &rw.writer;
-                let event_clone = event.clone();
+/// Called from within the async dispatch loop (`async_dispatch.rs`), which
+/// already runs inside a tokio runtime — so we just await each writer
+/// directly. A prior implementation built a nested `current_thread` runtime
+/// and `block_on`'d inside the dispatcher's own runtime, which panicked
+/// with "Cannot start a runtime from within a runtime" and silently lost
+/// every dispatched event for all non-console writers (see #210).
+///
+/// Writer handles are snapshotted (`Arc` cloned) under the registry lock
+/// and the guard is dropped before awaiting — `std::sync::RwLockReadGuard`
+/// must not be held across `.await`.
+///
+/// Writer failures are reported to stderr (not through the observe logging
+/// macros) to avoid recursing back into this dispatch path.
+pub(super) async fn dispatch_to_writers(event: &Event) {
+    let handles: Vec<Arc<dyn Writer>> = {
+        let registry = WRITER_REGISTRY.read().unwrap_or_else(|e| e.into_inner());
+        match *registry {
+            Some(ref map) => map
+                .values()
+                .filter(|rw| rw.enabled && rw.writer.should_write(event))
+                .map(|rw| Arc::clone(&rw.writer))
+                .collect(),
+            None => Vec::new(),
+        }
+    };
 
-                // Create a minimal runtime for the async call
-                // This is acceptable overhead since writes are batched
-                if let Ok(rt) = tokio::runtime::Builder::new_current_thread().build() {
-                    let _ = rt.block_on(async { writer.write(&event_clone).await });
-                }
-            }
+    for writer in handles {
+        if let Err(err) = writer.write(event).await {
+            // Write directly to stderr rather than routing through the
+            // observe logging shortcuts, which would dispatch another
+            // event back through this function and risk amplification
+            // loops when the cause of the failure is the dispatcher.
+            // Matches the pattern used by `ConsoleWriter::write_sync`.
+            use std::io::Write;
+            let mut stderr = std::io::stderr().lock();
+            let _ = writeln!(
+                stderr,
+                "[octarine::observe] writer '{}' failed: {}",
+                writer.name(),
+                err
+            );
         }
     }
 }

--- a/crates/octarine/src/observe/writers/protected.rs
+++ b/crates/octarine/src/observe/writers/protected.rs
@@ -9,7 +9,7 @@ use crate::primitives::runtime::r#async::{CircuitBreaker, CircuitBreakerConfig};
 use std::sync::Arc;
 
 use super::console::ConsoleWriter;
-use super::dispatch_to_writers_sync;
+use super::dispatch_to_writers;
 
 /// A writer protected by a circuit breaker
 ///
@@ -47,17 +47,27 @@ impl ProtectedWriter {
             .await
     }
 
-    /// Write event synchronously (for batch processing)
+    /// Dispatch an event through the full writer pipeline.
     ///
-    /// Dispatches to console and all registered writers.
-    /// This bypasses the circuit breaker since batch processing already
-    /// handles failures at a higher level.
-    pub fn write_sync(&self, event: &Event) {
-        // Always write to console for immediate feedback
+    /// Writes to the console synchronously for immediate feedback, then
+    /// awaits dispatch to all registered writers. Must be called from
+    /// within a tokio runtime — the dispatcher background thread runs one.
+    /// Bypasses the circuit breaker since batch processing already handles
+    /// failures at a higher level.
+    pub async fn write_event(&self, event: &Event) {
         self.console.write_sync(event);
+        dispatch_to_writers(event).await;
+    }
 
-        // Dispatch to all registered writers
-        dispatch_to_writers_sync(event);
+    /// Console-only fallback write.
+    ///
+    /// Used only when the dispatcher cannot build a tokio runtime
+    /// (`async_dispatch::EventDispatcher::new`). In that degraded state
+    /// there is no runtime to host async writers, so we write to stderr
+    /// via `ConsoleWriter` and skip registry dispatch entirely.
+    /// Production paths go through [`Self::write_event`].
+    pub fn write_sync(&self, event: &Event) {
+        self.console.write_sync(event);
     }
 
     /// Get circuit breaker state for monitoring
@@ -91,11 +101,76 @@ mod tests {
 
     #[test]
     fn test_protected_writer_sync() {
+        // `write_sync` is the console-only fallback used when no tokio
+        // runtime is available. It must not panic and must not require
+        // the registry to be initialised.
         let writer = ProtectedWriter::new();
         let event = Event::new(EventType::Debug, "sync test");
 
-        // Should not panic
         writer.write_sync(&event);
         assert!(writer.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn test_protected_writer_event_dispatches_to_registry() {
+        use crate::observe::writers::{MemoryWriter, register_writer, unregister_writer};
+        use std::sync::Arc;
+
+        // The writer registry is global and may receive concurrent events
+        // from other tests. Use a unique marker in the event message so
+        // assertions remain stable under `-j4` parallel execution.
+        let marker = "PROTECTED_DISPATCH_MARKER_c4f21";
+        let capture = Arc::new(MemoryWriter::with_capacity(64));
+        register_writer(Box::new(MemoryWriterHandle {
+            inner: Arc::clone(&capture),
+            name: "protected_dispatch_capture",
+        }));
+
+        let writer = ProtectedWriter::new();
+        writer
+            .write_event(&Event::new(EventType::Info, marker))
+            .await;
+
+        let received = capture
+            .all_events()
+            .iter()
+            .filter(|e| e.message.contains(marker))
+            .count();
+
+        unregister_writer("protected_dispatch_capture");
+
+        assert_eq!(
+            received, 1,
+            "registered writer should receive the marker event exactly once"
+        );
+    }
+
+    // Named proxy around an external `MemoryWriter` so multiple tests can
+    // register their own capture without colliding on the shared registry.
+    struct MemoryWriterHandle {
+        inner: std::sync::Arc<crate::observe::writers::MemoryWriter>,
+        name: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::observe::writers::Writer for MemoryWriterHandle {
+        async fn write(
+            &self,
+            event: &Event,
+        ) -> std::result::Result<(), crate::observe::writers::WriterError> {
+            self.inner.write(event).await
+        }
+
+        async fn flush(&self) -> std::result::Result<(), crate::observe::writers::WriterError> {
+            self.inner.flush().await
+        }
+
+        fn health_check(&self) -> crate::observe::writers::WriterHealthStatus {
+            self.inner.health_check()
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
     }
 }

--- a/crates/octarine/tests/observe/mod.rs
+++ b/crates/octarine/tests/observe/mod.rs
@@ -19,5 +19,6 @@ mod metrics_export;
 mod pii_pipeline;
 mod thresholds;
 mod tracing_integration;
+mod writer_dispatch;
 mod writer_file;
 mod writer_memory;

--- a/crates/octarine/tests/observe/writer_dispatch.rs
+++ b/crates/octarine/tests/observe/writer_dispatch.rs
@@ -1,0 +1,259 @@
+//! Integration tests for end-to-end writer dispatch through the async
+//! dispatcher.
+//!
+//! Regression coverage for issue #210: prior to the fix,
+//! `dispatch_to_writers_sync` built a nested tokio runtime inside the
+//! dispatcher's own runtime and the resulting panic was swallowed by
+//! `let _ = ...`, silently dropping events for every registered writer
+//! except the always-synchronous console.
+//!
+//! Cargo runs these tests in parallel inside a single process, sharing
+//! the global `WRITER_REGISTRY` and `EVENT_DISPATCHER`. Tests use unique
+//! per-test writer names and unique event message markers, and assertions
+//! filter captured events by marker — never by absolute count — so two
+//! tests that fan out through the dispatcher cannot disturb each other.
+
+#![allow(clippy::panic, clippy::expect_used)]
+
+use async_trait::async_trait;
+use octarine::observe::writers::{
+    MemoryWriter, Writer, WriterError, WriterHealthStatus, disable_writer, dispatch,
+    register_writer, unregister_writer,
+};
+use octarine::observe::{Event, EventType};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::time::{Instant, sleep};
+
+/// Poll `probe` up to `deadline`, checking every `interval`. Returns
+/// `true` as soon as the probe succeeds. Avoids fixed-duration sleeps so
+/// the test is resilient under CI scheduling jitter.
+async fn poll_until<F: FnMut() -> bool>(
+    deadline: Duration,
+    interval: Duration,
+    mut probe: F,
+) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        if probe() {
+            return true;
+        }
+        sleep(interval).await;
+    }
+    probe()
+}
+
+/// Count how many stored events match a message marker. Using markers
+/// rather than absolute counts lets tests run in parallel on the shared
+/// global dispatcher without disturbing each other.
+fn count_with_marker(writer: &MemoryWriter, marker: &str) -> usize {
+    writer
+        .all_events()
+        .iter()
+        .filter(|e| e.message.contains(marker))
+        .count()
+}
+
+/// Named proxy around a shared `MemoryWriter` so multiple concurrent tests
+/// can register distinct capture writers against the global registry.
+struct CaptureWriter {
+    inner: Arc<MemoryWriter>,
+    name: &'static str,
+}
+
+#[async_trait]
+impl Writer for CaptureWriter {
+    async fn write(&self, event: &Event) -> Result<(), WriterError> {
+        self.inner.write(event).await
+    }
+
+    async fn flush(&self) -> Result<(), WriterError> {
+        self.inner.flush().await
+    }
+
+    fn health_check(&self) -> WriterHealthStatus {
+        self.inner.health_check()
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+/// Writer that always fails. Used to verify a failing writer does not
+/// block dispatch to other writers.
+struct AlwaysFailingWriter {
+    name: &'static str,
+    failures: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Writer for AlwaysFailingWriter {
+    async fn write(&self, _event: &Event) -> Result<(), WriterError> {
+        self.failures.fetch_add(1, Ordering::Relaxed);
+        Err(WriterError::Other("simulated failure".into()))
+    }
+
+    async fn flush(&self) -> Result<(), WriterError> {
+        Ok(())
+    }
+
+    fn health_check(&self) -> WriterHealthStatus {
+        WriterHealthStatus::Healthy
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[tokio::test]
+async fn registered_writer_receives_dispatched_event() {
+    let capture = Arc::new(MemoryWriter::with_capacity(64));
+    let name = "writer_dispatch_receives";
+    let marker = "WD_RECEIVES_v1_7f4a";
+    register_writer(Box::new(CaptureWriter {
+        inner: Arc::clone(&capture),
+        name,
+    }));
+
+    dispatch(Event::new(EventType::Info, marker));
+
+    let received = poll_until(Duration::from_secs(2), Duration::from_millis(10), || {
+        count_with_marker(&capture, marker) >= 1
+    })
+    .await;
+
+    unregister_writer(name);
+
+    assert!(
+        received,
+        "registered writer never received the dispatched event (issue #210 regression)"
+    );
+    assert_eq!(
+        count_with_marker(&capture, marker),
+        1,
+        "expected exactly one event with marker {marker}"
+    );
+}
+
+#[tokio::test]
+async fn multiple_writers_all_receive_event() {
+    let a = Arc::new(MemoryWriter::with_capacity(64));
+    let b = Arc::new(MemoryWriter::with_capacity(64));
+    let name_a = "writer_dispatch_multi_a";
+    let name_b = "writer_dispatch_multi_b";
+    let marker = "WD_FANOUT_v1_a913";
+
+    register_writer(Box::new(CaptureWriter {
+        inner: Arc::clone(&a),
+        name: name_a,
+    }));
+    register_writer(Box::new(CaptureWriter {
+        inner: Arc::clone(&b),
+        name: name_b,
+    }));
+
+    dispatch(Event::new(EventType::Info, marker));
+
+    let both = poll_until(Duration::from_secs(2), Duration::from_millis(10), || {
+        count_with_marker(&a, marker) >= 1 && count_with_marker(&b, marker) >= 1
+    })
+    .await;
+
+    unregister_writer(name_a);
+    unregister_writer(name_b);
+
+    assert!(both, "both registered writers should receive the event");
+    assert_eq!(count_with_marker(&a, marker), 1);
+    assert_eq!(count_with_marker(&b, marker), 1);
+}
+
+#[tokio::test]
+async fn failing_writer_does_not_block_others() {
+    let failures = Arc::new(AtomicUsize::new(0));
+    let good = Arc::new(MemoryWriter::with_capacity(64));
+    let failing_name = "writer_dispatch_failing";
+    let good_name = "writer_dispatch_good_peer";
+    let marker = "WD_FAILING_v1_c027";
+
+    register_writer(Box::new(AlwaysFailingWriter {
+        name: failing_name,
+        failures: Arc::clone(&failures),
+    }));
+    register_writer(Box::new(CaptureWriter {
+        inner: Arc::clone(&good),
+        name: good_name,
+    }));
+
+    dispatch(Event::new(EventType::Info, marker));
+
+    let good_received = poll_until(Duration::from_secs(2), Duration::from_millis(10), || {
+        count_with_marker(&good, marker) >= 1
+    })
+    .await;
+
+    unregister_writer(failing_name);
+    unregister_writer(good_name);
+
+    assert!(
+        good_received,
+        "the healthy writer must receive the event even when a peer writer fails"
+    );
+    assert!(
+        failures.load(Ordering::Relaxed) >= 1,
+        "the failing writer should have been invoked at least once"
+    );
+}
+
+#[tokio::test]
+async fn disabled_writer_receives_nothing() {
+    let capture = Arc::new(MemoryWriter::with_capacity(64));
+    let name = "writer_dispatch_disabled";
+    let marker = "WD_DISABLED_v1_5b88";
+
+    register_writer(Box::new(CaptureWriter {
+        inner: Arc::clone(&capture),
+        name,
+    }));
+    disable_writer(name);
+
+    dispatch(Event::new(EventType::Info, marker));
+
+    // Use a second marker event on a second writer to know when the
+    // dispatcher has had a fair chance to process this test's submission.
+    // Polling the original capture until a deadline would always succeed
+    // by timing out; we want a positive signal that dispatch flushed.
+    let probe = Arc::new(MemoryWriter::with_capacity(64));
+    let probe_name = "writer_dispatch_disabled_probe";
+    let probe_marker = "WD_DISABLED_PROBE_v1_5b88";
+    register_writer(Box::new(CaptureWriter {
+        inner: Arc::clone(&probe),
+        name: probe_name,
+    }));
+    dispatch(Event::new(EventType::Info, probe_marker));
+
+    let probe_received = poll_until(Duration::from_secs(2), Duration::from_millis(10), || {
+        count_with_marker(&probe, probe_marker) >= 1
+    })
+    .await;
+
+    let disabled_count = count_with_marker(&capture, marker);
+
+    unregister_writer(name);
+    unregister_writer(probe_name);
+
+    assert!(
+        probe_received,
+        "probe writer should receive its event, confirming dispatcher flushed"
+    );
+    assert_eq!(
+        disabled_count, 0,
+        "disabled writer should not receive any events"
+    );
+}

--- a/docs/observe/integration.md
+++ b/docs/observe/integration.md
@@ -87,7 +87,15 @@ async fn setup_postgres() -> Result<PostgresBackend, WriterError> {
 
 ## Custom Writer Implementation
 
-Implement the `Writer` trait for custom destinations:
+Implement the `Writer` trait for custom destinations.
+
+**Runtime contract.** `Writer::write` is invoked from inside the observe
+dispatcher's tokio runtime (a dedicated background thread). Implementations
+may freely `.await` tokio I/O — HTTP clients, file handles, database
+drivers, async channels — and do not need to spawn their own runtime.
+A failure returned from `write` is logged to stderr and does not block
+dispatch to other registered writers.
+
 
 ```rust
 use octarine::observe::writers::{Writer, WriterError, HealthStatus};


### PR DESCRIPTION
## Summary

- Fixes silent data loss for every non-console registered writer (FileWriter, SqliteWriter, PostgresWriter, MemoryWriter, custom). `dispatch_to_writers_sync` built a nested tokio `current_thread` runtime inside the dispatcher's own runtime and swallowed the resulting panic via `let _ = ...`.
- Dispatcher now awaits `Writer::write` directly from the async `select!` loop — no nested runtime, no swallowed panics. Writer failures are logged to stderr.
- Registry internally stores `Arc<dyn Writer>` so handles can be snapshotted and the `std::sync::RwLock` guard dropped before `.await`. Public `register_writer(Box<dyn Writer>)` signature unchanged.
- `ProtectedWriter` gains `async fn write_event` for the hot path; `write_sync` becomes the console-only fallback used only when the dispatcher cannot build a tokio runtime at all.

## Test plan

- [x] `just test-filter writer_dispatch` — 4 new integration tests pass (happy path, fan-out, failing peer, disabled writer). Tests use unique event markers to stay stable under `cargo test -j4`.
- [x] `just test-octarine` — no regressions in existing writer/dispatcher tests (6216+ tests green).
- [x] `just clippy` — passes with `-D warnings`.
- [x] `just fmt-check` — formatting clean.
- [x] `just arch-check` — layer boundaries respected (changes limited to Layer 2 `observe/writers/**`).
- [x] `just preflight` — full gate green.

## Notes

- The fallback path in `async_dispatch.rs` (when `tokio::runtime::Builder::build()` fails) retains `write_sync` and is now explicitly console-only; registered writers are skipped because there is no runtime available to host their async `write` calls.
- Writer failures log directly to `stderr` via `writeln!(std::io::stderr().lock(), ...)` — using `observe::warn` would recurse through the same dispatcher this function powers and risk amplification loops.
- Added a short writer runtime contract to `docs/observe/integration.md` clarifying that `Writer::write` runs inside the dispatcher's tokio runtime and may freely `.await` tokio I/O.

Closes #210