### PR TITLE
refactor(observe): replace pub(super) use with pub(in crate::observe) use

### DIFF
--- a/crates/octarine/src/observe/context/mod.rs
+++ b/crates/octarine/src/observe/context/mod.rs
@@ -22,14 +22,14 @@ mod builder;
 // Builder exports - these are the main way to work with context
 // Internal to observe module only
 #[allow(unused_imports)]
-pub(super) use builder::ContextBuilder;
+pub(in crate::observe) use builder::ContextBuilder;
 
 // Export shortcuts at the appropriate level
 // Use the shortcuts module in this directory for cross-domain shortcuts
 pub(super) mod shortcuts;
 // Domain-specific shortcuts are in builder/shortcuts
 #[allow(unused_imports)]
-pub(super) use builder::shortcuts as domain_shortcuts;
+pub(in crate::observe) use builder::shortcuts as domain_shortcuts;
 
 // Public exports - carefully selected for external use
 // These are the only parts of context that should be exposed outside observe

--- a/crates/octarine/src/observe/event/mod.rs
+++ b/crates/octarine/src/observe/event/mod.rs
@@ -14,7 +14,7 @@ mod builder;
 
 // Builder exports - these are the main way to work with events
 // Internal to observe module only
-pub(super) use builder::EventBuilder;
+pub(in crate::observe) use builder::EventBuilder;
 
 // Shortcuts module (internal to observe)
 pub(super) mod shortcuts;

--- a/crates/octarine/src/observe/metrics/mod.rs
+++ b/crates/octarine/src/observe/metrics/mod.rs
@@ -71,7 +71,7 @@ mod export;
 pub(crate) mod builder;
 
 // Re-export builder for observe/builder/ to use
-pub(super) use builder::MetricsBuilder;
+pub(in crate::observe) use builder::MetricsBuilder;
 
 // Security validation no longer needed - handled by MetricName type
 

--- a/crates/octarine/src/observe/pii/mod.rs
+++ b/crates/octarine/src/observe/pii/mod.rs
@@ -125,5 +125,5 @@ pub use scanner::is_pii_present;
 pub use types::PiiType;
 
 // Internal API (for Event builder integration)
-pub(super) use redactor::scan_and_redact;
-pub(super) use types::PiiScanResult;
+pub(in crate::observe) use redactor::scan_and_redact;
+pub(in crate::observe) use types::PiiScanResult;

--- a/crates/octarine/src/observe/problem/mod.rs
+++ b/crates/octarine/src/observe/problem/mod.rs
@@ -15,11 +15,11 @@ pub(crate) mod builder;
 // Builder exports - these are the main way to work with problems
 // Internal to observe module only
 #[allow(unused_imports)]
-pub(super) use builder::ProblemBuilder;
+pub(in crate::observe) use builder::ProblemBuilder;
 
 // Shortcuts for common patterns (internal to observe)
 // These provide pre-configured problems for common use cases
-pub(super) use builder::shortcuts;
+pub(in crate::observe) use builder::shortcuts;
 
 // Public exports - carefully selected for external use
 pub use types::{Problem, Result};


### PR DESCRIPTION
## Summary

Replaces eight `pub(super) use` re-exports in `observe/{event,pii,context,problem,metrics}/mod.rs` with `pub(in crate::observe) use`, resolving the audit finding from `audit-octarine-visibility` (issue #170).

**Why not `pub(crate) use`?** The source items (`EventBuilder`, `MetricsBuilder`, `ContextBuilder`, `ProblemBuilder`, `PiiScanResult`, `scan_and_redact`, `builder::shortcuts`) are all declared `pub(in crate::observe)`. A naive `pub(crate) use` re-export would broaden beyond source visibility and fail to compile with E0364/E0365. `pub(in crate::observe) use` matches the source scope exactly, makes the intent explicit, and preserves access semantics without broadening any API surface.

## Affected files

- `observe/event/mod.rs:17` — `EventBuilder`
- `observe/pii/mod.rs:128-129` — `scan_and_redact`, `PiiScanResult`
- `observe/context/mod.rs:25,32` — `ContextBuilder`, `domain_shortcuts`
- `observe/problem/mod.rs:18,22` — `ProblemBuilder`, `shortcuts`
- `observe/metrics/mod.rs:74` — `MetricsBuilder`

## Test plan

- [x] `just fmt-check` — clean
- [x] `just clippy` — clean
- [x] `just arch-check` — clean
- [x] `just test-octarine` — 241 passed, 0 failed
- [x] Sanity grep: no `pub(super) use` re-exports remain in `observe/` (only struct-field `pub(super)` modifiers remain, out of scope)

## Pre-review findings

- 5x `missing-test-file` — false positives (these are `mod.rs` re-export files; no dedicated test file expected for a visibility-only change)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)