### PR TITLE
test(security): cover %VAR% and ^ in escape_shell_arg_windows

### DIFF
--- a/crates/octarine/src/primitives/security/commands/sanitization.rs
+++ b/crates/octarine/src/primitives/security/commands/sanitization.rs
@@ -339,6 +339,29 @@ mod tests {
         assert_eq!(escape_shell_arg_windows("user's"), "\"user's\"");
     }
 
+    #[test]
+    fn test_escape_shell_arg_windows_percent_expansion() {
+        // cmd.exe expands %VAR% even inside double quotes; the current
+        // implementation passes percent characters through unchanged.
+        // Locks in current behavior so any future change to percent
+        // handling is caught on Linux CI.
+        assert_eq!(escape_shell_arg_windows("%PATH%"), "\"%PATH%\"");
+        assert_eq!(escape_shell_arg_windows("%USERNAME%"), "\"%USERNAME%\"");
+        assert_eq!(escape_shell_arg_windows("a%VAR%b"), "\"a%VAR%b\"");
+        assert_eq!(escape_shell_arg_windows("%"), "\"%\"");
+    }
+
+    #[test]
+    fn test_escape_shell_arg_windows_caret_escape() {
+        // ^ is the cmd.exe escape character; inside double quotes cmd.exe
+        // does not interpret it, so the current implementation passes it
+        // through unchanged. Locks in current behavior.
+        assert_eq!(escape_shell_arg_windows("^"), "\"^\"");
+        assert_eq!(escape_shell_arg_windows("a^b"), "\"a^b\"");
+        assert_eq!(escape_shell_arg_windows("^^"), "\"^^\"");
+        assert_eq!(escape_shell_arg_windows("^&calc"), "\"^&calc\"");
+    }
+
     // ------------------------------------------------------------------------
     // Platform-Aware Escaping Tests
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `escape_shell_arg_windows` is not `cfg(windows)`-gated, so existing `test_escape_windows_*` cases already run on Linux CI for plain text, double quotes, backslash, single quotes, empty, and unicode. Coverage was missing, however, for two cmd.exe meta-characters: `%VAR%` (percent expansion) and `^` (escape character).
- Adds two new tests named per the audit's suggested convention:
  - `test_escape_shell_arg_windows_percent_expansion`
  - `test_escape_shell_arg_windows_caret_escape`
- Both tests document the **current** pass-through behavior — they intentionally do not assert that `%` or `^` are escaped. Their purpose is regression detection: if the function ever changes how it handles these characters, the tests will catch it on Linux CI.

## Out of scope (potential follow-up)
The pass-through of `%VAR%` is a real sanitization gap when escaped output is later piped through `cmd /C`. That is a behavioral change and warrants a separate audit issue.

## Test plan
- [x] `just test-mod "primitives::security::commands::sanitization"` — 30 passed (was 28)
- [x] `just preflight` — fmt, clippy, arch-check, full test suite all pass

Closes #198