### PR TITLE
fix(observe): harden integration-test dispatcher config against CI flakes

### DIFF
--- a/crates/octarine/src/observe/writers/async_dispatch.rs
+++ b/crates/octarine/src/observe/writers/async_dispatch.rs
@@ -180,6 +180,27 @@ impl DispatcherConfig {
             ..Default::default()
         }
     }
+
+    /// Create a configuration tuned for integration tests.
+    ///
+    /// Sets `batch_size = 1` and `flush_interval = 10ms` so dispatched events
+    /// are delivered to registered writers within tens of milliseconds rather
+    /// than waiting up to the default 1-second flush tick. Intended to be
+    /// applied once, via `configure_dispatcher(DispatcherConfig::testing())`,
+    /// before any test dispatches through the global singleton. Subsequent
+    /// tests in the same test binary inherit the configuration.
+    ///
+    /// Eliminates the CI flakiness where global-singleton batching under
+    /// heavy parallel test load delays writer dispatch past typical poll
+    /// deadlines (see issue #223).
+    #[must_use]
+    pub fn testing() -> Self {
+        Self {
+            batch_size: 1,
+            flush_interval: Duration::from_millis(10),
+            ..Default::default()
+        }
+    }
 }
 
 // =============================================================================

--- a/crates/octarine/tests/observe/async_dispatch.rs
+++ b/crates/octarine/tests/observe/async_dispatch.rs
@@ -21,6 +21,8 @@ use std::time::Duration;
 
 #[test]
 fn test_dispatch_stats_available() {
+    super::ensure_test_dispatcher();
+
     let stats = dispatcher_stats();
 
     // Stats should have reasonable values
@@ -30,6 +32,8 @@ fn test_dispatch_stats_available() {
 
 #[test]
 fn test_dispatch_health_check() {
+    super::ensure_test_dispatcher();
+
     // Health checks should return without panic
     let is_healthy = dispatcher_is_healthy();
     let is_degraded = dispatcher_is_degraded();
@@ -54,6 +58,8 @@ fn test_dispatch_health_check() {
 
 #[test]
 fn test_dispatch_capacity() {
+    super::ensure_test_dispatcher();
+
     let stats = dispatcher_stats();
 
     // Channel capacity should be 10,000 as per implementation
@@ -69,6 +75,8 @@ fn test_dispatch_capacity() {
 
 #[test]
 fn test_logging_shortcuts_queue_events() {
+    super::ensure_test_dispatcher();
+
     let stats_before = dispatcher_stats();
 
     // Queue some events via logging shortcuts
@@ -94,6 +102,8 @@ fn test_logging_shortcuts_queue_events() {
 
 #[test]
 fn test_many_events_queued_successfully() {
+    super::ensure_test_dispatcher();
+
     let stats_before = dispatcher_stats();
 
     // Queue many events rapidly
@@ -121,6 +131,8 @@ fn test_many_events_queued_successfully() {
 
 #[test]
 fn test_health_score_formula() {
+    super::ensure_test_dispatcher();
+
     let score = dispatcher_health_score();
 
     // Health score is calculated as:
@@ -140,6 +152,8 @@ fn test_health_score_formula() {
 
 #[test]
 fn test_health_thresholds() {
+    super::ensure_test_dispatcher();
+
     // Document the health thresholds
     // is_healthy: drop_rate < 5%
     // is_degraded: drop_rate > 1% OR retry_rate > 10%
@@ -176,6 +190,8 @@ fn test_health_thresholds() {
 
 #[tokio::test]
 async fn test_dispatch_from_async_context() {
+    super::ensure_test_dispatcher();
+
     let stats_before = dispatcher_stats();
 
     // Queue events from async context
@@ -198,6 +214,8 @@ async fn test_dispatch_from_async_context() {
 
 #[tokio::test]
 async fn test_concurrent_dispatch_from_tasks() {
+    super::ensure_test_dispatcher();
+
     let stats_before = dispatcher_stats();
 
     // Spawn multiple tasks that all log concurrently
@@ -236,6 +254,8 @@ async fn test_concurrent_dispatch_from_tasks() {
 
 #[test]
 fn test_dispatch_handles_burst_load() {
+    super::ensure_test_dispatcher();
+
     let stats_before = dispatcher_stats();
 
     // Send a burst of events
@@ -263,6 +283,8 @@ fn test_dispatch_handles_burst_load() {
 
 #[test]
 fn test_drops_are_tracked() {
+    super::ensure_test_dispatcher();
+
     let stats = dispatcher_stats();
 
     // Drops should be tracked (may be 0 if no backpressure)
@@ -279,6 +301,8 @@ fn test_drops_are_tracked() {
 
 #[test]
 fn test_stats_are_monotonic() {
+    super::ensure_test_dispatcher();
+
     let stats1 = dispatcher_stats();
 
     // Queue more events
@@ -300,6 +324,8 @@ fn test_stats_are_monotonic() {
 
 #[test]
 fn test_stats_capacity_is_constant() {
+    super::ensure_test_dispatcher();
+
     let stats1 = dispatcher_stats();
     info("capacity_test", "Test event");
     let stats2 = dispatcher_stats();
@@ -316,6 +342,8 @@ fn test_stats_capacity_is_constant() {
 
 #[test]
 fn test_empty_message_dispatch() {
+    super::ensure_test_dispatcher();
+
     // Empty messages should be handled
     info("edge_test", "");
 
@@ -324,6 +352,8 @@ fn test_empty_message_dispatch() {
 
 #[test]
 fn test_large_message_dispatch() {
+    super::ensure_test_dispatcher();
+
     // Large messages should be handled
     let large_message = "x".repeat(10_000);
     info("large_test", &large_message);
@@ -333,6 +363,8 @@ fn test_large_message_dispatch() {
 
 #[test]
 fn test_unicode_message_dispatch() {
+    super::ensure_test_dispatcher();
+
     // Unicode should be handled
     info("unicode_test", "日本語メッセージ 🎉 émoji");
 
@@ -341,6 +373,8 @@ fn test_unicode_message_dispatch() {
 
 #[test]
 fn test_special_chars_dispatch() {
+    super::ensure_test_dispatcher();
+
     // Special characters should be handled
     info("special_test", "Line1\nLine2\tTabbed\r\nWindows");
     info("special_test", "Quotes: \"double\" and 'single'");
@@ -355,6 +389,8 @@ fn test_special_chars_dispatch() {
 
 #[test]
 fn test_extended_stats_available() {
+    super::ensure_test_dispatcher();
+
     let stats = dispatcher_stats_extended();
 
     // Extended stats should have all fields
@@ -367,6 +403,8 @@ fn test_extended_stats_available() {
 
 #[test]
 fn test_extended_stats_health_methods() {
+    super::ensure_test_dispatcher();
+
     let stats = dispatcher_stats_extended();
 
     // Health score should match DispatcherStats method
@@ -387,6 +425,8 @@ fn test_extended_stats_health_methods() {
 
 #[test]
 fn test_overflow_strategy_accessor() {
+    super::ensure_test_dispatcher();
+
     let strategy = dispatcher_overflow_strategy();
 
     // Default strategy should be RetryThenDrop
@@ -399,6 +439,8 @@ fn test_overflow_strategy_accessor() {
 
 #[test]
 fn test_capacity_accessor() {
+    super::ensure_test_dispatcher();
+
     let capacity = dispatcher_capacity();
 
     // Should match stats capacity

--- a/crates/octarine/tests/observe/event_flow.rs
+++ b/crates/octarine/tests/observe/event_flow.rs
@@ -240,6 +240,8 @@ impl Writer for CountingWriter {
 
 #[test]
 fn test_writer_registration() {
+    super::ensure_test_dispatcher();
+
     let (writer, _count) = CountingWriter::new("test_counting_writer");
     register_writer(Box::new(writer));
 
@@ -255,6 +257,8 @@ fn test_writer_registration() {
 
 #[test]
 fn test_writer_health_monitoring() {
+    super::ensure_test_dispatcher();
+
     let (writer, _count) = CountingWriter::new("health_test_writer");
     register_writer(Box::new(writer));
 
@@ -271,6 +275,8 @@ fn test_writer_health_monitoring() {
 
 #[test]
 fn test_logging_shortcuts_do_not_panic() {
+    super::ensure_test_dispatcher();
+
     // These should execute without panicking
     // Note: They dispatch to async queue, so we can't verify output here
     debug("test", "Debug message");
@@ -282,6 +288,8 @@ fn test_logging_shortcuts_do_not_panic() {
 
 #[test]
 fn test_logging_with_empty_messages() {
+    super::ensure_test_dispatcher();
+
     // Empty messages should be handled gracefully
     info("test", "");
     warn("", "Empty operation");
@@ -289,6 +297,8 @@ fn test_logging_with_empty_messages() {
 
 #[test]
 fn test_logging_with_special_characters() {
+    super::ensure_test_dispatcher();
+
     // Special characters should not cause issues
     info("test", "Message with \"quotes\" and \\ backslash");
     info("test", "Message with\nnewline");

--- a/crates/octarine/tests/observe/mod.rs
+++ b/crates/octarine/tests/observe/mod.rs
@@ -11,6 +11,41 @@
 //! - Tracing crate integration
 //! - Audit builders and compliance tagging
 
+#![allow(clippy::panic, clippy::expect_used)]
+
+use std::sync::OnceLock;
+
+use octarine::observe::writers::{DispatcherConfig, configure_dispatcher};
+
+/// Apply `DispatcherConfig::testing()` to the global dispatcher exactly once
+/// per integration-test binary. Sets `batch_size = 1` and
+/// `flush_interval = 10ms` so dispatched events reach registered writers
+/// within tens of milliseconds instead of waiting up to the default
+/// 1-second flush tick.
+///
+/// Every test in this binary that queries the dispatcher (directly via
+/// `dispatch()` / stats APIs, or indirectly via logging shortcuts like
+/// `info()` / `warn()`) MUST call this helper first. The dispatcher is a
+/// lazily-initialised global: whichever test queries it first pins its
+/// configuration for the remainder of the binary, so a single test that
+/// skips this call can default-configure the singleton and re-introduce
+/// the CI flake described in issue #223.
+///
+/// Why an explicit per-test call rather than a binary-load ctor: the crate
+/// sets `unsafe_code = "forbid"` at the Cargo.toml level, which rules out
+/// `.init_array` crates like `ctor`. The `OnceLock` keeps the call cheap
+/// after the first test runs it.
+pub(super) fn ensure_test_dispatcher() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        // `configure_dispatcher` returns false if the dispatcher has already
+        // been initialised by an earlier dispatch in this process. Either
+        // outcome is fine — the critical invariant is that every test that
+        // touches the dispatcher calls this before doing so.
+        let _ = configure_dispatcher(DispatcherConfig::testing());
+    });
+}
+
 mod async_dispatch;
 mod audit_builders;
 mod context_capture;

--- a/crates/octarine/tests/observe/writer_dispatch.rs
+++ b/crates/octarine/tests/observe/writer_dispatch.rs
@@ -114,6 +114,8 @@ impl Writer for AlwaysFailingWriter {
 
 #[tokio::test]
 async fn registered_writer_receives_dispatched_event() {
+    super::ensure_test_dispatcher();
+
     let capture = Arc::new(MemoryWriter::with_capacity(64));
     let name = "writer_dispatch_receives";
     let marker = "WD_RECEIVES_v1_7f4a";
@@ -144,6 +146,8 @@ async fn registered_writer_receives_dispatched_event() {
 
 #[tokio::test]
 async fn multiple_writers_all_receive_event() {
+    super::ensure_test_dispatcher();
+
     let a = Arc::new(MemoryWriter::with_capacity(64));
     let b = Arc::new(MemoryWriter::with_capacity(64));
     let name_a = "writer_dispatch_multi_a";
@@ -175,8 +179,9 @@ async fn multiple_writers_all_receive_event() {
 }
 
 #[tokio::test]
-#[ignore = "consistently fails in CI due to global dispatcher batching under parallel test load (issue #223)"]
 async fn failing_writer_does_not_block_others() {
+    super::ensure_test_dispatcher();
+
     let failures = Arc::new(AtomicUsize::new(0));
     let good = Arc::new(MemoryWriter::with_capacity(64));
     let failing_name = "writer_dispatch_failing";
@@ -214,6 +219,8 @@ async fn failing_writer_does_not_block_others() {
 
 #[tokio::test]
 async fn disabled_writer_receives_nothing() {
+    super::ensure_test_dispatcher();
+
     let capture = Arc::new(MemoryWriter::with_capacity(64));
     let name = "writer_dispatch_disabled";
     let marker = "WD_DISABLED_v1_5b88";


### PR DESCRIPTION
## Summary

Fixes the flaky integration tests in the `observe_integration` binary that caused sporadic CI failures (most recently on PR #224, historically tracked in #223).

**Root cause**: The global `EVENT_DISPATCHER` is a lazily-initialised singleton with defaults of `batch_size = 100` and `flush_interval = 1s`. Whichever integration test queries the dispatcher first pins that config for the rest of the binary. Under CI's ~6000 parallel tests, single-event writer-dispatch tests routinely blow past their 2-second poll deadlines waiting for a batch to fill or a 1-second flush tick to fire.

**Fix**:

- **New preset** `DispatcherConfig::testing()` in `observe/writers/async_dispatch.rs` — `batch_size = 1` + `flush_interval = 10ms`, otherwise identical to `Default::default()` so existing assertions on capacity / overflow strategy still hold. Public alongside `development/production/high_volume/critical`.
- **Shared helper** `ensure_test_dispatcher()` in `tests/observe/mod.rs`, wrapping a `OnceLock` so the preset is applied exactly once per binary. A `ctor`-style binary-load init would be cleaner but the crate has `unsafe_code = "forbid"`, which rules out `.init_array` attribute crates.
- **Call sites**: every integration test that touches the dispatcher now invokes `super::ensure_test_dispatcher()` as its first line — whichever test runs first wins the init race and short-circuits the default-config path.
  - `writer_dispatch.rs`: 4 tests
  - `async_dispatch.rs`: 21 tests (only the ones that actually hit the dispatcher; pure config-struct tests are untouched)
  - `event_flow.rs`: 5 tests
- **Un-ignored** `failing_writer_does_not_block_others` — marked `#[ignore]` in 5cec0b3 specifically for this root cause. It now runs and passes reliably.

## Test plan

- `cargo test -p octarine --test observe_integration -j4` — 232 passed, 0 failed, 0 ignored.
- Stress runs:
  - 20× isolated `writer_dispatch` tests: all pass.
  - 10× full `observe_integration` binary: all pass (232/232 each).
- `just preflight` — fmt-check + clippy + arch-check + full workspace tests, exit 0, 6355 tests pass.

## Why not a ctor-style init

Attempted first — cleaner, no per-test sprinkle. Rejected because `ctor::ctor` expands to code requiring `allow(unsafe_code)`, and the crate's `Cargo.toml` has `[lints.rust] unsafe_code = "forbid"` which cannot be locally overridden. The explicit `super::ensure_test_dispatcher()` call is tedious but matches the project's conservative style and requires no new dependency.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)