### PR TITLE
docs(identifiers,crypto,runtime): add doc comments to public APIs

### DIFF
--- a/crates/octarine/src/primitives/data/crypto/pem.rs
+++ b/crates/octarine/src/primitives/data/crypto/pem.rs
@@ -155,6 +155,10 @@ pub fn encode_pem(label: &str, data: &[u8]) -> String {
     pem::encode(&pem_block)
 }
 
+/// Encode data as PEM (no-op stub when `crypto-validation` is disabled).
+///
+/// Returns an empty `String` because the PEM encoder is unavailable without
+/// the feature. Enable `crypto-validation` to perform real encoding.
 #[cfg(not(feature = "crypto-validation"))]
 pub fn encode_pem(_label: &str, _data: &[u8]) -> String {
     String::new()

--- a/crates/octarine/src/primitives/data/crypto/ssh.rs
+++ b/crates/octarine/src/primitives/data/crypto/ssh.rs
@@ -73,6 +73,11 @@ pub fn parse_ssh_public_key(data: &str) -> Result<ParsedSshPublicKey, Problem> {
     })
 }
 
+/// Parse an SSH public key (stub when `crypto-validation` is disabled).
+///
+/// Always returns `Err(Problem::validation(...))` because SSH parsing
+/// requires the `ssh-key` crate gated behind the feature. Enable
+/// `crypto-validation` to use the real parser.
 #[cfg(not(feature = "crypto-validation"))]
 pub fn parse_ssh_public_key(_data: &str) -> Result<ParsedSshPublicKey, Problem> {
     Err(Problem::validation("crypto-validation feature not enabled"))
@@ -119,6 +124,12 @@ pub fn ssh_key_fingerprint(data: &str) -> Result<String, Problem> {
     Ok(public_key.fingerprint(ssh_key::HashAlg::Sha256).to_string())
 }
 
+/// Compute the SHA-256 fingerprint of an SSH public key (stub when
+/// `crypto-validation` is disabled).
+///
+/// Always returns `Err(Problem::validation(...))` because fingerprinting
+/// requires the `ssh-key` crate gated behind the feature. Enable
+/// `crypto-validation` to compute real fingerprints.
 #[cfg(not(feature = "crypto-validation"))]
 pub fn ssh_key_fingerprint(_data: &str) -> Result<String, Problem> {
     Err(Problem::validation("crypto-validation feature not enabled"))

--- a/crates/octarine/src/primitives/data/crypto/x509.rs
+++ b/crates/octarine/src/primitives/data/crypto/x509.rs
@@ -134,11 +134,21 @@ pub fn parse_certificate_der(data: &[u8]) -> Result<ParsedCertificate, Problem> 
     })
 }
 
+/// Parse an X.509 certificate from PEM (stub when `crypto-validation` is disabled).
+///
+/// Always returns `Err(Problem::validation(...))` because certificate
+/// parsing requires the `x509-parser` crate gated behind the feature.
+/// Enable `crypto-validation` to use the real parser.
 #[cfg(not(feature = "crypto-validation"))]
 pub fn parse_certificate_pem(_data: &str) -> Result<ParsedCertificate, Problem> {
     Err(Problem::validation("crypto-validation feature not enabled"))
 }
 
+/// Parse an X.509 certificate from DER bytes (stub when `crypto-validation` is disabled).
+///
+/// Always returns `Err(Problem::validation(...))` because certificate
+/// parsing requires the `x509-parser` crate gated behind the feature.
+/// Enable `crypto-validation` to use the real parser.
 #[cfg(not(feature = "crypto-validation"))]
 pub fn parse_certificate_der(_data: &[u8]) -> Result<ParsedCertificate, Problem> {
     Err(Problem::validation("crypto-validation feature not enabled"))

--- a/crates/octarine/src/primitives/identifiers/common/patterns/biometric.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/biometric.rs
@@ -72,30 +72,37 @@ pub static BIOMETRIC_TEMPLATE_GENERIC: Lazy<Regex> = Lazy::new(|| {
         .expect("BUG: Invalid regex pattern")
 });
 
+/// Patterns matching labeled fingerprint identifiers (e.g., `fingerprint:`, `fp:`).
 pub fn fingerprints() -> Vec<&'static Regex> {
     vec![&*FINGERPRINT_LABELED]
 }
 
