### PR TITLE
chore(crypto): document LE wire format on encrypted-message serializers

### DIFF
--- a/crates/octarine/src/primitives/crypto/encryption/hybrid/encryption.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/hybrid/encryption.rs
@@ -263,7 +263,13 @@ impl HybridEncryption {
 
     /// Serialize the complete encrypted message.
     ///
-    /// Format: `[kem_ct_len (4)][kem_ct][x25519_pk (32)][nonce (12)][ct_len (4)][ct]`
+    /// # Wire format
+    ///
+    /// `[kem_ct_len (4)][kem_ct][x25519_pk (32)][nonce (12)][ct_len (4)][ct]`
+    ///
+    /// All length fields use little-endian encoding. This is a canonical
+    /// wire format, not native-endian, so ciphertexts remain portable
+    /// between little-endian and big-endian hosts.
     pub fn to_bytes(&self) -> Vec<u8> {
         let kem_len = self.kem_ciphertext.len() as u32;
         let ct_len = self.ciphertext.len() as u32;
@@ -287,6 +293,9 @@ impl HybridEncryption {
     }
 
     /// Deserialize an encrypted message from bytes.
+    ///
+    /// See [`to_bytes`](Self::to_bytes) for the wire format. All length
+    /// fields are decoded as little-endian.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, CryptoError> {
         if bytes.len() < 4 {
             return Err(CryptoError::decryption("Message too short"));

--- a/crates/octarine/src/primitives/crypto/encryption/persistent/encryption.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/persistent/encryption.rs
@@ -145,14 +145,19 @@ impl PersistentEncryption {
 
     /// Serialize to a byte vector.
     ///
-    /// Format (little-endian lengths):
+    /// # Wire format
+    ///
+    /// All length fields and the key version use little-endian encoding.
+    /// This is a canonical wire format, not native-endian, so ciphertexts
+    /// remain portable between little-endian and big-endian hosts.
+    ///
     /// ```text
-    /// [version: 4 bytes]
-    /// [kem_ct_len: 4 bytes][kem_ciphertext]
+    /// [version: 4 bytes (LE)]
+    /// [kem_ct_len: 4 bytes (LE)][kem_ciphertext]
     /// [chacha_nonce: 12 bytes]
-    /// [aes_ct_len: 4 bytes][aes_ciphertext]
+    /// [aes_ct_len: 4 bytes (LE)][aes_ciphertext]
     /// [aes_nonce: 12 bytes]
-    /// [ess_len: 4 bytes][encrypted_shared_secret]
+    /// [ess_len: 4 bytes (LE)][encrypted_shared_secret]
     /// [platform_nonce: 12 bytes]
     /// ```
     pub fn to_bytes(&self) -> Vec<u8> {
@@ -200,6 +205,9 @@ impl PersistentEncryption {
     }
 
     /// Deserialize from a byte slice.
+    ///
+    /// See [`to_bytes`](Self::to_bytes) for the wire format. All length
+    /// fields and the key version are decoded as little-endian.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary
- Add `# Wire format` doc sections to `to_bytes` and `from_bytes` on both hybrid (`primitives/crypto/encryption/hybrid/encryption.rs`) and persistent (`primitives/crypto/encryption/persistent/encryption.rs`) encrypted-message types.
- Documents the existing `.to_le_bytes()` choice as canonical little-endian wire format so ciphertexts remain portable between little-endian and big-endian hosts (MIPS, s390x, PowerPC).
- Persistent doc block additionally calls out that the `key_version` field is also LE — not just the length fields.
- `from_bytes` docs use rustdoc intra-doc links (`[to_bytes](Self::to_bytes)`) rather than duplicating the format block.

No behavior change. `.to_le_bytes()` is already endian-independent by definition; this is a pure documentation fix addressing the audit's arch-assumption finding.

## Test plan
- [x] `just fmt` / `just clippy` (all-targets, all-features, `-D warnings`) — clean
- [x] `just test-mod "primitives::crypto::encryption::hybrid"` — 22 passed
- [x] `just test-mod "primitives::crypto::encryption::persistent"` — 56 passed
- [x] `just arch-check` — passes
- [x] `cargo doc --no-deps -p octarine` — no new warnings on `to_bytes`/`from_bytes`/wire-format
- Existing `test_to_bytes_from_bytes_large_data` round-trip test continues to pass, confirming the encoding matches the newly-documented contract.

Closes #197