### PR TITLE
chore(architecture): document Layer 3 module archetypes and close structural gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,12 @@ See `docs/observe/` for detailed guides.
 - `builder.rs` - Builder patterns
 - `functions.rs` or `shortcuts.rs` - Convenience functions
 
+Layer 3 submodules follow one of three archetypes — see
+[Layer 3 Module Archetypes](docs/architecture/layer-architecture.md#layer-3-module-archetypes)
+for when to use the pure-function triple (`builder + types + shortcuts`),
+the stateful-service pattern (`manager + store + pool`), or a flat utility
+layout.
+
 ### Size Limits
 
 - Preferred: \<300 LOC per file

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -1,4 +1,4 @@
-//! Type definitions for identifier detection
+//! Core identifier type definitions
 //!
 //! Pure type definitions with no dependencies on other rust-core modules.
 
@@ -129,59 +129,6 @@ impl DetectionConfidence {
     }
 }
 
-/// Phone number region enumeration
-///
-/// Detected based on country code prefix in E.164 format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PhoneRegion {
-    /// North America (+1)
-    NorthAmerica,
-    /// United Kingdom (+44)
-    Uk,
-    /// Germany (+49)
-    Germany,
-    /// France (+33)
-    France,
-    /// Spain (+34)
-    Spain,
-    /// Italy (+39)
-    Italy,
-    /// Australia (+61)
-    Australia,
-    /// Japan (+81)
-    Japan,
-    /// China (+86)
-    China,
-    /// India (+91)
-    India,
-    /// Brazil (+55)
-    Brazil,
-    /// Russia (+7)
-    Russia,
-    /// Unknown or unrecognized region
-    Unknown,
-}
-
-impl std::fmt::Display for PhoneRegion {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NorthAmerica => write!(f, "North America (+1)"),
-            Self::Uk => write!(f, "United Kingdom (+44)"),
-            Self::Germany => write!(f, "Germany (+49)"),
-            Self::France => write!(f, "France (+33)"),
-            Self::Spain => write!(f, "Spain (+34)"),
-            Self::Italy => write!(f, "Italy (+39)"),
-            Self::Australia => write!(f, "Australia (+61)"),
-            Self::Japan => write!(f, "Japan (+81)"),
-            Self::China => write!(f, "China (+86)"),
-            Self::India => write!(f, "India (+91)"),
-            Self::Brazil => write!(f, "Brazil (+55)"),
-            Self::Russia => write!(f, "Russia (+7)"),
-            Self::Unknown => write!(f, "Unknown region"),
-        }
-    }
-}
-
 /// Result of finding an identifier pattern in text
 #[derive(Debug, Clone)]
 pub struct IdentifierMatch {
@@ -221,53 +168,6 @@ impl DetectionResult {
             identifier_type,
             confidence,
             is_sensitive,
-        }
-    }
-}
-
-/// Credit card brand/type enumeration
-///
-/// Detected based on BIN (Bank Identification Number) patterns.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CreditCardType {
-    /// Visa cards - starts with 4, 13/16/19 digits
-    Visa,
-    /// Mastercard - starts with 51-55 or 2221-2720, 16 digits
-    Mastercard,
-    /// American Express - starts with 34 or 37, 15 digits
-    AmericanExpress,
-    /// Discover - starts with 6011, 644-649, or 65, 16 digits
-    Discover,
-    /// JCB (Japan Credit Bureau) - starts with 3528-3589, 16 digits
-    Jcb,
-    /// Diners Club - starts with 300-305, 36, or 38, 14 digits
-    DinersClub,
-    /// UnionPay - starts with 62 or 81, 16-19 digits
-    UnionPay,
-    /// Maestro - starts with 5018/5020/5038/5893/6304/6759/6761-6763, 12-19 digits
-    Maestro,
-    /// Verve (Nigerian) - starts with 506099-506198 or 650002-650027, 16-19 digits
-    Verve,
-    /// RuPay (India) - starts with 60/65/81/82/508, 16 digits
-    RuPay,
-    /// Unknown or unsupported card type
-    Unknown,
-}
-
-impl std::fmt::Display for CreditCardType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Visa => write!(f, "Visa"),
-            Self::Mastercard => write!(f, "Mastercard"),
-            Self::AmericanExpress => write!(f, "American Express"),
-            Self::Discover => write!(f, "Discover"),
-            Self::Jcb => write!(f, "JCB"),
-            Self::DinersClub => write!(f, "Diners Club"),
-            Self::UnionPay => write!(f, "UnionPay"),
-            Self::Maestro => write!(f, "Maestro"),
-            Self::Verve => write!(f, "Verve"),
-            Self::RuPay => write!(f, "RuPay"),
-            Self::Unknown => write!(f, "Unknown"),
         }
     }
 }