+/// Patterns matching facial recognition data (face encodings and Face ID / Touch ID identifiers).
 pub fn facial() -> Vec<&'static Regex> {
     vec![&*FACE_ENCODING, &*FACE_ID]
 }
 
+/// Patterns matching iris scan data (IrisCode hex sequences and labeled iris templates).
 pub fn iris() -> Vec<&'static Regex> {
     vec![&*IRIS_CODE, &*IRIS_TEMPLATE]
 }
 
+/// Patterns matching labeled voice print identifiers (`voiceprint:`, `voice_id:`, `speaker_id:`).
 pub fn voice() -> Vec<&'static Regex> {
     vec![&*VOICE_PRINT]
 }
 
+/// Patterns matching DNA data (raw ATCG nucleotide sequences and STR marker labels).
 pub fn dna() -> Vec<&'static Regex> {
     vec![&*DNA_SEQUENCE, &*DNA_STR_MARKER]
 }
 
+/// Patterns matching biometric template encodings (ISO/IEC 19794 FMR/FIR/FTR/IIR and generic).
 pub fn templates() -> Vec<&'static Regex> {
     vec![&*BIOMETRIC_TEMPLATE_ISO, &*BIOMETRIC_TEMPLATE_GENERIC]
 }
 
+/// All biometric patterns from this module (fingerprints, facial, iris, voice, DNA, templates).
 pub fn all() -> Vec<&'static Regex> {
     vec![
         &*FINGERPRINT_LABELED,

--- a/crates/octarine/src/primitives/identifiers/common/patterns/location.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/location.rs
@@ -100,6 +100,7 @@ pub static UK_POSTCODE: Lazy<Regex> = Lazy::new(|| {
 pub static CANADA_POSTAL: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\b[A-Z]\d[A-Z]\s*\d[A-Z]\d\b").expect("BUG: Invalid regex pattern"));
 
+/// Patterns matching GPS coordinates (decimal degrees, DMS, and labeled latitude/longitude).
 pub fn coordinates() -> Vec<&'static Regex> {
     vec![
         &*DECIMAL_DEGREES,
@@ -109,14 +110,19 @@ pub fn coordinates() -> Vec<&'static Regex> {
     ]
 }
 
+/// Patterns matching physical addresses (US street addresses, PO boxes, apartment/suite numbers).
 pub fn addresses() -> Vec<&'static Regex> {
     vec![&*US_STREET_ADDRESS, &*PO_BOX, &*APT_SUITE]
 }
 
+/// Patterns matching postal codes (US ZIP and ZIP+4, UK postcode, Canadian postal code).
+///
+/// ZIP+4 is matched first so the more specific pattern wins over plain US ZIP.
 pub fn postal_codes() -> Vec<&'static Regex> {
     vec![&*US_ZIP_PLUS4, &*US_ZIP, &*UK_POSTCODE, &*CANADA_POSTAL]
 }
 
+/// All location patterns from this module (coordinates, addresses, postal codes).
 pub fn all() -> Vec<&'static Regex> {
     let mut patterns = Vec::new();
     patterns.extend(coordinates());

--- a/crates/octarine/src/primitives/identifiers/common/patterns/medical.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/medical.rs
@@ -105,30 +105,39 @@ pub static DEA_UNLABELED: Lazy<Regex> =
 pub static DEA_EXACT: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[A-Za-z]{2}\d{7}$").expect("BUG: Invalid regex pattern"));
 
+/// Patterns matching DEA (Drug Enforcement Administration) registration numbers,
+/// both labeled (`DEA: AB1234567`) and unlabeled (raw `AB1234567`).
 pub fn dea_numbers() -> Vec<&'static Regex> {
     vec![&*DEA_LABELED, &*DEA_UNLABELED]
 }
 
+/// Patterns matching labeled Medical Record Numbers (`MRN:`, `Patient ID:`, `Medical Record #`).
 pub fn mrn() -> Vec<&'static Regex> {
     vec![&*MRN_LABELED]
 }
 
+/// Patterns matching health insurance identifiers (Medicare format and labeled policy/group numbers).
 pub fn insurance() -> Vec<&'static Regex> {
     vec![&*INSURANCE_MEDICARE, &*INSURANCE_POLICY, &*INSURANCE_GROUP]
 }
 
+/// Patterns matching labeled prescription numbers (`RX#`, `Prescription Number:`, `rx`).
 pub fn prescriptions() -> Vec<&'static Regex> {
     vec![&*PRESCRIPTION]
 }
 
