### PR TITLE
chore(crypto): drop value from SecureEnvBuilder::with_var debug log

### DIFF
--- a/crates/octarine/src/crypto/secrets/env.rs
+++ b/crates/octarine/src/crypto/secrets/env.rs
@@ -133,10 +133,7 @@ impl SecureEnvBuilder {
     pub fn with_var(self, name: impl Into<String>, value: impl Into<String>) -> Self {
         let name = name.into();
         let value = value.into();
-        observe::debug(
-            "crypto.secrets.env",
-            format!("Adding variable: {}={}", name, value),
-        );
+        observe::debug("crypto.secrets.env", format!("Adding variable: {}", name));
         Self {
             inner: self.inner.with_var(name, value),
         }


### PR DESCRIPTION
## Summary

- `SecureEnvBuilder::with_var` logged `name=value` at DEBUG, while the mirror method `with_secret` correctly logged only `name`.
- Because `observe::debug` fans out to every configured writer (console, file, SQLite, Postgres), callers using `with_var` for connection strings, internal hostnames, or sensitive feature flags were leaking those values into durable audit sinks.
- Brings `with_var` in line with `with_secret` — log only the variable name. No API change, no behavior change besides the log payload.

## Test plan

- [x] `just test-mod "crypto::secrets::env"` → 27 passed
- [x] `just test-octarine` → all crate tests pass
- [x] `just clippy` → clean
- [x] `just arch-check` → clean
- [x] Grepped repo for the log string — only two hits, both in `env.rs`; no tests assert on it.

Closes #155