### PR TITLE
docs: replace phantom API paths in example code blocks

### DIFF
--- a/docs/architecture/builder-pattern.md
+++ b/docs/architecture/builder-pattern.md
@@ -150,8 +150,8 @@ security/
 │   └── sanitization/
 │       ├── shortcuts.rs             # Sanitization-only
 │       └── ...
-└── access_control/
-    ├── shortcuts.rs                  # Access control only
+└── paths/
+    ├── shortcuts.rs                  # Path operations only
     └── ...
 ```
 

--- a/docs/module-quality.md
+++ b/docs/module-quality.md
@@ -405,7 +405,7 @@ Check mod.rs for module documentation:
 //! # Examples
 //!
 //! ```ignore
-//! use octarine::security::data::detection::identifiers::network;
+//! use octarine::primitives::identifiers::network;
 //!
 //! // Detect UUID
 //! let result = network::detect_network_identifier("550e8400-...");

--- a/docs/patterns/builder-hierarchy-pattern.md
+++ b/docs/patterns/builder-hierarchy-pattern.md
@@ -325,7 +325,7 @@ security/
 │   ├── mod.rs                 # SecurityBuilder facade
 │   ├── data.rs                # Re-exports from security/data/builder/
 │   ├── data_shortcuts.rs
-│   ├── access_control.rs      # Re-exports from security/access_control/builder/
+│   ├── paths.rs               # Re-exports from security/paths/builder/
 │   └── aggregate.rs
 │
 └── data/

--- a/docs/patterns/cascading-visibility.md
+++ b/docs/patterns/cascading-visibility.md
@@ -264,10 +264,10 @@ let is_safe = security::validate_path("/path");
 ### What's NOT Accessible
 
 ```rust
-// ❌ These FAIL - modules are internal
-use octarine::security::data;                          // ERROR: `data` is private
-use octarine::security::data::detection;               // ERROR
-use octarine::security::data::detection::identifiers;  // ERROR
+// ❌ These FAIL - primitives layer is pub(crate), not importable externally
+use octarine::primitives;                              // ERROR: `primitives` is crate-private
+use octarine::primitives::security::paths;             // ERROR
+use octarine::primitives::identifiers::network;        // ERROR
 ```
 
 ## Implementation Checklist


### PR DESCRIPTION
## Summary

Four documentation files still referenced phantom API paths (`security::data::detection`, `security::data::detection::identifiers[::network]`, and `access_control`) that don't exist in the crate. Readers copying these into real code would hit compile errors; ERROR-block teaching examples lose pedagogical value when the cited paths aren't real-but-private.

Each phantom path is replaced with a real module path from `crates/octarine/src/`, preserving teaching intent:

- `docs/patterns/builder-hierarchy-pattern.md:328` — `access_control.rs` → `paths.rs` (real Layer 3 `security/paths/builder/`)
- `docs/architecture/builder-pattern.md:153` — `access_control/` → `paths/` (real Layer 3 `security/paths/` with `shortcuts.rs`)
- `docs/patterns/cascading-visibility.md:267-270` — three phantom ERROR imports replaced with real `pub(crate)` paths: `octarine::primitives`, `octarine::primitives::security::paths`, `octarine::primitives::identifiers::network`. All three are verified crate-internal, so the ERROR lesson holds against real modules.
- `docs/module-quality.md:408` — docstring `use` line → `octarine::primitives::identifiers::network` (the module the docstring actually describes)

## Acceptance criteria

- [x] `docs/patterns/builder-hierarchy-pattern.md:328` — phantom `access_control.rs` replaced
- [x] `docs/architecture/builder-pattern.md:153` — phantom `access_control/` directory replaced
- [x] `docs/patterns/cascading-visibility.md:268-270` — phantom ERROR imports replaced with real `pub(crate)` paths
- [x] `docs/module-quality.md:408` — docstring import corrected to real path
- [x] `grep -rn "security::data::detection" docs/` → 0 hits
- [x] `grep -rn "access_control" docs/` → 1 hit, see note below

## Note on `access_control` residual

`docs/observe/api-guide.md:114` still contains `"access_control"` — but it's a **string-literal operation name** passed to `observe::fail_permission()`, not a module path. Changing it would be scope creep (and the operation label is legitimate). The issue's grep AC was written against module-path usage; the string literal is expected out-of-scope.

## Test plan

- [x] `grep -rn "security::data::detection" docs/` — 0 hits
- [x] `grep -rn "access_control" docs/` — only `api-guide.md:114` (string literal, expected)
- [x] Verified each replacement path exists in `crates/octarine/src/`:
  - `primitives/security/paths/` (`pub(crate)`)
  - `primitives/identifiers/network/` (`pub(crate)`)
  - `security/paths/` (Layer 3, public) with `shortcuts.rs`, `builder.rs`

No code changes — docs only.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)