+/// Patterns matching healthcare provider identifiers (currently NPI / National Provider Identifier).
 pub fn provider_ids() -> Vec<&'static Regex> {
     vec![&*NPI]
 }
 
+/// Patterns matching standard medical coding systems (ICD-10 diagnosis codes and CPT procedure codes).
 pub fn medical_codes() -> Vec<&'static Regex> {
     vec![&*ICD10, &*CPT]
 }
 
+/// All medical patterns from this module — MRN, insurance (Medicare/policy/group),
+/// prescription, NPI, ICD-10, CPT, and DEA (labeled + unlabeled).
 pub fn all() -> Vec<&'static Regex> {
     vec![
         &*MRN_LABELED,

--- a/crates/octarine/src/primitives/identifiers/common/patterns/network.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/network.rs
@@ -33,6 +33,7 @@ pub mod email {
             .expect("BUG: Invalid regex pattern")
     });
 
+    /// All email patterns in this submodule — standard `user@domain.tld` and IP-literal `user@[1.2.3.4]`.
     pub fn all() -> Vec<&'static Regex> {
         vec![&*STANDARD, &*IP_LITERAL]
     }
@@ -137,6 +138,9 @@ pub mod phone {
             .expect("BUG: Invalid regex pattern")
     });
 
+    /// All phone patterns in this submodule — US formats (with country code,
+    /// parens, or plain) plus country-specific patterns for UK, DE, FR, AU,
+    /// IN, JP, BR, CN, and a generic E.164 text-scanning fallback.
     pub fn all() -> Vec<&'static Regex> {
         vec![
             &*WITH_COUNTRY_CODE,
@@ -672,22 +676,30 @@ pub static SSH_PRIVATE_KEY_HEADER: Lazy<Regex> = Lazy::new(|| {
         .expect("BUG: Invalid regex pattern")
 });
 
+/// Patterns matching UUIDs — version 4, version 5, and any RFC 4122 version (1-5).
 pub fn uuids() -> Vec<&'static Regex> {
     vec![&*UUID_V4, &*UUID_V5, &*UUID_ANY]
 }
 
+/// Patterns matching MAC addresses in colon, hyphen, and Cisco dot-separated formats.
 pub fn macs() -> Vec<&'static Regex> {
     vec![&*MAC_COLON, &*MAC_HYPHEN, &*MAC_DOT]
 }
 
+/// Patterns matching IP addresses — IPv4, IPv6, and labeled IPv4 (`IP: 1.2.3.4`).
 pub fn ips() -> Vec<&'static Regex> {
     vec![&*IPV4, &*IPV6, &*IPV4_LABELED]
 }
 
+/// Patterns matching URLs — HTTP/HTTPS, FTP, WebSocket (wss/ws), and a generic protocol fallback.
 pub fn urls() -> Vec<&'static Regex> {
     vec![&*URL_HTTP, &*URL_FTP, &*URL_WSS, &*URL_WS, &*URL_GENERIC]
 }
 
+/// Patterns matching API keys, tokens, and connection-string secrets across
+/// major cloud, SaaS, and developer platforms (AWS, GCP, Azure, GitHub,
+/// GitLab, Stripe, Slack, OpenAI, Vault, and many others — see the
+/// individual `API_KEY_*` constants for the full list).
 pub fn api_keys() -> Vec<&'static Regex> {
     vec![
         &*API_KEY_GENERIC,
@@ -734,6 +746,8 @@ pub fn api_keys() -> Vec<&'static Regex> {
     ]
 }
 
+/// Patterns matching SSH key material — public keys (rsa/ed25519/ecdsa/dss),
+/// MD5 and SHA-256 fingerprints, and private-key PEM headers.
 pub fn ssh_keys() -> Vec<&'static Regex> {
     vec![
         &*SSH_PUBLIC_KEY,
@@ -743,6 +757,10 @@ pub fn ssh_keys() -> Vec<&'static Regex> {
     ]
 }
 
