### PR TITLE
fix(identifiers): add 6 IdentifierType variants for PiiType symmetry

### DIFF
--- a/crates/octarine/src/observe/pii/types.rs
+++ b/crates/octarine/src/observe/pii/types.rs
@@ -507,6 +507,12 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::Jwt => Self::Jwt,
             IdentifierType::ApiKey => Self::ApiKey,
             IdentifierType::SessionId => Self::SessionId,
+            IdentifierType::OAuthToken => Self::OAuthToken,
+            IdentifierType::SshKey => Self::SshKey,
+            IdentifierType::OnePasswordToken => Self::OnePasswordToken,
+            IdentifierType::OnePasswordVaultRef => Self::OnePasswordVaultRef,
+            IdentifierType::BearerToken => Self::BearerToken,
+            IdentifierType::UrlWithCredentials => Self::UrlWithCredentials,
             // fallback: no dedicated PiiType variants for developer tokens
             IdentifierType::GitHubToken
             | IdentifierType::GitLabToken
@@ -925,6 +931,27 @@ mod tests {
         assert_eq!(PiiType::from(IdentifierType::Jwt), PiiType::Jwt);
         assert_eq!(PiiType::from(IdentifierType::ApiKey), PiiType::ApiKey);
         assert_eq!(PiiType::from(IdentifierType::SessionId), PiiType::SessionId);
+        assert_eq!(
+            PiiType::from(IdentifierType::OAuthToken),
+            PiiType::OAuthToken
+        );
+        assert_eq!(PiiType::from(IdentifierType::SshKey), PiiType::SshKey);
+        assert_eq!(
+            PiiType::from(IdentifierType::OnePasswordToken),
+            PiiType::OnePasswordToken
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::OnePasswordVaultRef),
+            PiiType::OnePasswordVaultRef
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::BearerToken),
+            PiiType::BearerToken
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::UrlWithCredentials),
+            PiiType::UrlWithCredentials
+        );
 
         // Database
         assert_eq!(

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -307,10 +307,17 @@ impl StreamingScanner {
                 | IdentifierType::Port
                 | IdentifierType::Jwt
                 | IdentifierType::ApiKey
-                | IdentifierType::SessionId => {
-                    // These are detected by network module's find_all_in_text
-                    // but we don't have specific find_X_in_text methods for them
-                    // Skip for now in selective scan
+                | IdentifierType::SessionId
+                | IdentifierType::OAuthToken
+                | IdentifierType::SshKey
+                | IdentifierType::OnePasswordToken
+                | IdentifierType::OnePasswordVaultRef
+                | IdentifierType::BearerToken
+                | IdentifierType::UrlWithCredentials => {
+                    // These are detected by network/token modules via
+                    // find_all_in_text / is_X predicates, but the streaming
+                    // scanner has no dedicated find_X_in_text methods for
+                    // them. Skip for now in selective scan.
                     continue;
                 }
 

--- a/crates/octarine/src/primitives/identifiers/token/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/token/detection/mod.rs
@@ -270,12 +270,12 @@ pub fn is_token_identifier(value: &str) -> bool {
 /// maps the richer `TokenType` enum to the cross-domain `IdentifierType`:
 ///
 /// - Dedicated variants (`Jwt`, `GitHub` → `GitHubToken`, `GitLab` →
-///   `GitLabToken`, `AwsAccessKey`, `AwsSessionToken`, `SessionId`) map
-///   directly.
-/// - `UrlWithCredentials` maps to `Url`.
-/// - SSH keys/fingerprints map to `HighEntropyString` (no dedicated SSH
-///   variant in `IdentifierType`; matches the `From<IdentifierType>` bridge
-///   fallback in `observe/pii/types.rs`).
+///   `GitLabToken`, `AwsAccessKey`, `AwsSessionToken`, `SessionId`,
+///   `SshKey`, `OnePasswordToken`, `OnePasswordVaultRef`, `BearerToken`,
+///   `UrlWithCredentials`) map directly.
+/// - `AwsSecretKey` maps to `HighEntropyString` — AWS secrets have no
+///   dedicated variant and match the `From<IdentifierType>` bridge
+///   fallback in `observe/pii/types.rs`.
 /// - All other provider-specific tokens (Stripe, Square, Shopify, Mailgun,
 ///   Discord, Slack, Telegram, OpenAI, etc.) map to `ApiKey`.
 #[must_use]
@@ -288,21 +288,21 @@ pub fn detect_token_identifier(value: &str) -> Option<IdentifierType> {
         TokenType::AwsAccessKey => IdentifierType::AwsAccessKey,
         TokenType::AwsSessionToken => IdentifierType::AwsSessionToken,
         TokenType::SessionId => IdentifierType::SessionId,
-        TokenType::UrlWithCredentials => IdentifierType::Url,
-        // No SshKey variant in IdentifierType; HighEntropyString matches the
-        // observe/pii/types.rs bridge fallback for SSH material.
-        TokenType::SshPrivateKey
-        | TokenType::SshPublicKey
-        | TokenType::SshFingerprint
-        | TokenType::AwsSecretKey => IdentifierType::HighEntropyString,
+        TokenType::UrlWithCredentials => IdentifierType::UrlWithCredentials,
+        TokenType::SshPrivateKey | TokenType::SshPublicKey | TokenType::SshFingerprint => {
+            IdentifierType::SshKey
+        }
+        TokenType::OnePasswordServiceToken => IdentifierType::OnePasswordToken,
+        TokenType::OnePasswordVaultRef => IdentifierType::OnePasswordVaultRef,
+        TokenType::BearerToken => IdentifierType::BearerToken,
+        // AWS secret keys have no dedicated variant; HighEntropyString
+        // matches the observe/pii/types.rs bridge fallback.
+        TokenType::AwsSecretKey => IdentifierType::HighEntropyString,
         // All remaining provider-specific tokens collapse to the generic
         // ApiKey variant.
         TokenType::GcpApiKey
         | TokenType::AzureKey
         | TokenType::StripeKey
-        | TokenType::OnePasswordServiceToken
-        | TokenType::OnePasswordVaultRef
-        | TokenType::BearerToken
         | TokenType::GenericApiKey
         | TokenType::SquareToken
         | TokenType::PayPalToken
@@ -573,10 +573,39 @@ mod tests {
             Some(IdentifierType::SessionId)
         );
 
-        // SSH keys collapse to HighEntropyString
+        // SSH keys/fingerprints map to dedicated SshKey variant
         assert_eq!(
             detect_token_identifier("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8..."),
-            Some(IdentifierType::HighEntropyString)
+            Some(IdentifierType::SshKey)
+        );
+
+        // 1Password tokens and vault references
+        let op_token = format!(
+            "ops_{}",
+            "eyJzaWduSW5BZGRyZXNzIjoiaHR0cHM6Ly9teS4xcGFzc3dvcmQuY29tIiwidXNlckF1dGgiOiJ5"
+        );
+        assert_eq!(
+            detect_token_identifier(&op_token),
+            Some(IdentifierType::OnePasswordToken)
+        );
+        assert_eq!(
+            detect_token_identifier("op://Production/Database/password"),
+            Some(IdentifierType::OnePasswordVaultRef)
+        );
+
+        // Bearer tokens
+        assert_eq!(
+            detect_token_identifier(&format!(
+                "Bearer {}",
+                "abcdefghijklmnopqrstuvwxyz0123456789"
+            )),
+            Some(IdentifierType::BearerToken)
+        );
+
+        // URLs with embedded credentials
+        assert_eq!(
+            detect_token_identifier("https://user:pass@example.com/path"),
+            Some(IdentifierType::UrlWithCredentials)
         );
 
         // Provider-specific tokens collapse to ApiKey

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -47,7 +47,13 @@ pub enum IdentifierType {
     Jwt,
     ApiKey,
     SessionId,
-    HighEntropyString, // Entropy-detected potential secrets
+    OAuthToken,          // Generic OAuth 2.0 access/refresh tokens
+    SshKey,              // SSH public/private keys and fingerprints
+    OnePasswordToken,    // 1Password service account tokens (ops_...)
+    OnePasswordVaultRef, // 1Password secret reference (op://vault/item/field)
+    BearerToken,         // Authorization: Bearer <token>
+    UrlWithCredentials,  // URL with embedded user:pass@host credentials
+    HighEntropyString,   // Entropy-detected potential secrets
 
     // Database identifiers
     ConnectionString,


### PR DESCRIPTION
## Summary

- Adds 6 variants to `IdentifierType` — `OAuthToken`, `SshKey`, `OnePasswordToken`, `OnePasswordVaultRef`, `BearerToken`, `UrlWithCredentials` — completing bidirectional registry symmetry with `PiiType`.
- Wires each new variant into `From<IdentifierType> for PiiType` as a direct one-to-one mapping.
- Promotes `detect_token_identifier` from fallback mappings (`HighEntropyString` / `ApiKey` / `Url`) to the new dedicated variants. `AwsSecretKey` continues to map to `HighEntropyString` (no dedicated variant).
- Extends the `StreamingScanner::scan_types` skip-group for token variants that have no dedicated `find_X_in_text` method.

## Test plan

- [x] `just test-mod "primitives::identifiers::token::detection"` — 102 passed
- [x] `just test-mod "observe::pii::types"` — 21 passed (incl. new `from_identifier_type_direct_mappings` assertions for all 6 new variants)
- [x] `just preflight` — fmt, clippy, arch-check, full test suite (6,404 passed, 0 failed)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)