@@ -314,113 +214,6 @@ impl IdentifierMatch {
     /// Check if the match is empty
     pub fn is_empty(&self) -> bool {
         self.len() == 0
-    }
-}
-
-// =============================================================================
-// Credential-Specific Types
-// =============================================================================
-
-/// Types of credentials that can be detected
-///
-/// Credentials are "something you know" (NIST 800-63 Factor 1).
-/// Unlike pattern-based identifiers (SSN, email), credentials are opaque
-/// strings detected by context (labels like "password:", JSON keys, etc.).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum CredentialType {
-    /// Password (text-based secret)
-    Password,
-    /// PIN (numeric secret, typically 4-8 digits)
-    Pin,
-    /// Security question answer
-    SecurityAnswer,
-    /// Passphrase (multi-word secret)
-    Passphrase,
-    /// Generic/unknown credential type
-    Generic,
-}
-
-impl CredentialType {
-    /// Returns the credential type name
-    #[must_use]
-    pub const fn name(&self) -> &'static str {
-        match self {
-            Self::Password => "password",
-            Self::Pin => "pin",
-            Self::SecurityAnswer => "security_answer",
-            Self::Passphrase => "passphrase",
-            Self::Generic => "credential",
-        }
-    }
-
-    /// Convert to the corresponding IdentifierType
-    #[must_use]
-    pub const fn to_identifier_type(self) -> IdentifierType {
-        match self {
-            Self::Password => IdentifierType::Password,
-            Self::Pin => IdentifierType::Pin,
-            Self::SecurityAnswer => IdentifierType::SecurityAnswer,
-            Self::Passphrase => IdentifierType::Passphrase,
-            Self::Generic => IdentifierType::Unknown,
-        }
-    }
-}
-
-/// Result of finding a credential pattern in text
-///
-/// Unlike `IdentifierMatch`, credential matches include the label/key
-/// that preceded the credential value (e.g., "password" in "password=secret").
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CredentialMatch {
-    /// Start position of the credential VALUE (not the label)
-    pub start: usize,
-    /// End position of the credential value
-    pub end: usize,
-    /// The matched credential value
-    pub value: String,
-    /// Type of credential detected
-    pub credential_type: CredentialType,
-    /// The label/key that preceded this credential (e.g., "password")
-    pub label: String,
-}
-
-impl CredentialMatch {
-    /// Create a new credential match
-    pub fn new(
-        start: usize,
-        end: usize,
-        value: String,
-        credential_type: CredentialType,
-        label: String,
-    ) -> Self {
-        Self {
-            start,
-            end,
-            value,
-            credential_type,
-            label,
-        }
-    }
-
-    /// Get the length of the matched credential value
-    pub fn len(&self) -> usize {
-        self.end.saturating_sub(self.start)
-    }
-
-    /// Check if the match is empty
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Convert to a generic IdentifierMatch (loses label information)
-    pub fn into_identifier_match(self) -> IdentifierMatch {
-        IdentifierMatch::new(
-            self.start,
-            self.end,
-            self.value,
-            self.credential_type.to_identifier_type(),
-            DetectionConfidence::High,
-        )
     }
 }
 