+/// All network patterns from this module — UUIDs, MAC addresses, IPs, URLs
+/// (incl. URLs with embedded credentials), international phone numbers, JWTs,
+/// API keys for every supported platform, OAuth/bearer tokens, database
+/// connection strings, and SSH key material.
 pub fn all() -> Vec<&'static Regex> {
     vec![
         &*UUID_V4,

--- a/crates/octarine/src/primitives/identifiers/common/patterns/vehicle.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/vehicle.rs
@@ -34,6 +34,8 @@ pub static LICENSE_PLATE: Lazy<Regex> = Lazy::new(|| {
         .expect("BUG: Invalid regex pattern")
 });
 
+/// All vehicle patterns from this module — labeled, explicit, and standalone
+/// 17-character VINs, plus US license plate formats.
 pub fn all() -> Vec<&'static Regex> {
     vec![
         &*VIN_LABELED,

--- a/crates/octarine/src/primitives/identifiers/medical/sanitization/text.rs
+++ b/crates/octarine/src/primitives/identifiers/medical/sanitization/text.rs
@@ -355,6 +355,22 @@ pub fn redact_dea_numbers_in_text(text: &str, policy: TextRedactionPolicy) -> Co
     Cow::Owned(result)
 }
 
+/// Redact every medical identifier type in `text` using the given policy.
+///
+/// Composes all per-identifier text redactors (MRN, insurance, prescription,
+/// NPI/provider, ICD-10/CPT codes, DEA numbers) in a single pass so callers
+/// get a fully sanitized `String` without managing the order themselves.
+///
+/// # Arguments
+///
+/// * `text` - Text to scan for any medical identifiers
+/// * `policy` - Text redaction policy applied uniformly to every identifier type
+///
+/// # Returns
+///
+/// Owned `String` with all detected medical identifiers replaced according to
+/// `policy`. The result is always owned because at least one underlying
+/// redactor may have transformed the input.
 pub fn redact_all_medical_in_text(text: &str, policy: TextRedactionPolicy) -> String {
     let result = redact_mrn_in_text(text, policy);
     let result = redact_insurance_in_text(&result, policy);

--- a/crates/octarine/src/runtime/database/pool.rs
+++ b/crates/octarine/src/runtime/database/pool.rs
@@ -349,7 +349,12 @@ fn build_connect_options(config: &PoolConfig) -> Result<PgConnectOptions, PoolEr
     Ok(options)
 }
 
-// Stub implementation when postgres feature is not enabled
+/// Stub `ManagedPool` for builds without the `postgres` feature.
+///
+/// Provides the same surface as the real `ManagedPool` so downstream code
+/// can compile, but every constructor and method returns
+/// `Err(PoolError::Config(...))`. Enable the `postgres` feature to use the
+/// fully-functional pool documented above.
 #[cfg(not(feature = "postgres"))]
 pub struct ManagedPool {
     _private: (),


### PR DESCRIPTION
## Summary

Add `///` doc comments to public APIs flagged by `audit-docs` /
`check-docs-missing-api`:

- **`primitives/identifiers/common/patterns/{biometric,location,medical,network,vehicle}.rs`** —
  describe each `Vec<&'static Regex>` accessor's pattern set (e.g.,
  `coordinates()` returns GPS coordinate patterns; `api_keys()` returns
  the cloud/SaaS secret patterns).
- **`primitives/data/crypto/{pem,ssh,x509}.rs`** — document the
  `#[cfg(not(feature = "crypto-validation"))]` stubs of `encode_pem`,
  `parse_ssh_public_key`, `ssh_key_fingerprint`, `parse_certificate_pem`,
  and `parse_certificate_der`. The active feature-gated counterparts
  were already documented; only the stubs were missing docs. Each stub
  doc explains the no-op return (empty `String` or
  `Err(Problem::validation(...))`) and points at the feature flag.
- **`runtime/database/pool.rs`** — type-level doc on the
  `#[cfg(not(feature = "postgres"))]` `ManagedPool` stub mirroring the
  documented postgres-gated version above it.
- **`primitives/identifiers/medical/sanitization/text.rs`** — doc for
  `redact_all_medical_in_text`, the composition helper that runs every
  per-identifier text redactor in sequence.

Documentation-only change — no behavior, no new tests, no API surface
changes.

## Test plan

- `just fmt-check` — passes
- `just clippy` — passes (`-D warnings`, all-features)
- `just test-octarine` — passes (6380+ tests, 0 failures)

## Pre-review findings

- 5x `missing-test-file` — flagged on the pattern files
  (`{biometric,location,medical,network,vehicle}.rs`). False positive:
  these files contain only static `Lazy<Regex>` constants and trivial
  `vec![&*X]` accessors. Coverage lives in the Layer 3 wrappers
  (`data/`, `security/`, `identifiers/`) and the PII scanner suites that
  consume these patterns.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)