### PR TITLE
feat(identifiers): add IdentifierType::Ein variant for EIN-specific classification

### DIFF
--- a/crates/octarine/src/identifiers/builder/government.rs
+++ b/crates/octarine/src/identifiers/builder/government.rs
@@ -232,6 +232,20 @@ impl GovernmentBuilder {
         self.inner.find_tax_ids_in_text(text)
     }
 
+    /// Check if value is a valid EIN (Employer Identification Number)
+    ///
+    /// Validates both the `XX-XXXXXXX` format and the IRS campus code prefix.
+    #[must_use]
+    pub fn is_ein(&self, value: &str) -> bool {
+        self.inner.is_ein(value)
+    }
+
+    /// Find all valid EINs in text
+    #[must_use]
+    pub fn find_eins_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        self.inner.find_eins_in_text(text)
+    }
+
     /// Validate EIN format
     ///
     /// # Errors

--- a/crates/octarine/src/identifiers/shortcuts.rs
+++ b/crates/octarine/src/identifiers/shortcuts.rs
@@ -249,6 +249,27 @@ pub fn redact_ssns(text: &str) -> String {
     GovernmentBuilder::new().redact_ssns_in_text_with_strategy(text, SsnRedactionStrategy::Token)
 }
 
+/// Check if value is a valid EIN (Employer Identification Number)
+#[must_use]
+pub fn is_ein(value: &str) -> bool {
+    GovernmentBuilder::new().is_ein(value)
+}
+
+/// Find all valid EINs in text
+#[must_use]
+pub fn find_eins(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_eins_in_text(text)
+}
+
+/// Validate an EIN format
+///
+/// # Errors
+///
+/// Returns `Problem` if the EIN format or IRS campus code prefix is invalid.
+pub fn validate_ein(ein: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_ein(ein)
+}
+
 // ============================================================
 // CREDIT CARD SHORTCUTS
 // ============================================================

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -75,6 +75,9 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
     if !government.find_passports_in_text(text).is_empty() {
         pii_types.push(PiiType::Passport);
     }
+    if !government.find_eins_in_text(text).is_empty() {
+        pii_types.push(PiiType::Ein);
+    }
     if !government.find_tax_ids_in_text(text).is_empty() {
         pii_types.push(PiiType::TaxId);
     }

