### PR TITLE
feat(identifiers): complete dual-API contract for financial, personal, token, crypto

### DIFF
--- a/crates/octarine/src/identifiers/builder/crypto.rs
+++ b/crates/octarine/src/identifiers/builder/crypto.rs
@@ -10,8 +10,8 @@ use std::time::Instant;
 use crate::observe::Problem;
 use crate::observe::metrics::{MetricName, increment_by, record};
 use crate::primitives::identifiers::{
-    CertificateType, CryptoDetectionResult, CryptoIdentifierBuilder, KeyFormat, KeyType,
-    SignatureAlgorithm,
+    CertificateType, CryptoDetectionResult, CryptoIdentifierBuilder, IdentifierType, KeyFormat,
+    KeyType, SignatureAlgorithm,
 };
 
 #[allow(clippy::expect_used)]
@@ -156,6 +156,21 @@ impl CryptoBuilder {
     #[must_use]
     pub fn is_public_key(&self, data: &str) -> bool {
         self.inner.is_public_key(data)
+    }
+
+    /// Check whether `data` is any cryptographic artifact (dual-API contract).
+    #[must_use]
+    pub fn is_crypto_identifier(&self, data: &str) -> bool {
+        self.inner.is_crypto_identifier(data)
+    }
+
+    /// Detect crypto identifier type (dual-API contract).
+    ///
+    /// Returns [`IdentifierType::HighEntropyString`] for any recognised
+    /// PEM/DER/SSH artifact, otherwise `None`.
+    #[must_use]
+    pub fn detect_crypto_identifier(&self, data: &str) -> Option<IdentifierType> {
+        self.inner.detect_crypto_identifier(data)
     }
 
     /// Check if the data is any type of cryptographic artifact

--- a/crates/octarine/src/identifiers/builder/financial.rs
+++ b/crates/octarine/src/identifiers/builder/financial.rs
@@ -138,6 +138,17 @@ impl FinancialBuilder {
         self.inner.is_financial_identifier(value)
     }
 
+    /// Detect financial identifier type (dual-API alias for [`Self::find`]).
+    ///
+    /// Provided to match the `detect_{domain}_identifier` /
+    /// `is_{domain}_identifier` contract shared by every identifier domain.
+    /// Unlike [`Self::find`], this is a plain pass-through without observe
+    /// instrumentation — use [`Self::find`] when you want metrics recorded.
+    #[must_use]
+    pub fn detect_financial_identifier(&self, value: &str) -> Option<IdentifierType> {
+        self.inner.detect_financial_identifier(value)
+    }
+
     /// Check if value is a credit card
     #[must_use]
     pub fn is_credit_card(&self, value: &str) -> bool {

--- a/crates/octarine/src/identifiers/builder/personal.rs
+++ b/crates/octarine/src/identifiers/builder/personal.rs
@@ -110,6 +110,17 @@ impl PersonalBuilder {
         self.inner.is_personal_identifier(value)
     }
 
+    /// Detect personal identifier type (dual-API alias for [`Self::detect`]).
+    ///
+    /// Provided to match the `detect_{domain}_identifier` /
+    /// `is_{domain}_identifier` contract shared by every identifier domain.
+    /// Unlike [`Self::detect`], this is a plain pass-through without observe
+    /// instrumentation — use [`Self::detect`] when you want metrics recorded.
+    #[must_use]
+    pub fn detect_personal_identifier(&self, value: &str) -> Option<IdentifierType> {
+        self.inner.detect_personal_identifier(value)
+    }
+
     /// Check if value is an email address
     #[must_use]
     pub fn is_email(&self, value: &str) -> bool {

--- a/crates/octarine/src/identifiers/builder/token.rs
+++ b/crates/octarine/src/identifiers/builder/token.rs
@@ -9,9 +9,9 @@ use std::borrow::Cow;
 
 use crate::observe::Problem;
 use crate::primitives::identifiers::{
-    ApiKeyProvider, ApiKeyRedactionStrategy, JwtAlgorithm, JwtMetadata, JwtRedactionStrategy,
-    SessionIdRedactionStrategy, SshFingerprintRedactionStrategy, SshKeyRedactionStrategy,
-    TokenIdentifierBuilder, TokenTextPolicy, TokenType,
+    ApiKeyProvider, ApiKeyRedactionStrategy, IdentifierType, JwtAlgorithm, JwtMetadata,
+    JwtRedactionStrategy, SessionIdRedactionStrategy, SshFingerprintRedactionStrategy,
+    SshKeyRedactionStrategy, TokenIdentifierBuilder, TokenTextPolicy, TokenType,
 };
 
 /// Token identifier builder with observability
@@ -313,6 +313,17 @@ impl TokenBuilder {
     #[must_use]
     pub fn is_token_identifier(&self, value: &str) -> bool {
         self.inner.is_token_identifier(value)
+    }
+
+    /// Detect token identifier type (dual-API contract).
+    ///
+    /// Companion to [`Self::is_token_identifier`] that returns the matched
+    /// `IdentifierType`. Unlike [`Self::detect_token_type`], the result uses
+    /// the cross-domain `IdentifierType` enum so tokens can be compared with
+    /// identifiers from other domains (network, personal, financial, etc.).
+    #[must_use]
+    pub fn detect_token_identifier(&self, value: &str) -> Option<IdentifierType> {
+        self.inner.detect_token_identifier(value)
     }
 
     // ============================================================================

--- a/crates/octarine/src/primitives/identifiers/crypto/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/crypto/builder.rs
@@ -5,6 +5,7 @@
 
 use crate::primitives::Problem;
 
+use super::super::types::IdentifierType;
 use super::detection;
 use super::types::{
     CertificateType, CryptoDetectionResult, KeyFormat, KeyType, SignatureAlgorithm,
@@ -254,6 +255,26 @@ impl CryptoIdentifierBuilder {
         result.format != KeyFormat::Unknown || result.key_type.is_some() || result.is_certificate
     }
 
+    /// Check whether `data` is any cryptographic artifact (dual-API contract).
+    ///
+    /// Semantically identical to [`Self::is_crypto_artifact`]; kept as the
+    /// `is_{domain}_identifier` pair for [`Self::detect_crypto_identifier`]
+    /// so crypto conforms to the cross-domain contract.
+    #[must_use]
+    pub fn is_crypto_identifier(&self, data: &str) -> bool {
+        detection::is_crypto_identifier(data)
+    }
+
+    /// Detect crypto identifier type (dual-API contract).
+    ///
+    /// Returns [`IdentifierType::HighEntropyString`] for any recognised
+    /// PEM/DER/SSH artifact, otherwise `None`. See
+    /// [`detection::detect_crypto_identifier`] for the mapping rationale.
+    #[must_use]
+    pub fn detect_crypto_identifier(&self, data: &str) -> Option<IdentifierType> {
+        detection::detect_crypto_identifier(data)
+    }
+
     /// Classify a certificate type (requires parsing for accurate results)
     ///
     /// Note: This is a basic heuristic. For accurate classification,
@@ -340,6 +361,20 @@ FAKE_TEST_DATA_NOT_A_REAL_CERTIFICATE
         assert!(builder.is_crypto_artifact(SAMPLE_SSH_KEY));
         assert!(builder.is_crypto_artifact(SAMPLE_CERT_PEM));
         assert!(!builder.is_crypto_artifact("just some random text"));
+    }
+
+    #[test]
+    fn test_dual_api_identifier() {
+        let builder = CryptoIdentifierBuilder::new();
+
+        assert!(builder.is_crypto_identifier(SAMPLE_RSA_PEM));
+        assert!(!builder.is_crypto_identifier("just some random text"));
+
+        assert_eq!(
+            builder.detect_crypto_identifier(SAMPLE_CERT_PEM),
+            Some(IdentifierType::HighEntropyString)
+        );
+        assert_eq!(builder.detect_crypto_identifier("plain text"), None);
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/crypto/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/crypto/detection.rs
@@ -3,6 +3,7 @@
 //! Pure detection functions for identifying cryptographic artifact types.
 //! This is the CLASSIFICATION concern - answering "What type is this?"
 
+use super::super::types::IdentifierType;
 use super::patterns::{
     LABEL_CERTIFICATE, LABEL_CERTIFICATE_REQUEST, LABEL_EC_PRIVATE_KEY,
     LABEL_ENCRYPTED_PRIVATE_KEY, LABEL_OPENSSH_PRIVATE_KEY, LABEL_PRIVATE_KEY, LABEL_PUBLIC_KEY,
@@ -340,6 +341,33 @@ pub fn detect_crypto_artifact(data: &str) -> CryptoDetectionResult {
     result
 }
 
+/// Detect crypto identifier type (dual-API contract).
+///
+/// Companion to [`is_crypto_identifier`] that returns the matched
+/// `IdentifierType`. Internally dispatches to [`detect_crypto_artifact`] and
+/// maps any recognised artifact (PEM/DER/SSH format, known key type, or
+/// certificate) to [`IdentifierType::HighEntropyString`] — this is the
+/// closest existing variant, since `IdentifierType` has no dedicated
+/// `Certificate` / `PrivateKey` / `SshKey` variant. A follow-up may add
+/// those variants and refine this mapping.
+#[must_use]
+pub fn detect_crypto_identifier(data: &str) -> Option<IdentifierType> {
+    let result = detect_crypto_artifact(data);
+    if result.format != KeyFormat::Unknown || result.key_type.is_some() || result.is_certificate {
+        Some(IdentifierType::HighEntropyString)
+    } else {
+        None
+    }
+}
+
+/// Check whether `data` is any cryptographic artifact (dual-API contract).
+///
+/// Returns `true` when [`detect_crypto_identifier`] would return `Some`.
+#[must_use]
+pub fn is_crypto_identifier(data: &str) -> bool {
+    detect_crypto_identifier(data).is_some()
+}
+
 /// Detect signature algorithm from OID string
 ///
 /// Common OIDs:
@@ -518,6 +546,32 @@ FAKE_TEST_DATA_NOT_A_REAL_CERTIFICATE
         let result = detect_crypto_artifact(SAMPLE_SSH_RSA_KEY);
         assert_eq!(result.key_type, Some(KeyType::SshRsa));
         assert_eq!(result.format, KeyFormat::Ssh);
+    }
+
+    #[test]
+    fn test_detect_crypto_identifier() {
+        assert_eq!(
+            detect_crypto_identifier(SAMPLE_CERTIFICATE_PEM),
+            Some(IdentifierType::HighEntropyString)
+        );
+        assert_eq!(
+            detect_crypto_identifier(SAMPLE_RSA_PUBLIC_PEM),
+            Some(IdentifierType::HighEntropyString)
+        );
+        assert_eq!(
+            detect_crypto_identifier(SAMPLE_SSH_ED25519_KEY),
+            Some(IdentifierType::HighEntropyString)
+        );
+        assert_eq!(detect_crypto_identifier("plain text, not a key"), None);
+        assert_eq!(detect_crypto_identifier(""), None);
+    }
+
+    #[test]
+    fn test_is_crypto_identifier() {
+        assert!(is_crypto_identifier(SAMPLE_CERTIFICATE_PEM));
+        assert!(is_crypto_identifier(SAMPLE_SSH_RSA_KEY));
+        assert!(!is_crypto_identifier("plain text"));
+        assert!(!is_crypto_identifier(""));
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/crypto/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/crypto/mod.rs
@@ -75,5 +75,8 @@ pub use builder::CryptoIdentifierBuilder;
 // Re-export types for public API (needed for function signatures)
 pub use types::{CertificateType, CryptoDetectionResult, KeyFormat, KeyType, SignatureAlgorithm};
 
-// Detection functions are accessed via CryptoIdentifierBuilder, not directly exported
-// This follows the same pattern as primitives/identifiers/network/
+// Dual-API contract (shared across identifier domains): re-export the two
+// aggregate functions so callers can invoke them without going through
+// `CryptoIdentifierBuilder`. Other `is_*` / `detect_*` functions remain
+// behind the builder — the dual-API pair is the explicit exception.
+pub use detection::{detect_crypto_identifier, is_crypto_identifier};

--- a/crates/octarine/src/primitives/identifiers/financial/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/builder.rs
@@ -42,6 +42,16 @@ impl FinancialIdentifierBuilder {
         detection::is_financial_identifier(value)
     }
 
+    /// Detect financial identifier type (dual-API contract alias).
+    ///
+    /// Companion to [`Self::is_financial_identifier`] — both delegate to the
+    /// same aggregate detector; this one returns the matched
+    /// `IdentifierType`.
+    #[must_use]
+    pub fn detect_financial_identifier(&self, value: &str) -> Option<IdentifierType> {
+        detection::detect_financial_identifier(value)
+    }
+
     /// Check if value is a credit card
     #[must_use]
     pub fn is_credit_card(&self, value: &str) -> bool {

--- a/crates/octarine/src/primitives/identifiers/financial/detection/common.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/detection/common.rs
@@ -63,6 +63,20 @@ pub fn is_financial_identifier(value: &str) -> bool {
     find_financial_identifier(value).is_some()
 }
 
+/// Detect financial identifier type (dual-API contract alias).
+///
+/// Every identifier domain exposes the pair `detect_{domain}_identifier` /
+/// `is_{domain}_identifier`. This is the aggregate entry point that returns
+/// which specific `IdentifierType` matched — the bool counterpart is
+/// [`is_financial_identifier`].
+///
+/// Semantically identical to [`find_financial_identifier`]; kept as an alias
+/// for contract consistency across domains.
+#[must_use]
+pub fn detect_financial_identifier(value: &str) -> Option<IdentifierType> {
+    find_financial_identifier(value)
+}
+
 /// Detect all financial identifiers in text
 ///
 /// Comprehensive scanner that detects all financial PII types in one pass:
@@ -218,6 +232,20 @@ mod tests {
         assert!(is_financial_identifier("4242424242424242"));
         assert!(is_financial_identifier("121000358"));
         assert!(!is_financial_identifier("not financial"));
+    }
+
+    #[test]
+    fn test_detect_financial_identifier() {
+        assert_eq!(
+            detect_financial_identifier("4242424242424242"),
+            Some(IdentifierType::CreditCard)
+        );
+        assert_eq!(
+            detect_financial_identifier("121000358"),
+            Some(IdentifierType::RoutingNumber)
+        );
+        assert_eq!(detect_financial_identifier("not financial"), None);
+        assert_eq!(detect_financial_identifier(""), None);
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/financial/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/detection/mod.rs
@@ -54,6 +54,6 @@ pub use crypto::{
 
 // Re-export common/aggregate functions
 pub use common::{
-    detect_all_financial_in_text, find_financial_identifier, is_financial_identifier,
-    is_financial_present, is_payment_data_present,
+    detect_all_financial_in_text, detect_financial_identifier, find_financial_identifier,
+    is_financial_identifier, is_financial_present, is_payment_data_present,
 };

--- a/crates/octarine/src/primitives/identifiers/personal/builder/core.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/builder/core.rs
@@ -36,6 +36,16 @@ impl PersonalIdentifierBuilder {
         detection::is_personal_identifier(value)
     }
 
+    /// Detect personal identifier type (dual-API contract alias).
+    ///
+    /// Companion to [`Self::is_personal_identifier`]; returns the matched
+    /// `IdentifierType` instead of a bool. Semantically identical to
+    /// [`Self::find`] — kept for contract consistency with other domains.
+    #[must_use]
+    pub fn detect_personal_identifier(&self, value: &str) -> Option<IdentifierType> {
+        detection::detect_personal_identifier(value)
+    }
+
     /// Check if value is PII (any personal identifier)
     #[must_use]
     pub fn is_pii(&self, value: &str) -> bool {

--- a/crates/octarine/src/primitives/identifiers/personal/detection/common.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/detection/common.rs
@@ -95,6 +95,20 @@ pub fn is_personal_identifier(value: &str) -> bool {
     find_personal_identifier(value).is_some()
 }
 
+/// Detect personal identifier type (dual-API contract alias).
+///
+/// Every identifier domain exposes the pair `detect_{domain}_identifier` /
+/// `is_{domain}_identifier`. This is the aggregate entry point that returns
+/// which specific `IdentifierType` matched — the bool counterpart is
+/// [`is_personal_identifier`].
+///
+/// Semantically identical to [`find_personal_identifier`]; kept as an alias
+/// for contract consistency across domains.
+#[must_use]
+pub fn detect_personal_identifier(value: &str) -> Option<IdentifierType> {
+    find_personal_identifier(value)
+}
+
 /// Check if value is PII (any personal identifier)
 ///
 /// Alias for `is_personal_identifier` - checks if a single value matches
@@ -238,6 +252,28 @@ mod tests {
         assert!(is_pii("user@example.com"));
         assert!(is_pii("+15551234567"));
         assert!(!is_pii("550e8400-e29b-41d4-a716-446655440000")); // UUID is not PII
+    }
+
+    #[test]
+    fn test_detect_personal_identifier() {
+        assert_eq!(
+            detect_personal_identifier("user@example.com"),
+            Some(IdentifierType::Email)
+        );
+        assert_eq!(
+            detect_personal_identifier("+15551234567"),
+            Some(IdentifierType::PhoneNumber)
+        );
+        assert_eq!(
+            detect_personal_identifier("john_doe"),
+            Some(IdentifierType::Username)
+        );
+        assert_eq!(detect_personal_identifier(""), None);
+        // UUID is not PII
+        assert_eq!(
+            detect_personal_identifier("550e8400-e29b-41d4-a716-446655440000"),
+            None
+        );
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/personal/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/detection/mod.rs
@@ -52,8 +52,8 @@ pub use username::{detect_usernames_in_text, is_username};
 
 // Re-export common/aggregate functions
 pub use common::{
-    detect_all_pii_in_text, find_personal_identifier, is_personal_identifier, is_pii,
-    is_pii_present,
+    detect_all_pii_in_text, detect_personal_identifier, find_personal_identifier,
+    is_personal_identifier, is_pii, is_pii_present,
 };
 
 // Re-export deduplicate_matches for internal use by sibling modules

--- a/crates/octarine/src/primitives/identifiers/token/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/token/builder.rs
@@ -4,6 +4,7 @@
 
 use crate::primitives::Problem;
 
+use super::super::types::IdentifierType;
 use super::{conversion, detection, redaction, sanitization, validation};
 
 // Re-export types for convenience
@@ -256,6 +257,15 @@ impl TokenIdentifierBuilder {
     /// Check if value is any type of token
     pub fn is_token_identifier(&self, value: &str) -> bool {
         detection::is_token_identifier(value)
+    }
+
+    /// Detect token identifier type (dual-API contract).
+    ///
+    /// Companion to [`Self::is_token_identifier`] that returns the matched
+    /// `IdentifierType` (see [`detection::detect_token_identifier`] for the
+    /// `TokenType` → `IdentifierType` mapping).
+    pub fn detect_token_identifier(&self, value: &str) -> Option<IdentifierType> {
+        detection::detect_token_identifier(value)
     }
 
     // ============================================================================

--- a/crates/octarine/src/primitives/identifiers/token/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/token/detection/mod.rs
@@ -36,6 +36,8 @@ mod session;
 mod ssh;
 mod types;
 
+use super::super::types::IdentifierType;
+
 // Re-export types
 pub use types::{ApiKeyProvider, JwtAlgorithm, TokenType};
 
@@ -261,6 +263,72 @@ pub fn is_token_identifier(value: &str) -> bool {
     detect_token_type(value).is_some()
 }
 
+/// Detect token identifier type (dual-API contract).
+///
+/// Companion to [`is_token_identifier`] that returns the matched
+/// `IdentifierType`. Internally dispatches via [`detect_token_type`] and
+/// maps the richer `TokenType` enum to the cross-domain `IdentifierType`:
+///
+/// - Dedicated variants (`Jwt`, `GitHub` → `GitHubToken`, `GitLab` →
+///   `GitLabToken`, `AwsAccessKey`, `AwsSessionToken`, `SessionId`) map
+///   directly.
+/// - `UrlWithCredentials` maps to `Url`.
+/// - SSH keys/fingerprints map to `HighEntropyString` (no dedicated SSH
+///   variant in `IdentifierType`; matches the `From<IdentifierType>` bridge
+///   fallback in `observe/pii/types.rs`).
+/// - All other provider-specific tokens (Stripe, Square, Shopify, Mailgun,
+///   Discord, Slack, Telegram, OpenAI, etc.) map to `ApiKey`.
+#[must_use]
+pub fn detect_token_identifier(value: &str) -> Option<IdentifierType> {
+    let token_type = detect_token_type(value)?;
+    Some(match token_type {
+        TokenType::Jwt => IdentifierType::Jwt,
+        TokenType::GitHub => IdentifierType::GitHubToken,
+        TokenType::GitLab => IdentifierType::GitLabToken,
+        TokenType::AwsAccessKey => IdentifierType::AwsAccessKey,
+        TokenType::AwsSessionToken => IdentifierType::AwsSessionToken,
+        TokenType::SessionId => IdentifierType::SessionId,
+        TokenType::UrlWithCredentials => IdentifierType::Url,
+        // No SshKey variant in IdentifierType; HighEntropyString matches the
+        // observe/pii/types.rs bridge fallback for SSH material.
+        TokenType::SshPrivateKey
+        | TokenType::SshPublicKey
+        | TokenType::SshFingerprint
+        | TokenType::AwsSecretKey => IdentifierType::HighEntropyString,
+        // All remaining provider-specific tokens collapse to the generic
+        // ApiKey variant.
+        TokenType::GcpApiKey
+        | TokenType::AzureKey
+        | TokenType::StripeKey
+        | TokenType::OnePasswordServiceToken
+        | TokenType::OnePasswordVaultRef
+        | TokenType::BearerToken
+        | TokenType::GenericApiKey
+        | TokenType::SquareToken
+        | TokenType::PayPalToken
+        | TokenType::ShopifyToken
+        | TokenType::MailchimpToken
+        | TokenType::MailgunToken
+        | TokenType::ResendToken
+        | TokenType::BrevoToken
+        | TokenType::DatabricksToken
+        | TokenType::VaultToken
+        | TokenType::CloudflareOriginCaKey
+        | TokenType::NpmToken
+        | TokenType::PyPiToken
+        | TokenType::NuGetKey
+        | TokenType::ArtifactoryToken
+        | TokenType::DockerHubToken
+        | TokenType::TelegramToken
+        | TokenType::DiscordToken
+        | TokenType::SlackToken
+        | TokenType::TwilioToken
+        | TokenType::SendGridToken
+        | TokenType::OpenAiKey
+        | TokenType::BitbucketToken => IdentifierType::ApiKey,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
@@ -473,5 +541,56 @@ mod tests {
         assert!(!is_token_identifier("not-a-token"));
         assert!(!is_token_identifier("regular text"));
         assert!(!is_token_identifier(""));
+    }
+
+    #[test]
+    fn test_detect_token_identifier() {
+        // Dedicated mappings (tokens constructed at runtime to avoid
+        // triggering secret scanners on literal high-entropy strings).
+        let ghp = format!("{}{}", "ghp_", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
+        assert_eq!(
+            detect_token_identifier(&ghp),
+            Some(IdentifierType::GitHubToken)
+        );
+        assert_eq!(
+            detect_token_identifier("glpat-xxxxxxxxxxxxxxxxxxxx"),
+            Some(IdentifierType::GitLabToken)
+        );
+        let akia = format!("AKIA{}", "IOSFODNN7EXAMPLE");
+        assert_eq!(
+            detect_token_identifier(&akia),
+            Some(IdentifierType::AwsAccessKey)
+        );
+        let jwt = format!(
+            "{}.{}.{}",
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ",
+            "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        );
+        assert_eq!(detect_token_identifier(&jwt), Some(IdentifierType::Jwt));
+        assert_eq!(
+            detect_token_identifier("Ab3De8Gh2Jk5Mn9Pq4Rs7Tv0Wx3Yz6"),
+            Some(IdentifierType::SessionId)
+        );
+
+        // SSH keys collapse to HighEntropyString
+        assert_eq!(
+            detect_token_identifier("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8..."),
+            Some(IdentifierType::HighEntropyString)
+        );
+
+        // Provider-specific tokens collapse to ApiKey
+        assert_eq!(
+            detect_token_identifier(&format!("sk_live_{}", "EXAMPLE000000000KEY01abcdef")),
+            Some(IdentifierType::ApiKey)
+        );
+        assert_eq!(
+            detect_token_identifier(&format!("shpat_{}", "abcdef1234567890abcdef1234567890")),
+            Some(IdentifierType::ApiKey)
+        );
+
+        // Non-tokens
+        assert_eq!(detect_token_identifier("not-a-token"), None);
+        assert_eq!(detect_token_identifier(""), None);
     }
 }


### PR DESCRIPTION
## Summary

Wires up the missing `detect_{domain}_identifier(v) -> Option<IdentifierType>` half of the dual-API contract for the four non-compliant identifier domains (audit finding `octarine-identifiers/incomplete-dual-api`):

- **financial** / **personal**: `detect_*_identifier` added as thin aliases over the existing `find_*_identifier` — same `Option<IdentifierType>` return, preserved for backward compatibility.
- **token**: new `detect_token_identifier` maps `TokenType → IdentifierType`. Dedicated variants (`Jwt`, `GitHub`, `GitLab`, `Aws*`, `SessionId`) map directly; `UrlWithCredentials → Url`; SSH material + `AwsSecretKey → HighEntropyString` (no `SshKey` variant, matches `observe/pii/types.rs` bridge fallback); remaining provider tokens collapse to `ApiKey`.
- **crypto**: new `is_crypto_identifier` / `detect_crypto_identifier` return `Some(HighEntropyString)` for any recognised PEM/DER/SSH artifact. These two are now re-exported from `primitives/identifiers/crypto/mod.rs` as the documented exception to the builder-only access rule.

Each domain also gains matching delegate methods on both the primitive builder and the Layer 3 observe-instrumented builder.

**Out of scope (follow-up)**: adding `IdentifierType::Certificate` / `PrivateKey` / `SshKey` variants would tighten the crypto + token-SSH mapping but cascades to `PiiType` and PII scanner domains.

## Test plan

- [x] `just clippy` — clean, no warnings
- [x] `just fmt-check` — clean
- [x] `just arch-check` — clean
- [x] `just test-octarine` — 6386 lib tests pass (15 new assertions across the four domains + builders), 241 doctests pass
- [x] Dual-API verification: `grep -rn "pub fn (is|detect)_{d}_identifier"` shows both halves for financial, personal, token, crypto

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)