### PR TITLE
chore(pii-scanner): wire routing-number detection through scan_financial

### DIFF
--- a/crates/octarine/src/identifiers/builder/financial.rs
+++ b/crates/octarine/src/identifiers/builder/financial.rs
@@ -268,6 +268,22 @@ impl FinancialBuilder {
         self.inner.detect_bank_accounts_in_text(text)
     }
 
+    /// Detect all routing numbers in text with ABA checksum validation
+    ///
+    /// Emits `pci_data_found` because routing numbers are financial PII
+    /// subject to PCI-DSS handling requirements.
+    #[must_use]
+    pub fn detect_routing_numbers_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let matches = self.inner.detect_routing_numbers_in_text(text);
+
+        if self.emit_events && !matches.is_empty() {
+            increment_by(metric_names::detected(), matches.len() as u64);
+            increment_by(metric_names::pci_data_found(), matches.len() as u64);
+        }
+
+        matches
+    }
+
     /// Detect all IBANs in text with MOD-97 checksum validation
     ///
     /// Emits `pci_data_found` because IBAN is regulated financial PII
@@ -669,6 +685,18 @@ mod tests {
         assert_eq!(matches.len(), 1);
         let first = matches.first().expect("one IBAN match expected");
         assert_eq!(first.identifier_type, IdentifierType::Iban);
+    }
+
+    #[test]
+    fn test_detect_routing_numbers_in_text() {
+        let builder = FinancialBuilder::silent();
+        let matches = builder.detect_routing_numbers_in_text("ABA routing: 021000021");
+        assert!(!matches.is_empty());
+        let first = matches.first().expect("one routing match expected");
+        assert_eq!(first.identifier_type, IdentifierType::RoutingNumber);
+
+        let none = builder.detect_routing_numbers_in_text("no routing number here");
+        assert!(none.is_empty());
     }
 
     #[test]

--- a/crates/octarine/src/identifiers/shortcuts.rs
+++ b/crates/octarine/src/identifiers/shortcuts.rs
@@ -278,6 +278,12 @@ pub fn is_routing_number(value: &str) -> bool {
     FinancialBuilder::new().is_routing_number(value)
 }
 
+/// Detect all routing numbers in text with ABA checksum validation
+#[must_use]
+pub fn detect_routing_numbers(text: &str) -> Vec<IdentifierMatch> {
+    FinancialBuilder::new().detect_routing_numbers_in_text(text)
+}
+
 /// Validate a routing number
 pub fn validate_routing_number(routing: &str) -> Result<(), Problem> {
     FinancialBuilder::new().validate_routing_number(routing)
@@ -1173,6 +1179,10 @@ mod tests {
         assert!(!is_routing_number("000000000"));
         assert!(validate_routing_number("021000021").is_ok());
         assert!(validate_routing_number("invalid").is_err());
+
+        let matches = detect_routing_numbers("ABA routing: 021000021");
+        assert!(!matches.is_empty());
+        assert!(detect_routing_numbers("no routing here").is_empty());
     }
 
     #[test]

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -47,6 +47,9 @@ pub(super) fn scan_financial(text: &str, pii_types: &mut Vec<PiiType>) {
         if !financial.detect_bank_accounts_in_text(text).is_empty() {
             pii_types.push(PiiType::BankAccount);
         }
+        if !financial.detect_routing_numbers_in_text(text).is_empty() {
+            pii_types.push(PiiType::RoutingNumber);
+        }
         if !financial.detect_payment_tokens_in_text(text).is_empty() {
             pii_types.push(PiiType::PaymentToken);
         }

--- a/crates/octarine/src/observe/pii/scanner/mod.rs
+++ b/crates/octarine/src/observe/pii/scanner/mod.rs
@@ -225,6 +225,17 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_for_pii_routing_number() {
+        let text = "ABA routing: 021000021"; // Valid ABA checksum
+        let types = scan_for_pii(text);
+        assert!(
+            types.contains(&PiiType::RoutingNumber),
+            "Should detect routing number, got {:?}",
+            types
+        );
+    }
+
+    #[test]
     fn test_scan_for_pii_email() {
         let text = "Contact: user@example.com";
         let types = scan_for_pii(text);

--- a/crates/octarine/src/primitives/identifiers/financial/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/builder.rs
@@ -140,6 +140,12 @@ impl FinancialIdentifierBuilder {
         detection::detect_bank_accounts_in_text(text)
     }
 
+    /// Detect all routing numbers in text with ABA checksum validation
+    #[must_use]
+    pub fn detect_routing_numbers_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::detect_routing_numbers_in_text(text)
+    }
+
     /// Detect all IBANs in text with MOD-97 checksum validation
     #[must_use]
     pub fn detect_ibans_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
@@ -606,6 +612,21 @@ mod tests {
                 .iter()
                 .all(|m| m.identifier_type == IdentifierType::Iban)
         );
+    }
+
+    #[test]
+    fn test_detect_routing_numbers_in_text() {
+        let builder = FinancialIdentifierBuilder::new();
+        let matches = builder.detect_routing_numbers_in_text("ABA routing: 021000021");
+        assert!(!matches.is_empty());
+        assert!(
+            matches
+                .iter()
+                .all(|m| m.identifier_type == IdentifierType::RoutingNumber)
+        );
+
+        let none = builder.detect_routing_numbers_in_text("no routing number here");
+        assert!(none.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `detect_routing_numbers_in_text` to the primitive `FinancialIdentifierBuilder`, Layer 3 `FinancialBuilder` (with `detected` + `pci_data_found` metrics matching the IBAN pattern), and a public `detect_routing_numbers` shortcut.
- Wires the new method into `observe::pii::scanner::scan_financial`, so `PiiType::RoutingNumber` is emitted whenever scanned text contains a valid ABA routing number.
- Closes a silent-miss audit finding: the variant existed and was classified `is_pci_protected()`, but no scanner code path pushed it. `is_financial_present` already returned true for routing-only text via `detect_all_financial_in_text`, making the gap user-visible.

## Test plan

- [x] `just test-mod "primitives::identifiers::financial::builder"` — new `test_detect_routing_numbers_in_text` passes (33 tests)
- [x] `just test-mod "identifiers::builder::financial"` — new Layer 3 `test_detect_routing_numbers_in_text` passes (14 tests)
- [x] `just test-mod "identifiers::shortcuts"` — extended `test_routing_number_shortcuts` covers `detect_routing_numbers` (26 tests)
- [x] `just test-mod "observe::pii::scanner"` — new `test_scan_for_pii_routing_number` asserts `PiiType::RoutingNumber` is emitted for `"ABA routing: 021000021"` (15 tests)
- [x] `just preflight` — fmt + clippy + shellcheck + arch-check + 6,378 workspace tests, 0 failed

## Pre-review findings

- 1x missing-test-file (`crates/octarine/src/observe/pii/scanner/domains.rs`) — advisory false positive; scanner convention is inline tests in `scanner/mod.rs`, where this PR adds `test_scan_for_pii_routing_number`.

Closes #164