### PR TITLE
chore(observe): add From<IdentifierType> for PiiType bridge

### DIFF
--- a/crates/octarine/src/observe/pii/types.rs
+++ b/crates/octarine/src/observe/pii/types.rs
@@ -13,6 +13,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::primitives::identifiers::IdentifierType;
+
 /// Types of PII that can be detected
 ///
 /// Organized by domain for clarity. Each variant maps to detection
@@ -391,6 +393,113 @@ impl PiiType {
     }
 }
 
+// Maps every `IdentifierType` variant to its `PiiType` counterpart. The match
+// has no wildcard arm; because `IdentifierType` is not `#[non_exhaustive]`,
+// adding a new variant will fail compilation here until it is explicitly
+// mapped. This is the compile-time bridge that keeps the two registries in
+// sync — the scanner (`observe/pii/scanner/domains.rs`) remains the
+// authoritative source for the mapping semantics.
+impl From<IdentifierType> for PiiType {
+    fn from(id: IdentifierType) -> Self {
+        match id {
+            // Personal
+            IdentifierType::Email => Self::Email,
+            IdentifierType::PhoneNumber => Self::Phone,
+            IdentifierType::Ssn => Self::Ssn,
+            IdentifierType::PersonalName => Self::Name,
+            IdentifierType::Birthdate => Self::Birthdate,
+            IdentifierType::Username => Self::Username,
+
+            // Credential
+            IdentifierType::Password => Self::Password,
+            IdentifierType::Pin => Self::Pin,
+            IdentifierType::SecurityAnswer => Self::SecurityAnswer,
+            IdentifierType::Passphrase => Self::Passphrase,
+
+            // Network
+            IdentifierType::Uuid => Self::Uuid,
+            IdentifierType::IpAddress => Self::IpAddress,
+            IdentifierType::MacAddress => Self::MacAddress,
+            IdentifierType::Url => Self::Url,
+            IdentifierType::Domain => Self::Domain,
+            IdentifierType::Hostname => Self::Hostname,
+            IdentifierType::Port => Self::Port,
+
+            // Payment
+            IdentifierType::CreditCard => Self::CreditCard,
+            IdentifierType::BankAccount => Self::BankAccount,
+            IdentifierType::RoutingNumber => Self::RoutingNumber,
+            IdentifierType::PaymentToken => Self::PaymentToken,
+            // fallback: no dedicated PiiType::CryptoAddress variant yet
+            IdentifierType::CryptoAddress => Self::PaymentToken,
+            // fallback: IBAN is a bank account number
+            IdentifierType::Iban => Self::BankAccount,
+
+            // Token/Key
+            IdentifierType::Jwt => Self::Jwt,
+            IdentifierType::ApiKey => Self::ApiKey,
+            IdentifierType::SessionId => Self::SessionId,
+            // fallback: no dedicated PiiType variants for developer tokens
+            IdentifierType::GitHubToken
+            | IdentifierType::GitLabToken
+            | IdentifierType::AwsAccessKey
+            | IdentifierType::AwsSessionToken
+            | IdentifierType::HighEntropyString => Self::ApiKey,
+
+            // Database
+            IdentifierType::ConnectionString => Self::ConnectionString,
+
+            // Government
+            IdentifierType::DriverLicense => Self::DriverLicense,
+            IdentifierType::Passport => Self::Passport,
+            IdentifierType::TaxId => Self::TaxId,
+            IdentifierType::NationalId => Self::NationalId,
+            // fallback: no dedicated PiiType variants for country-specific IDs
+            IdentifierType::KoreaRrn
+            | IdentifierType::AustraliaTfn
+            | IdentifierType::AustraliaAbn
+            | IdentifierType::IndiaAadhaar
+            | IdentifierType::IndiaPan
+            | IdentifierType::SingaporeNric
+            | IdentifierType::FinlandHetu
+            | IdentifierType::PolandPesel
+            | IdentifierType::ItalyFiscalCode
+            | IdentifierType::SpainNif
+            | IdentifierType::SpainNie => Self::NationalId,
+
+            // Organizational
+            IdentifierType::EmployeeId => Self::EmployeeId,
+            IdentifierType::StudentId => Self::StudentId,
+            IdentifierType::BadgeNumber => Self::BadgeNumber,
+            IdentifierType::VehicleId => Self::Vin,
+
+            // Location
+            IdentifierType::GPSCoordinate => Self::GpsCoordinates,
+            IdentifierType::StreetAddress => Self::Address,
+            IdentifierType::PostalCode => Self::PostalCode,
+
+            // Medical
+            IdentifierType::MedicalRecordNumber => Self::Mrn,
+            IdentifierType::HealthInsurance => Self::InsuranceNumber,
+            IdentifierType::Prescription => Self::PrescriptionNumber,
+            IdentifierType::ProviderID => Self::Npi,
+            IdentifierType::MedicalCode => Self::IcdCode,
+            IdentifierType::MedicalLicense => Self::DeaNumber,
+
+            // Biometric
+            IdentifierType::Fingerprint => Self::FingerprintId,
+            IdentifierType::FacialRecognition => Self::FaceId,
+            IdentifierType::IrisScan => Self::IrisId,
+            IdentifierType::VoicePrint => Self::VoiceId,
+            IdentifierType::DNASequence => Self::DnaId,
+            IdentifierType::BiometricTemplate => Self::BiometricTemplate,
+
+            // Generic
+            IdentifierType::Unknown => Self::Generic,
+        }
+    }
+}
+
 /// Result of PII scanning operation
 #[derive(Debug, Clone)]
 pub(crate) struct PiiScanResult {
@@ -617,5 +726,222 @@ mod tests {
         // Credit card alone does not trigger PHI
         let result = PiiScanResult::with_pii(vec![PiiType::CreditCard], "redacted".to_string());
         assert!(!result.contains_phi);
+    }
+
+    #[test]
+    fn from_identifier_type_direct_mappings() {
+        // One-to-one pairs where the PiiType variant matches the IdentifierType
+        // variant by name or by the scanner's direct-push convention.
+
+        // Personal
+        assert_eq!(PiiType::from(IdentifierType::Email), PiiType::Email);
+        assert_eq!(PiiType::from(IdentifierType::Ssn), PiiType::Ssn);
+        assert_eq!(PiiType::from(IdentifierType::Birthdate), PiiType::Birthdate);
+        assert_eq!(PiiType::from(IdentifierType::Username), PiiType::Username);
+
+        // Credential
+        assert_eq!(PiiType::from(IdentifierType::Password), PiiType::Password);
+        assert_eq!(PiiType::from(IdentifierType::Pin), PiiType::Pin);
+        assert_eq!(
+            PiiType::from(IdentifierType::Passphrase),
+            PiiType::Passphrase
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::SecurityAnswer),
+            PiiType::SecurityAnswer
+        );
+
+        // Network
+        assert_eq!(PiiType::from(IdentifierType::Uuid), PiiType::Uuid);
+        assert_eq!(PiiType::from(IdentifierType::IpAddress), PiiType::IpAddress);
+        assert_eq!(
+            PiiType::from(IdentifierType::MacAddress),
+            PiiType::MacAddress
+        );
+        assert_eq!(PiiType::from(IdentifierType::Url), PiiType::Url);
+        assert_eq!(PiiType::from(IdentifierType::Domain), PiiType::Domain);
+        assert_eq!(PiiType::from(IdentifierType::Hostname), PiiType::Hostname);
+        assert_eq!(PiiType::from(IdentifierType::Port), PiiType::Port);
+
+        // Payment
+        assert_eq!(
+            PiiType::from(IdentifierType::CreditCard),
+            PiiType::CreditCard
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::BankAccount),
+            PiiType::BankAccount
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::RoutingNumber),
+            PiiType::RoutingNumber
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::PaymentToken),
+            PiiType::PaymentToken
+        );
+
+        // Token/Key
+        assert_eq!(PiiType::from(IdentifierType::Jwt), PiiType::Jwt);
+        assert_eq!(PiiType::from(IdentifierType::ApiKey), PiiType::ApiKey);
+        assert_eq!(PiiType::from(IdentifierType::SessionId), PiiType::SessionId);
+
+        // Database
+        assert_eq!(
+            PiiType::from(IdentifierType::ConnectionString),
+            PiiType::ConnectionString
+        );
+
+        // Government
+        assert_eq!(
+            PiiType::from(IdentifierType::DriverLicense),
+            PiiType::DriverLicense
+        );
+        assert_eq!(PiiType::from(IdentifierType::Passport), PiiType::Passport);
+        assert_eq!(PiiType::from(IdentifierType::TaxId), PiiType::TaxId);
+        assert_eq!(
+            PiiType::from(IdentifierType::NationalId),
+            PiiType::NationalId
+        );
+
+        // Organizational
+        assert_eq!(
+            PiiType::from(IdentifierType::EmployeeId),
+            PiiType::EmployeeId
+        );
+        assert_eq!(PiiType::from(IdentifierType::StudentId), PiiType::StudentId);
+        assert_eq!(
+            PiiType::from(IdentifierType::BadgeNumber),
+            PiiType::BadgeNumber
+        );
+
+        // Location
+        assert_eq!(
+            PiiType::from(IdentifierType::PostalCode),
+            PiiType::PostalCode
+        );
+
+        // Biometric
+        assert_eq!(
+            PiiType::from(IdentifierType::BiometricTemplate),
+            PiiType::BiometricTemplate
+        );
+    }
+
+    #[test]
+    fn from_identifier_type_scanner_parity() {
+        // Non-obvious mappings — these mirror what
+        // observe/pii/scanner/domains.rs pushes for each detected
+        // IdentifierType. Changing either side without the other would create
+        // silent drift.
+
+        // Personal (scanner: scan_personal)
+        assert_eq!(PiiType::from(IdentifierType::PhoneNumber), PiiType::Phone);
+        assert_eq!(PiiType::from(IdentifierType::PersonalName), PiiType::Name);
+
+        // Organizational (scanner: scan_government, L75-77)
+        assert_eq!(PiiType::from(IdentifierType::VehicleId), PiiType::Vin);
+
+        // Location (scanner: scan_location)
+        assert_eq!(
+            PiiType::from(IdentifierType::GPSCoordinate),
+            PiiType::GpsCoordinates
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::StreetAddress),
+            PiiType::Address
+        );
+
+        // Medical (scanner: scan_medical)
+        assert_eq!(
+            PiiType::from(IdentifierType::MedicalRecordNumber),
+            PiiType::Mrn
+        );
+        assert_eq!(PiiType::from(IdentifierType::ProviderID), PiiType::Npi);
+        assert_eq!(
+            PiiType::from(IdentifierType::HealthInsurance),
+            PiiType::InsuranceNumber
+        );
+        assert_eq!(PiiType::from(IdentifierType::MedicalCode), PiiType::IcdCode);
+        assert_eq!(
+            PiiType::from(IdentifierType::Prescription),
+            PiiType::PrescriptionNumber
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::MedicalLicense),
+            PiiType::DeaNumber
+        );
+
+        // Biometric (scanner: scan_biometric)
+        assert_eq!(
+            PiiType::from(IdentifierType::Fingerprint),
+            PiiType::FingerprintId
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::FacialRecognition),
+            PiiType::FaceId
+        );
+        assert_eq!(PiiType::from(IdentifierType::IrisScan), PiiType::IrisId);
+        assert_eq!(PiiType::from(IdentifierType::VoicePrint), PiiType::VoiceId);
+        assert_eq!(PiiType::from(IdentifierType::DNASequence), PiiType::DnaId);
+    }
+
+    #[test]
+    fn from_identifier_type_fallback_mappings() {
+        // Pin the intentional fallbacks so they can't silently change. When a
+        // dedicated PiiType variant is eventually added (e.g., PiiType::Iban,
+        // PiiType::CryptoAddress, country-specific IDs), the corresponding
+        // assertion here will flip and signal the mapping needs review.
+
+        // Payment fallbacks
+        assert_eq!(
+            PiiType::from(IdentifierType::Iban),
+            PiiType::BankAccount,
+            "Iban fallback: IBAN is a bank account number"
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::CryptoAddress),
+            PiiType::PaymentToken,
+            "CryptoAddress fallback: no dedicated PiiType variant yet"
+        );
+
+        // Developer-token fallbacks (all collapse to ApiKey)
+        for id in [
+            IdentifierType::GitHubToken,
+            IdentifierType::GitLabToken,
+            IdentifierType::AwsAccessKey,
+            IdentifierType::AwsSessionToken,
+            IdentifierType::HighEntropyString,
+        ] {
+            assert_eq!(
+                PiiType::from(id.clone()),
+                PiiType::ApiKey,
+                "{id:?} should fall back to ApiKey"
+            );
+        }
+
+        // Country-specific national-ID fallbacks (all collapse to NationalId)
+        for id in [
+            IdentifierType::KoreaRrn,
+            IdentifierType::AustraliaTfn,
+            IdentifierType::AustraliaAbn,
+            IdentifierType::IndiaAadhaar,
+            IdentifierType::IndiaPan,
+            IdentifierType::SingaporeNric,
+            IdentifierType::FinlandHetu,
+            IdentifierType::PolandPesel,
+            IdentifierType::ItalyFiscalCode,
+            IdentifierType::SpainNif,
+            IdentifierType::SpainNie,
+        ] {
+            assert_eq!(
+                PiiType::from(id.clone()),
+                PiiType::NationalId,
+                "{id:?} should fall back to NationalId"
+            );
+        }
+
+        // Generic catch-all
+        assert_eq!(PiiType::from(IdentifierType::Unknown), PiiType::Generic);
     }
 }


