### PR TITLE
docs(architecture): standardize on three-layer terminology

### DIFF
--- a/.claude/agents/audit-octarine-layers/audit-octarine-layers.md
+++ b/.claude/agents/audit-octarine-layers/audit-octarine-layers.md
@@ -44,7 +44,7 @@ Octarine has a strict three-layer architecture:
 | Layer | Path prefix (under `crates/octarine/src/`) | Visibility    | Can Import                                       |
 | ----- | ------------------------------------------ | ------------- | ------------------------------------------------ |
 | L1    | `primitives/`                              | `pub(crate)`  | External crates, `crate::observe::Problem` ONLY  |
-| L1b   | `testing/`                                 | `pub` + gated | Everything                                       |
+| L1    | `testing/`                                 | `pub` + gated | Everything                                       |
 | L2    | `observe/`                                 | `pub`         | `primitives/` only                               |
 | L3    | `identifiers/`, `data/`, `runtime/`, `crypto/`, `security/`, `auth/`, `http/`, `io/` | `pub` | `primitives/` + `observe/` |
 

--- a/.claude/skills/octarine-architecture/SKILL.md
+++ b/.claude/skills/octarine-architecture/SKILL.md
@@ -14,7 +14,7 @@ code goes, diagnosing a visibility issue, or reviewing naming.
 | Layer | Path | Visibility | Can Import | CANNOT Import |
 |-------|------|-----------|------------|---------------|
 | **L1** | `primitives/` | `pub(crate)` | External crates, `Problem` type only | `observe::*`, any L3 module |
-| **L1b** | `testing/` | `pub` + `#[cfg(feature)]` | Everything | — |
+| **L1** | `testing/` | `pub` + `#[cfg(feature)]` | Everything | — |
 | **L2** | `observe/` | `pub` | `primitives/` | Any L3 module, `testing/` |
 | **L3** | `identifiers/`, `data/`, `runtime/`, `crypto/`, `security/` | `pub` | `primitives/` + `observe/` | `testing/` (except `#[cfg(test)]`) |
 
@@ -113,6 +113,6 @@ pub fn is_email(value: &str) -> bool {
 
 ## When NOT to Use
 
-- Working exclusively in the `testing/` module (it has its own visibility rules as L1b)
+- Working exclusively in the `testing/` module (it has its own visibility rules as a Layer 1 consumer)
 - Working on code outside `crates/octarine/src/`
 - Pure documentation changes

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -4,7 +4,7 @@ This section covers the system design, patterns, and architectural decisions for
 
 ## Quick Links
 
-- **Layer Architecture**: [`layer-architecture.md`](./layer-architecture.md) - **START HERE** - Four-layer dependency rules
+- **Layer Architecture**: [`layer-architecture.md`](./layer-architecture.md) - **START HERE** - Three-layer dependency rules
 - **Module Patterns**: [`module-patterns.md`](./module-patterns.md) - Three-layer pattern and builder pattern
 - **System Design**: [`system-design.md`](./system-design.md) - Overall library architecture
 - **Testing Patterns**: [`testing-patterns.md`](./testing-patterns.md) - Shared test infrastructure

--- a/docs/architecture/layer-architecture.md
+++ b/docs/architecture/layer-architecture.md
@@ -4,7 +4,7 @@ This document defines the strict layer architecture that governs module dependen
 
 ## Overview
 
-octarine uses a **four-layer architecture** where each layer can only depend on layers below it:
+octarine uses a **three-layer architecture** where each layer can only depend on layers below it:
 
 ```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -81,9 +81,9 @@ octarine uses a **four-layer architecture** where each layer can only depend on 
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
-## The Four Layers Explained
+## The Three Layers Explained
 
-### Layer 1a: primitives/ (Internal Foundation)
+### Layer 1: primitives/ (Internal Foundation)
 
 **Visibility**: `pub(crate)` - Only accessible within octarine
 
@@ -110,7 +110,9 @@ use crate::security::*;       // No Layer 3 dependencies
 use crate::testing::*;        // No testing dependency
 ```
 
-### Layer 1b: testing/ (Shared Test Infrastructure)
+Layer 1 also includes shared test infrastructure, which is feature-gated and acts as a consumer of all layers.
+
+#### testing/ (Shared Test Infrastructure)
 
 **Visibility**: `pub` with `#[cfg(feature = "testing")]`
 


### PR DESCRIPTION
## Summary

Aligns `docs/architecture/layer-architecture.md` and `docs/architecture/index.md` with the canonical "three-layer" phrasing used in `CLAUDE.md` and `README.md`. Demotes the `testing/` subsection from a pseudo-layer (`Layer 1b`) to an h4 nested under `Layer 1: primitives/` — preserves all content while dropping the 1a/1b numbering.

The existing ASCII diagram already depicted three layers with `primitives/` and `testing/` inside a shared "Layer 1: Foundation" box, so no diagram edits were needed. The complementary "The Critical Rule: Testing is a Consumer" section is also left untouched.

Scope also covers two `.claude/` tooling files (`octarine-architecture` skill and `audit-octarine-layers` agent) that carried the same `L1b` notation in their architecture tables. Per user direction during planning — ticket officially covered only the two docs files, but leaving tooling inconsistent would defeat the standardization.

## Files changed

- `docs/architecture/layer-architecture.md` — overview sentence, "The Four Layers Explained" → "The Three Layers Explained", Layer 1a/1b headings reworked
- `docs/architecture/index.md` — quick-link description
- `.claude/skills/octarine-architecture/SKILL.md` — architecture table row label + one prose reference
- `.claude/agents/audit-octarine-layers/audit-octarine-layers.md` — architecture table row label

## Test plan

- [x] `rg -i "four[- ]?layer"` in `docs/` and scoped `.claude/` dirs → no matches
- [x] `rg "Layer 1[ab]\b|\bL1[ab]\b"` in `docs/` and scoped `.claude/` dirs → no matches
- [x] `just preflight` → exit 0 (241 doctests ok, 0 failed)
- [x] Visual review of `## The Three Layers Explained` section — h3 `Layer 1: primitives/` with `testing/` as nested h4 subsection, followed by sibling h3 `Layer 2` / `Layer 3`

## Out of scope

- `crates/octarine/src/primitives/data/paths/filename/mod.rs:8` — "four layers" refers to the internal structure of the filename domain (FilenameBuilder / detection / validation / sanitization / construction), not the overall crate architecture. Left unchanged.
- `docs/runtime/README.md:25` "two-layer architecture" — correct for runtime's internal L1+L3 scope.
- `CHANGELOG.md:162` — historical release note, preserved as-is.

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)