--- a/crates/octarine/src/primitives/identifiers/types/financial.rs
+++ b/crates/octarine/src/primitives/identifiers/types/financial.rs
@@ -1,0 +1,48 @@
+//! Financial identifier types (credit card brands, etc.)
+
+/// Credit card brand/type enumeration
+///
+/// Detected based on BIN (Bank Identification Number) patterns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreditCardType {
+    /// Visa cards - starts with 4, 13/16/19 digits
+    Visa,
+    /// Mastercard - starts with 51-55 or 2221-2720, 16 digits
+    Mastercard,
+    /// American Express - starts with 34 or 37, 15 digits
+    AmericanExpress,
+    /// Discover - starts with 6011, 644-649, or 65, 16 digits
+    Discover,
+    /// JCB (Japan Credit Bureau) - starts with 3528-3589, 16 digits
+    Jcb,
+    /// Diners Club - starts with 300-305, 36, or 38, 14 digits
+    DinersClub,
+    /// UnionPay - starts with 62 or 81, 16-19 digits
+    UnionPay,
+    /// Maestro - starts with 5018/5020/5038/5893/6304/6759/6761-6763, 12-19 digits
+    Maestro,
+    /// Verve (Nigerian) - starts with 506099-506198 or 650002-650027, 16-19 digits
+    Verve,
+    /// RuPay (India) - starts with 60/65/81/82/508, 16 digits
+    RuPay,
+    /// Unknown or unsupported card type
+    Unknown,
+}
+
+impl std::fmt::Display for CreditCardType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Visa => write!(f, "Visa"),
+            Self::Mastercard => write!(f, "Mastercard"),
+            Self::AmericanExpress => write!(f, "American Express"),
+            Self::Discover => write!(f, "Discover"),
+            Self::Jcb => write!(f, "JCB"),
+            Self::DinersClub => write!(f, "Diners Club"),
+            Self::UnionPay => write!(f, "UnionPay"),
+            Self::Maestro => write!(f, "Maestro"),
+            Self::Verve => write!(f, "Verve"),
+            Self::RuPay => write!(f, "RuPay"),
+            Self::Unknown => write!(f, "Unknown"),
+        }
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/types/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/types/mod.rs
@@ -1,0 +1,13 @@
+//! Type definitions for identifier detection
+//!
+//! Pure type definitions with no dependencies on other rust-core modules.
+//! Split into per-concern files mirroring the Layer 3 `identifiers/types/`
+//! layout.
+
+mod core;
+mod financial;
+mod personal;
+
+pub use core::{DetectionConfidence, DetectionResult, IdentifierMatch, IdentifierType};
+pub use financial::CreditCardType;
+pub use personal::{CredentialMatch, CredentialType, PhoneRegion};