### PR DESCRIPTION
## Summary

Adds `impl From<IdentifierType> for PiiType` in `crates/octarine/src/observe/pii/types.rs`, centralizing the mapping that was previously scattered across `observe/pii/scanner/domains.rs` as hard-coded match arms.

**Compile-time enforcement**: the match has no wildcard arm, and `IdentifierType` is not `#[non_exhaustive]`. Adding a new `IdentifierType` variant will now fail compilation until an explicit `PiiType` counterpart is chosen — closing the drift window that produced the audit finding in issue #162.

**Fallback mappings** (pinned by unit tests so they cannot change silently):

- `Iban` → `PiiType::BankAccount`
- `CryptoAddress` → `PiiType::PaymentToken`
- `GitHubToken`, `GitLabToken`, `AwsAccessKey`, `AwsSessionToken`, `HighEntropyString` → `PiiType::ApiKey`
- 11 country-specific IDs (`KoreaRrn`, `AustraliaTfn`/`Abn`, `IndiaAadhaar`/`Pan`, `SingaporeNric`, `FinlandHetu`, `PolandPesel`, `ItalyFiscalCode`, `SpainNif`/`Nie`) → `PiiType::NationalId`
- `Unknown` → `PiiType::Generic`

Dedicated `PiiType` variants for those categories are intentionally deferred to follow-up issues (requires touching `name()`, `domain()`, `is_*_protected()`, the redactor, and the scanner — out of scope here).

## Test plan

- `just test-mod "observe::pii::types"` — 18 passed, 0 failed (3 new: `from_identifier_type_direct_mappings`, `from_identifier_type_scanner_parity`, `from_identifier_type_fallback_mappings`).
- `just preflight` — fmt-check + clippy + arch-check + full workspace tests (6358 passed, 0 failed), exit 0.

## Out of scope (follow-ups)

- Refactoring `scanner/domains.rs` to use the new `From` impl.
- Adding dedicated `PiiType` variants for `Iban`, `CryptoAddress`, the dev-token family, and country-specific IDs.
- Scanner coverage gaps surfaced during exploration (`RoutingNumber`, `Hostname`, `Port` have `PiiType` variants but no scanner push paths).

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)