--- a/crates/octarine/src/observe/pii/scanner/mod.rs
+++ b/crates/octarine/src/observe/pii/scanner/mod.rs
@@ -218,6 +218,42 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_for_pii_ein() {
+        // Valid EIN (12-3456789, Brookhaven prefix) — must surface as PiiType::Ein
+        // and PiiType::TaxId both, since EIN is a specific kind of tax ID.
+        let text = "Company EIN: 12-3456789";
+        let types = scan_for_pii(text);
+        assert!(
+            types.contains(&PiiType::Ein),
+            "Should detect EIN, got {:?}",
+            types
+        );
+        assert!(
+            types.contains(&PiiType::TaxId),
+            "EIN is a tax ID — both classifications should fire, got {:?}",
+            types
+        );
+    }
+
+    #[test]
+    fn test_scan_for_pii_invalid_ein_only_tax_id() {
+        // Invalid IRS prefix (00) — EIN-specific scan should NOT match,
+        // but the broad TaxId pattern still catches it.
+        let text = "Bad EIN: 00-0000001";
+        let types = scan_for_pii(text);
+        assert!(
+            !types.contains(&PiiType::Ein),
+            "Invalid IRS prefix must not produce PiiType::Ein, got {:?}",
+            types
+        );
+        assert!(
+            types.contains(&PiiType::TaxId),
+            "Broad tax ID pattern still matches, got {:?}",
+            types
+        );
+    }
+
+    #[test]
     fn test_scan_for_pii_credit_card() {
         let text = "Card: 4242424242424242"; // Stripe test card
         let types = scan_for_pii(text);

--- a/crates/octarine/src/observe/pii/types.rs
+++ b/crates/octarine/src/observe/pii/types.rs
@@ -520,6 +520,7 @@ impl From<IdentifierType> for PiiType {
             // Government
             IdentifierType::DriverLicense => Self::DriverLicense,
             IdentifierType::Passport => Self::Passport,
+            IdentifierType::Ein => Self::Ein,
             IdentifierType::TaxId => Self::TaxId,
             IdentifierType::NationalId => Self::NationalId,
             IdentifierType::KoreaRrn => Self::KoreaRrn,
@@ -937,6 +938,7 @@ mod tests {
             PiiType::DriverLicense
         );
         assert_eq!(PiiType::from(IdentifierType::Passport), PiiType::Passport);
+        assert_eq!(PiiType::from(IdentifierType::Ein), PiiType::Ein);
         assert_eq!(PiiType::from(IdentifierType::TaxId), PiiType::TaxId);
         assert_eq!(
             PiiType::from(IdentifierType::NationalId),

--- a/crates/octarine/src/primitives/identifiers/government/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder.rs
@@ -184,6 +184,20 @@ impl GovernmentIdentifierBuilder {
         detection::find_tax_ids_in_text(text)
     }
 
+    /// Check if value is a valid EIN (Employer Identification Number)
+    ///
+    /// Validates both the `XX-XXXXXXX` format and the IRS campus code prefix.
+    #[must_use]
+    pub fn is_ein(&self, value: &str) -> bool {
+        detection::is_ein(value)
+    }
+
+    /// Find all valid EINs in text
+    #[must_use]
+    pub fn find_eins_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_eins_in_text(text)
+    }
+
     /// Validate EIN format
     ///
     /// # Errors

--- a/crates/octarine/src/primitives/identifiers/government/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection.rs
@@ -196,9 +196,23 @@ pub fn is_ssn(value: &str) -> bool {
 }
 
 /// Check if a value matches tax ID format (EIN, TIN, ITIN)
+///
+/// This is a broad superset check — any value matching `is_ein` will also
+/// match `is_tax_id`. Use `is_ein` when EIN-specific classification is needed.
 #[must_use]
 pub fn is_tax_id(value: &str) -> bool {
     patterns::tax_id::all().iter().any(|p| p.is_match(value))
+}
+
+/// Check if a value is a valid EIN (Employer Identification Number)
+///
+/// Distinguishes EINs from other tax IDs (ITINs, generic TINs) by validating
+/// both the `XX-XXXXXXX` format and the IRS campus code prefix. Used by
+/// `detect_government_identifier` to return `IdentifierType::Ein` for valid
+/// EINs and fall through to `IdentifierType::TaxId` for other tax IDs.
+#[must_use]
+pub fn is_ein(value: &str) -> bool {
+    super::validation::validate_ein(value).is_ok()
 }
 
 /// Check if a value matches driver's license format
@@ -614,6 +628,8 @@ pub fn find_poland_pesels_in_text(text: &str) -> Vec<IdentifierMatch> {
 pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
     if is_ssn(value) {
         Some(IdentifierType::Ssn)
+    } else if is_ein(value) {
+        Some(IdentifierType::Ein)
     } else if is_tax_id(value) {
         Some(IdentifierType::TaxId)
     } else if is_driver_license(value) {
@@ -742,10 +758,13 @@ pub fn find_ssns_in_text(text: &str) -> Vec<IdentifierMatch> {
 
 /// Find all tax ID patterns in text (EIN, TIN, ITIN)
 ///
-/// Scans for:
-/// - EIN (Employer Identification Number): "00-0000001"
-/// - TIN (Taxpayer Identification Number)
-/// - ITIN (Individual Taxpayer ID): "9XX-XX-XXXX"
+/// Scans for any tax ID format and tags matches with `IdentifierType::TaxId`.
+/// This is a broad superset finder — text containing a valid EIN will produce
+/// matches here AND in `find_eins_in_text`. The PII scanner pushes both
+/// `PiiType::TaxId` and `PiiType::Ein` for such inputs, which correctly
+/// reflects that the value satisfies both classifications.
+///
+/// Use `find_eins_in_text` when EIN-specific classification is needed.
 ///
 /// # Examples
 ///
@@ -773,6 +792,52 @@ pub fn find_tax_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
                 full_match.end(),
                 full_match.as_str().to_string(),
                 IdentifierType::TaxId,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+/// Find all valid EIN patterns in text
+///
+/// Scans for tax ID format candidates and keeps only those that pass
+/// `is_ein` (valid `XX-XXXXXXX` format with a valid IRS campus code prefix).
+/// Matches are tagged with `IdentifierType::Ein`.
+///
+/// The same input string can also appear in `find_tax_ids_in_text` results
+/// because EINs are a subset of tax IDs — see that function's documentation.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::detection;
+///
+/// let text = "Company EIN: 12-3456789";
+/// let matches = detection::find_eins_in_text(text);
+/// assert_eq!(matches.len(), 1);
+/// ```
+#[must_use]
+pub fn find_eins_in_text(text: &str) -> Vec<IdentifierMatch> {
+    // ReDoS protection
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::tax_id::all() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            let matched_text = full_match.as_str();
+            if !is_ein(matched_text) {
+                continue;
+            }
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                matched_text.to_string(),
+                IdentifierType::Ein,
             ));
         }
     }
@@ -1032,6 +1097,7 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
     let mut all_matches = Vec::new();
 
     all_matches.extend(find_ssns_in_text(text));
+    all_matches.extend(find_eins_in_text(text));
     all_matches.extend(find_tax_ids_in_text(text));
     all_matches.extend(find_driver_licenses_in_text(text));
     all_matches.extend(find_passports_in_text(text));
@@ -1246,6 +1312,84 @@ mod tests {
         assert_eq!(matches.len(), 1);
         let first = matches.first().expect("Should detect tax ID pattern");
         assert_eq!(first.identifier_type, IdentifierType::TaxId);
+    }
+
+    #[test]
+    fn test_is_ein_valid_irs_prefix() {
+        assert!(is_ein("12-3456789")); // Brookhaven
+        assert!(is_ein("20-1234567")); // Austin
+        assert!(is_ein("95-1234567")); // Internet
+    }
+
+    #[test]
+    fn test_is_ein_rejects_invalid_prefix() {
+        assert!(!is_ein("00-0000001")); // Invalid prefix 00
+        assert!(!is_ein("07-1234567")); // Invalid prefix 07
+        assert!(!is_ein("89-1234567")); // Invalid prefix 89
+    }
+
+    #[test]
+    fn test_is_ein_rejects_itin_format() {
+        // ITINs use SSN-style XXX-XX-XXXX format, not EIN's XX-XXXXXXX
+        assert!(!is_ein("912-34-5678"));
+        assert!(!is_ein("900-70-1234"));
+    }
+
+    #[test]
+    fn test_is_ein_rejects_non_tax_ids() {
+        assert!(!is_ein("invalid"));
+        assert!(!is_ein(""));
+        assert!(!is_ein("123456789")); // No dash
+    }
+
+    #[test]
+    fn test_find_eins_in_text() {
+        let text = "Company EIN: 12-3456789 and another 20-1234567";
+        let matches = find_eins_in_text(text);
+        assert_eq!(matches.len(), 2);
+        assert!(
+            matches
+                .iter()
+                .all(|m| m.identifier_type == IdentifierType::Ein),
+            "All matches should be tagged Ein, not TaxId"
+        );
+    }
+
+    #[test]
+    fn test_find_eins_in_text_skips_invalid_prefix() {
+        // 00-0000001 has invalid prefix; should NOT appear in EIN results
+        let text = "Bad EIN: 00-0000001 and good EIN: 12-3456789";
+        let matches = find_eins_in_text(text);
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("Should detect valid EIN");
+        assert_eq!(first.matched_text, "12-3456789");
+    }
+
+    #[test]
+    fn test_find_eins_in_text_skips_itin() {
+        // ITINs match the broader tax_id patterns but are not EINs
+        let text = "ITIN: 912-34-5678";
+        let matches = find_eins_in_text(text);
+        assert!(matches.is_empty(), "ITINs must not be classified as EIN");
+    }
+
+    #[test]
+    fn test_detect_government_identifier_returns_ein() {
+        // Valid EIN goes to Ein, not TaxId
+        assert_eq!(
+            detect_government_identifier("12-3456789"),
+            Some(IdentifierType::Ein)
+        );
+        // Invalid-prefix tax IDs still fall through to TaxId
+        assert_eq!(
+            detect_government_identifier("00-0000001"),
+            Some(IdentifierType::TaxId)
+        );
+        // ITINs continue to be TaxId
+        assert_eq!(
+            detect_government_identifier("912-34-5678"),
+            Some(IdentifierType::TaxId)
+        );
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -377,6 +377,13 @@ impl StreamingScanner {
                         total = total.saturating_add(1);
                     }
                 }
+                IdentifierType::Ein => {
+                    let government = GovernmentIdentifierBuilder::new();
+                    for m in government.find_eins_in_text(text) {
+                        let _ = self.buffer.push(m);
+                        total = total.saturating_add(1);
+                    }
+                }
                 IdentifierType::TaxId => {
                     let government = GovernmentIdentifierBuilder::new();
                     for m in government.find_tax_ids_in_text(text) {

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -55,7 +55,8 @@ pub enum IdentifierType {
     // Government/Official identifiers
     DriverLicense,
     Passport,
-    TaxId, // EIN, TIN, ITIN
+    Ein,   // Employer Identification Number (XX-XXXXXXX, IRS campus prefix)
+    TaxId, // TIN, ITIN (EIN has its own variant)
     NationalId,
     KoreaRrn,        // South Korea Resident Registration Number
     AustraliaTfn,    // Australian Tax File Number


### PR DESCRIPTION
## Summary

- Adds `IdentifierType::Ein` variant alongside the existing `TaxId`, resolving the audit-flagged registry asymmetry where `PiiType::Ein` had no `IdentifierType` counterpart and was effectively dead code.
- Adds `is_ein` (delegates to existing `validate_ein`) and `find_eins_in_text` in `primitives/identifiers/government/detection.rs`. EIN-specific classification now distinguishes valid EINs (`XX-XXXXXXX` with a valid IRS campus prefix) from ITINs and other tax IDs.
- Wires the new functions through the primitives builder, Layer 3 builder, PII scanner (`scan_government`), shortcuts, and the `streaming.rs` exhaustive match.
- Adds the `IdentifierType::Ein => Self::Ein` arm to `From<IdentifierType> for PiiType` — the no-wildcard match guarantees this is required at compile time, keeping the registries in sync.
- `find_tax_ids_in_text` keeps its broad superset behavior. Scanner now pushes both `PiiType::Ein` and `PiiType::TaxId` for valid EIN inputs, which correctly reflects that the value satisfies both classifications.
- Updates `IdentifierType::TaxId` comment from `// EIN, TIN, ITIN` to `// TIN, ITIN (EIN has its own variant)`.

## Test plan

- [x] `just preflight` (fmt + clippy + arch-check + 6404 tests, all green)
- [x] 11 new tests cover: valid IRS prefix, invalid prefix, ITIN-format rejection, non-tax-id inputs, scanner producing both `Ein` and `TaxId` for valid EINs, scanner producing only `TaxId` for invalid-prefix inputs, `From<IdentifierType::Ein>`, and `detect_government_identifier` returning `Ein` for valid EINs while `00-0000001` and ITINs continue to fall through to `TaxId`.

## Pre-review notes

- Scanner tests for `domains.rs` live in `scanner/mod.rs` (existing convention) — the pre-review gate's missing-test-file finding is a false positive.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)