--- a/crates/octarine/src/primitives/identifiers/types/personal.rs
+++ b/crates/octarine/src/primitives/identifiers/types/personal.rs
@@ -1,0 +1,163 @@
+//! Personal identifier types (phone regions, credentials)
+
+use super::core::{DetectionConfidence, IdentifierMatch, IdentifierType};
+
+/// Phone number region enumeration
+///
+/// Detected based on country code prefix in E.164 format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhoneRegion {
+    /// North America (+1)
+    NorthAmerica,
+    /// United Kingdom (+44)
+    Uk,
+    /// Germany (+49)
+    Germany,
+    /// France (+33)
+    France,
+    /// Spain (+34)
+    Spain,
+    /// Italy (+39)
+    Italy,
+    /// Australia (+61)
+    Australia,
+    /// Japan (+81)
+    Japan,
+    /// China (+86)
+    China,
+    /// India (+91)
+    India,
+    /// Brazil (+55)
+    Brazil,
+    /// Russia (+7)
+    Russia,
+    /// Unknown or unrecognized region
+    Unknown,
+}
+
+impl std::fmt::Display for PhoneRegion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NorthAmerica => write!(f, "North America (+1)"),
+            Self::Uk => write!(f, "United Kingdom (+44)"),
+            Self::Germany => write!(f, "Germany (+49)"),
+            Self::France => write!(f, "France (+33)"),
+            Self::Spain => write!(f, "Spain (+34)"),
+            Self::Italy => write!(f, "Italy (+39)"),
+            Self::Australia => write!(f, "Australia (+61)"),
+            Self::Japan => write!(f, "Japan (+81)"),
+            Self::China => write!(f, "China (+86)"),
+            Self::India => write!(f, "India (+91)"),
+            Self::Brazil => write!(f, "Brazil (+55)"),
+            Self::Russia => write!(f, "Russia (+7)"),
+            Self::Unknown => write!(f, "Unknown region"),
+        }
+    }
+}
+
+// =============================================================================
+// Credential-Specific Types
+// =============================================================================
+
+/// Types of credentials that can be detected
+///
+/// Credentials are "something you know" (NIST 800-63 Factor 1).
+/// Unlike pattern-based identifiers (SSN, email), credentials are opaque
+/// strings detected by context (labels like "password:", JSON keys, etc.).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CredentialType {
+    /// Password (text-based secret)
+    Password,
+    /// PIN (numeric secret, typically 4-8 digits)
+    Pin,
+    /// Security question answer
+    SecurityAnswer,
+    /// Passphrase (multi-word secret)
+    Passphrase,
+    /// Generic/unknown credential type
+    Generic,
+}
+
+impl CredentialType {
+    /// Returns the credential type name
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::Password => "password",
+            Self::Pin => "pin",
+            Self::SecurityAnswer => "security_answer",
+            Self::Passphrase => "passphrase",
+            Self::Generic => "credential",
+        }
+    }
+
+    /// Convert to the corresponding IdentifierType
+    #[must_use]
+    pub const fn to_identifier_type(self) -> IdentifierType {
+        match self {
+            Self::Password => IdentifierType::Password,
+            Self::Pin => IdentifierType::Pin,
+            Self::SecurityAnswer => IdentifierType::SecurityAnswer,
+            Self::Passphrase => IdentifierType::Passphrase,
+            Self::Generic => IdentifierType::Unknown,
+        }
+    }
+}
+
+/// Result of finding a credential pattern in text
+///
+/// Unlike `IdentifierMatch`, credential matches include the label/key
+/// that preceded the credential value (e.g., "password" in "password=secret").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialMatch {
+    /// Start position of the credential VALUE (not the label)
+    pub start: usize,
+    /// End position of the credential value
+    pub end: usize,
+    /// The matched credential value
+    pub value: String,
+    /// Type of credential detected
+    pub credential_type: CredentialType,
+    /// The label/key that preceded this credential (e.g., "password")
+    pub label: String,
+}
+
+impl CredentialMatch {
+    /// Create a new credential match
+    pub fn new(
+        start: usize,
+        end: usize,
+        value: String,
+        credential_type: CredentialType,
+        label: String,
+    ) -> Self {
+        Self {
+            start,
+            end,
+            value,
+            credential_type,
+            label,
+        }
+    }
+
+    /// Get the length of the matched credential value
+    pub fn len(&self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Check if the match is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Convert to a generic IdentifierMatch (loses label information)
+    pub fn into_identifier_match(self) -> IdentifierMatch {
+        IdentifierMatch::new(
+            self.start,
+            self.end,
+            self.value,
+            self.credential_type.to_identifier_type(),
+            DetectionConfidence::High,
+        )
+    }
+}

--- a/crates/octarine/src/security/queries/mod.rs
+++ b/crates/octarine/src/security/queries/mod.rs
@@ -70,11 +70,8 @@
 
 mod builder;
 mod shortcuts;
+mod types;
 
 pub use builder::QueryBuilder;
 pub use shortcuts::*;
-
-// Re-export key types from primitives
-pub use crate::primitives::security::queries::{
-    GraphqlAnalysis, GraphqlConfig, GraphqlSchema, QueryThreat, QueryType,
-};
+pub use types::{GraphqlAnalysis, GraphqlConfig, GraphqlSchema, QueryThreat, QueryType};

--- a/crates/octarine/src/security/queries/types.rs
+++ b/crates/octarine/src/security/queries/types.rs
@@ -1,0 +1,10 @@
+//! Query security types re-exported from primitives
+//!
+//! Follows the same pattern as `security::formats::types` — lifts the
+//! `pub(crate)` primitives types into this crate's public API without a
+//! wrapper layer. Use this module as the canonical import path for query
+//! security types from downstream code.
+
+pub use crate::primitives::security::queries::{
+    GraphqlAnalysis, GraphqlConfig, GraphqlSchema, QueryThreat, QueryType,
+};

--- a/docs/architecture/layer-architecture.md
+++ b/docs/architecture/layer-architecture.md
@@ -195,6 +195,93 @@ pub fn validate_path(path: &str) -> Result<(), Problem> {
 use crate::testing::*;
 ```
 
+#### Layer 3 Module Archetypes
+
+Layer 3 submodules fall into two architectural archetypes plus a carve-out
+for thin utility modules. The choice depends on whether the module's
+operations are stateless or lifecycle-bound.
+
+##### Archetype A — Pure-function triple (builder + types + shortcuts)
+
+**When to use**: Stateless detection, validation, sanitization, or
+transformation. The operation takes input, consults config, returns a result.
+No persistent state between calls.
+
+**Examples**: `data/*`, `security/{commands,formats,network,paths,queries}`,
+`identifiers/`, `crypto/validation`, `io/formats`, `runtime/async`.
+
+**File layout**:
+
+```text
+module/
+├── mod.rs         # Re-exports only, plus module-level doc and architecture diagram
+├── builder.rs     # XxxBuilder wrapping a primitive builder with observe instrumentation
+├── types.rs       # Wrapper types bridging pub(crate) primitives → pub public API
+└── shortcuts.rs   # Module-level convenience functions that delegate to a default builder
+```
+
+Rationale: `primitives/` is `pub(crate)`, so its types cannot be re-exported
+directly at `pub`. Wrapper types in `types.rs` with bidirectional `From`
+impls (see `security/network/types.rs`) provide a stable public API that can
+evolve independently of the internal primitives.
+
+##### Archetype B — Stateful service (manager + store + optional pool)
+
+**When to use**: Lifecycle-bound resources, session-like state, pooled
+connections, or any module where successive calls share mutable state.
+
+**Examples**: `auth/{session,lockout,mfa,remember,reset}`, `runtime/database`,
+`crypto/secrets`.
+
+**File layout**:
+
+```text
+module/
+├── mod.rs         # Re-exports, doc, architecture diagram
+├── manager.rs     # Public API type that owns the state and exposes operations
+├── store.rs       # Persistence trait + implementations (in-memory, database, etc.)
+└── pool.rs        # Optional: connection pool, resource pool
+```
+
+Rationale: A `Builder` API with `shortcuts` assumes operations are stateless
+and cheap to construct. For a `SessionManager` or connection pool, each
+instance represents a live resource; exposing it through module-level
+shortcuts would either leak a global or force every caller to reconstruct
+state. The `manager` + `store` split keeps persistence pluggable while
+keeping the manager the single public entry point.
+
+##### When neither fits — thin utility modules
+
+Small single-concern modules (one algorithm, one protocol, one driver) MAY
+expose a flat `.rs`-per-concern layout without a builder or shortcuts
+surface. Examples:
+
+- `crypto/auth/hmac` — one algorithm family
+- `auth/csrf`, `auth/password` — one concern each
+- `crypto/keys/{kdf,password,random}` — algorithm variants
+- `runtime/cli/*`, `http/middleware/*`, `http/presets/*` — drivers/presets
+- `io/magic` — file-magic detection
+- `runtime/formats/{json,xml,yaml}` — format adapters
+
+A builder around a single free function adds ceremony without value. If one
+of these modules grows a second orthogonal concern (e.g. detection AND
+validation AND sanitization) it should be migrated to Archetype A.
+
+##### Hybrid modules
+
+If a module has a `builder.rs` but is missing `types.rs` or `shortcuts.rs`
+(e.g. `runtime/config` today), treat it as in-progress toward Archetype A and
+file follow-up work to complete the triple or justify the deviation in the
+module docstring.
+
+##### Quick archetype chooser
+
+| Question                                                  | Archetype                  |
+| --------------------------------------------------------- | -------------------------- |
+| Does every call return a fresh result from inputs alone?  | A — pure-function triple   |
+| Does the module own state that outlives a single call?    | B — stateful service       |
+| Is the module a single algorithm, protocol, or driver?    | Utility (flat `.rs` files) |
+
 ## The Critical Rule: Testing is a Consumer
 
 The `testing` module breaks the normal "down only" rule because it's a **consumer** of the public API, not a **provider** to it:


### PR DESCRIPTION
## Summary

Resolves audit-architecture finding that Layer 3 submodules followed two
incompatible conventions without documentation. Chose the document path
(issue option 2) over forcing the triple onto stateful auth/runtime
services, which would be harmful.

- **Docs**: Add `Layer 3 Module Archetypes` section to
  `docs/architecture/layer-architecture.md` documenting three patterns
  (pure-function triple, stateful service, thin utility) plus a
  hybrid-in-progress carve-out and a quick-chooser table. Cross-reference
  the new section from `CLAUDE.md`.
- **`security/queries/types.rs`** (new): 3-line `pub use` re-export mirroring
  the `security/formats/types.rs` pattern. Every `security/*` submodule now
  has a local `types.rs`.
- **`primitives/identifiers/types.rs` → `types/` directory**: split the
  469-line file into per-concern files (`core.rs`, `personal.rs`,
  `financial.rs`) mirroring the Layer 3 `identifiers/types/` layout. No
  external imports change — all downstream references continue to resolve
  through the unchanged `mod types;` declaration.

Documentation + structural refactor only: no API changes, no behavior
changes.

## Test plan

- [x] `just fmt-check` passes
- [x] `just clippy` passes (no warnings with `-D warnings`)
- [x] `just arch-check` passes (layer boundaries, naming, visibility)
- [x] `just test-octarine` — 6380 unit tests + all doctests pass
- [x] `just preflight` — full bundle passes
- [x] `git diff --stat`: 8 files changed, 330 insertions, 213 deletions

## Pre-review findings (advisory)

Pre-review scanner flagged `missing-test-file` (HIGH) on the new/moved
type-definition and re-export files. These are idiomatic Rust inline
`#[cfg(test)]` targets, not sidecar-test targets — no action needed.
The inline `DetectionConfidence` tests from the original `types.rs`
were preserved in `types/core.rs`.

Closes #175