### PR TITLE
refactor(io): remove module-level dead_code suppression in ops.rs

### DIFF
--- a/crates/octarine/src/io/ops.rs
+++ b/crates/octarine/src/io/ops.rs
@@ -32,9 +32,6 @@
 //! let contents = ops.read_file_sync("config.json")?;
 //! ```
 
-// This module provides public APIs for library consumers
-#![allow(dead_code)]
-
 use std::io::{Read, Write};
 use std::path::Path;
 
@@ -731,16 +728,6 @@ impl SecureFileOps {
             AuditLevel::Full | AuditLevel::Debug
         ) {
             observe::info(operation, message);
-        }
-    }
-
-    #[allow(dead_code)]
-    fn log_warn(&self, operation: &str, message: String) {
-        if matches!(
-            self.config.audit_level,
-            AuditLevel::Warnings | AuditLevel::Full | AuditLevel::Debug
-        ) {
-            observe::warn(operation, message);
         }
     }
 


### PR DESCRIPTION
## Summary

- Deletes the blanket `#![allow(dead_code)]` at `crates/octarine/src/io/ops.rs:36` that was hiding the module's entire 1049-line surface.
- Deletes the one genuinely-dead item that the allow was covering: the private `log_warn` helper (which already carried its own item-level `#[allow(dead_code)]` — the smoking gun).
- No other items surfaced when the allow was removed. Public APIs on `SecureFileOps`, `SecureFileOpsBuilder`, `SecureFileOpsConfig`, and `AuditLevel` are reachable through the `pub use` chain at `io/mod.rs:175` and exercised by `crates/octarine/tests/io/secure_file_ops.rs` (405 LOC) — so the lint correctly leaves them alone.

**Net change**: -13 lines. No behavior change.

## Test plan

- [x] `just clippy` — clean with `-D warnings`, no new dead_code warnings
- [x] `just test-mod "io::ops"` — 16/16 unit tests pass
- [x] `cargo test -p octarine --test io_integration` — 43/43 integration tests pass
- [x] `just arch-check` — clean
- [x] `just preflight` — full gate passes

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)