### PR TITLE
refactor: reduce complexity in detection dispatch and shutdown hooks

### DIFF
--- a/crates/octarine/src/primitives/data/paths/filetype/detection.rs
+++ b/crates/octarine/src/primitives/data/paths/filetype/detection.rs
@@ -152,6 +152,36 @@ static CERTIFICATE_EXTENSIONS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
 });
 
 // ============================================================================
+// Dispatch Tables
+// ============================================================================
+
+// Each entry pairs a membership set with the FileCategory it maps to.
+// Order matters — security-sensitive categories are checked first so that
+// ambiguous extensions like `.key` resolve to Credential rather than a
+// benign category further down the list.
+type ExtensionRule = (&'static Lazy<HashSet<&'static str>>, FileCategory);
+
+static EXTENSION_RULES: &[ExtensionRule] = &[
+    (&CREDENTIAL_EXTENSIONS, FileCategory::Credential),
+    (&CERTIFICATE_EXTENSIONS, FileCategory::Certificate),
+    (&EXECUTABLE_EXTENSIONS, FileCategory::Executable),
+    (&LIBRARY_EXTENSIONS, FileCategory::Library),
+    (&IMAGE_EXTENSIONS, FileCategory::Image),
+    (&AUDIO_EXTENSIONS, FileCategory::Audio),
+    (&VIDEO_EXTENSIONS, FileCategory::Video),
+    (&DOCUMENT_EXTENSIONS, FileCategory::Document),
+    (&SPREADSHEET_EXTENSIONS, FileCategory::Spreadsheet),
+    (&PRESENTATION_EXTENSIONS, FileCategory::Presentation),
+    (&TEXT_EXTENSIONS, FileCategory::Text),
+    (&SOURCE_CODE_EXTENSIONS, FileCategory::SourceCode),
+    (&SCRIPT_EXTENSIONS, FileCategory::Script),
+    (&CONFIG_EXTENSIONS, FileCategory::Config),
+    (&DATA_EXTENSIONS, FileCategory::Data),
+    (&ARCHIVE_EXTENSIONS, FileCategory::Archive),
+    (&COMPRESSED_EXTENSIONS, FileCategory::Compressed),
+];
+
+// ============================================================================
 // Detection Functions
 // ============================================================================
 
@@ -219,79 +249,31 @@ fn get_extension_lower(path: &str) -> Option<String> {
 
 /// Detect category by extension
 fn detect_by_extension(ext: &str) -> FileCategory {
-    // Order matters - check more specific/sensitive first
-    if CREDENTIAL_EXTENSIONS.contains(ext) {
-        return FileCategory::Credential;
-    }
-    if CERTIFICATE_EXTENSIONS.contains(ext) {
-        return FileCategory::Certificate;
-    }
-    if EXECUTABLE_EXTENSIONS.contains(ext) {
-        return FileCategory::Executable;
-    }
-    if LIBRARY_EXTENSIONS.contains(ext) {
-        return FileCategory::Library;
-    }
-    if IMAGE_EXTENSIONS.contains(ext) {
-        return FileCategory::Image;
-    }
-    if AUDIO_EXTENSIONS.contains(ext) {
-        return FileCategory::Audio;
-    }
-    if VIDEO_EXTENSIONS.contains(ext) {
-        return FileCategory::Video;
-    }
-    if DOCUMENT_EXTENSIONS.contains(ext) {
-        return FileCategory::Document;
-    }
-    if SPREADSHEET_EXTENSIONS.contains(ext) {
-        return FileCategory::Spreadsheet;
-    }
-    if PRESENTATION_EXTENSIONS.contains(ext) {
-        return FileCategory::Presentation;
-    }
-    if TEXT_EXTENSIONS.contains(ext) {
-        return FileCategory::Text;
-    }
-    if SOURCE_CODE_EXTENSIONS.contains(ext) {
-        return FileCategory::SourceCode;
-    }
-    if SCRIPT_EXTENSIONS.contains(ext) {
-        return FileCategory::Script;
-    }
-    if CONFIG_EXTENSIONS.contains(ext) {
-        return FileCategory::Config;
-    }
-    if DATA_EXTENSIONS.contains(ext) {
-        return FileCategory::Data;
-    }
-    if ARCHIVE_EXTENSIONS.contains(ext) {
-        return FileCategory::Archive;
-    }
-    if COMPRESSED_EXTENSIONS.contains(ext) {
-        return FileCategory::Compressed;
-    }
-
-    FileCategory::Unknown
+    EXTENSION_RULES
+        .iter()
+        .find(|(set, _)| set.contains(ext))
+        .map(|(_, cat)| *cat)
+        .unwrap_or(FileCategory::Unknown)
 }
 
-/// Detect category by special filename patterns
-fn detect_by_filename(path: &str) -> Option<FileCategory> {
-    let filename = path.rsplit(['/', '\\']).next()?;
-    let lower = filename.to_lowercase();
+// ============================================================================
+// Filename Predicates
+// ============================================================================
+// Rule order in FILENAME_RULES matches the original if-chain so that
+// overlapping cases resolve identically (e.g. `.htpasswd` matches the
+// credential rule before the hidden-file rule, and `.env.local` matches
+// the env rule before the hidden-file rule).
 
-    // Temporary files
-    if lower.ends_with('~')
+fn is_temporary_filename(lower: &str) -> bool {
+    lower.ends_with('~')
         || lower.starts_with('#')
         || lower.ends_with(".tmp")
         || lower.ends_with(".temp")
         || lower.ends_with(".swp")
-    {
-        return Some(FileCategory::Temporary);
-    }
+}
 
-    // Credential files by name
-    if lower.contains("password")
+fn is_credential_filename(lower: &str) -> bool {
+    lower.contains("password")
         || lower.contains("secret")
         || lower.contains("credential")
         || lower.contains("api_key")
@@ -299,26 +281,41 @@ fn detect_by_filename(path: &str) -> Option<FileCategory> {
         || lower == ".htpasswd"
         || lower == "shadow"
         || lower == "passwd"
-    {
-        return Some(FileCategory::Credential);
-    }
+}
 
-    // SSH keys
-    if lower.starts_with("id_") || lower == "authorized_keys" || lower == "known_hosts" {
-        return Some(FileCategory::Key);
-    }
+fn is_ssh_key_filename(lower: &str) -> bool {
+    lower.starts_with("id_") || lower == "authorized_keys" || lower == "known_hosts"
+}
 
-    // Environment files
-    if lower == ".env" || lower.starts_with(".env.") {
-        return Some(FileCategory::Credential);
-    }
+fn is_env_filename(lower: &str) -> bool {
+    lower == ".env" || lower.starts_with(".env.")
+}
 
-    // Hidden files (dotfiles without extension) - must check after specific dotfiles
-    if lower.starts_with('.') && !lower[1..].contains('.') {
-        return Some(FileCategory::Hidden);
-    }
+// Dotfile with no secondary extension (e.g. `.bashrc`, not `.bash.bak`).
+// Char-iterator form avoids `lower[1..]` which would trip clippy::indexing_slicing.
+fn is_hidden_filename(lower: &str) -> bool {
+    let mut chars = lower.chars();
+    matches!(chars.next(), Some('.')) && !chars.any(|c| c == '.')
+}
 
-    None
+type FilenameRule = (fn(&str) -> bool, FileCategory);
+
+static FILENAME_RULES: &[FilenameRule] = &[
+    (is_temporary_filename, FileCategory::Temporary),
+    (is_credential_filename, FileCategory::Credential),
+    (is_ssh_key_filename, FileCategory::Key),
+    (is_env_filename, FileCategory::Credential),
+    (is_hidden_filename, FileCategory::Hidden),
+];
+
+/// Detect category by special filename patterns
+fn detect_by_filename(path: &str) -> Option<FileCategory> {
+    let filename = path.rsplit(['/', '\\']).next()?;
+    let lower = filename.to_lowercase();
+    FILENAME_RULES
+        .iter()
+        .find(|(pred, _)| pred(&lower))
+        .map(|(_, cat)| *cat)
 }
 
 // ============================================================================

--- a/crates/octarine/src/primitives/identifiers/location/validation.rs
+++ b/crates/octarine/src/primitives/identifiers/location/validation.rs
@@ -226,18 +226,21 @@ fn validate_gps_coordinate_impl(trimmed: &str) -> Result<GpsFormat, Problem> {
 pub fn validate_street_address(address: &str) -> Result<(), Problem> {
     let trimmed = address.trim();
 
-    // Null byte check (CRITICAL - prevents string truncation in C APIs)
-    if trimmed.contains('\0') {
+    // Critical security checks first (null byte, injection, traversal) so
+    // attacks fail fast before any format validation runs.
+    if is_null_byte_present(trimmed) {
         return Err(Problem::Validation(
             "Street address contains null byte".into(),
         ));
     }
-
-    // Injection pattern check (CRITICAL - addresses used in file paths/commands)
-    // Must check BEFORE other validation to fail fast on attacks
     if is_injection_pattern_present(trimmed) {
         return Err(Problem::Validation(
             "Street address contains injection pattern".into(),
+        ));
+    }
+    if is_path_traversal_present(trimmed) {
+        return Err(Problem::Validation(
+            "Street address contains path traversal pattern".into(),
         ));
     }
 
@@ -245,50 +248,52 @@ pub fn validate_street_address(address: &str) -> Result<(), Problem> {
     // Detection patterns require specific US formats with recognized suffixes.
     // Validator is intentionally lenient for international/non-standard addresses.
 
-    // Path traversal check (addresses may be used in file paths)
-    if trimmed.contains("..") {
-        return Err(Problem::Validation(
-            "Street address contains path traversal pattern".into(),
-        ));
-    }
-
-    // Length validation (5-200 characters is reasonable)
     if trimmed.len() < 5 || trimmed.len() > 200 {
         return Err(Problem::Validation(
             "Street address must be 5-200 characters".into(),
         ));
     }
-
-    // Must contain at least one digit (street number)
-    if !trimmed.chars().any(|c| c.is_ascii_digit()) {
+    if !is_street_number_present(trimmed) {
         return Err(Problem::Validation(
             "Street address must contain a street number".into(),
         ));
     }
-
-    // Must contain at least one letter (street name)
-    if !trimmed.chars().any(|c| c.is_ascii_alphabetic()) {
+    if !is_street_name_present(trimmed) {
         return Err(Problem::Validation(
             "Street address must contain a street name".into(),
         ));
     }
-
-    // Check for valid characters (alphanumeric + common address chars)
-    if !trimmed.chars().all(|c| {
-        c.is_ascii_alphanumeric()
-            || c == ' '
-            || c == ','
-            || c == '.'
-            || c == '-'
-            || c == '#'
-            || c == '/'
-    }) {
+    if !trimmed.chars().all(is_valid_address_character) {
         return Err(Problem::Validation(
             "Street address contains invalid characters".into(),
         ));
     }
 
     Ok(())
+}
+
+// ============================================================================
+// Street Address Predicates
+// ============================================================================
+
+fn is_null_byte_present(s: &str) -> bool {
+    s.contains('\0')
+}
+
+fn is_path_traversal_present(s: &str) -> bool {
+    s.contains("..")
+}
+
+fn is_street_number_present(s: &str) -> bool {
+    s.chars().any(|c| c.is_ascii_digit())
+}
+
+fn is_street_name_present(s: &str) -> bool {
+    s.chars().any(|c| c.is_ascii_alphabetic())
+}
+
+fn is_valid_address_character(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, ' ' | ',' | '.' | '-' | '#' | '/')
 }
 
 /// Validate postal code format (returns Result with postal code type)

--- a/crates/octarine/src/runtime/shutdown/hooks.rs
+++ b/crates/octarine/src/runtime/shutdown/hooks.rs
@@ -277,104 +277,10 @@ impl ShutdownCoordinator {
         // Execute hooks with overall timeout
         let timeout_result = tokio::time::timeout(self.timeout, async {
             for hook in hooks.iter() {
-                // Use hook's individual timeout or default
-                let hook_timeout = hook.timeout.unwrap_or(default_hook_timeout);
-                let max_attempts = hook.max_retries.saturating_add(1); // retries + initial attempt
-
-                let retry_info = if hook.max_retries > 0 {
-                    format!(", max_retries={}", hook.max_retries)
-                } else {
-                    String::new()
-                };
-
-                observe::debug(
-                    "shutdown_hook_executing",
-                    format!(
-                        "Executing shutdown hook '{}' with {}ms timeout{}",
-                        hook.name,
-                        hook_timeout.as_millis(),
-                        retry_info
-                    ),
-                );
-
-                let hook_start = std::time::Instant::now();
-                let mut last_error = None;
-                let mut hook_succeeded = false;
-                let mut hook_timed_out = false;
-
-                // Try execution with retries
-                for attempt in 0..max_attempts {
-                    if attempt > 0 {
-                        observe::debug(
-                            "shutdown_hook_retry",
-                            format!(
-                                "Retrying shutdown hook '{}' (attempt {}/{})",
-                                hook.name,
-                                attempt.saturating_add(1),
-                                max_attempts
-                            ),
-                        );
-                        tokio::time::sleep(hook.retry_delay).await;
-                    }
-
-                    let result = tokio::time::timeout(hook_timeout, (hook.func)()).await;
-
-                    match result {
-                        Ok(Ok(())) => {
-                            hook_succeeded = true;
-                            break;
-                        }
-                        Ok(Err(e)) => {
-                            last_error = Some(e);
-                            // Continue to retry if we have attempts left
-                        }
-                        Err(_) => {
-                            hook_timed_out = true;
-                            // Timeout - don't retry, timeouts are usually not transient
-                            break;
-                        }
-                    }
-                }
-
-                let hook_duration = hook_start.elapsed();
-
-                if hook_succeeded {
-                    succeeded = succeeded.saturating_add(1);
-                    observe::info(
-                        "shutdown_hook_completed",
-                        format!(
-                            "Shutdown hook '{}' completed successfully in {}ms",
-                            hook.name,
-                            hook_duration.as_millis()
-                        ),
-                    );
-                } else if hook_timed_out {
-                    timed_out = timed_out.saturating_add(1);
-                    observe::warn(
-                        "shutdown_hook_timeout",
-                        format!(
-                            "Shutdown hook '{}' timed out after {}ms",
-                            hook.name,
-                            hook_timeout.as_millis()
-                        ),
-                    );
-                } else if let Some(ref e) = last_error {
-                    failed = failed.saturating_add(1);
-                    let retry_msg = if hook.max_retries > 0 {
-                        format!(" after {} retries", hook.max_retries)
-                    } else {
-                        String::new()
-                    };
-                    observe::error(
-                        "shutdown_hook_failed",
-                        format!(
-                            "Shutdown hook '{}' failed{} in {}ms: {}",
-                            hook.name,
-                            retry_msg,
-                            hook_duration.as_millis(),
-                            e
-                        ),
-                    );
+                match execute_single_hook(hook, default_hook_timeout).await {
+                    HookOutcome::Succeeded => succeeded = succeeded.saturating_add(1),
+                    HookOutcome::TimedOut => timed_out = timed_out.saturating_add(1),
+                    HookOutcome::Failed => failed = failed.saturating_add(1),
                 }
             }
         })
@@ -424,6 +330,111 @@ impl ShutdownCoordinator {
 
         stats
     }
+}
+
+// ============================================================================
+// Per-Hook Execution
+// ============================================================================
+
+#[derive(Debug, Clone, Copy)]
+enum HookOutcome {
+    Succeeded,
+    TimedOut,
+    Failed,
+}
+
+/// Execute one shutdown hook with its configured timeout and retry policy.
+///
+/// Encapsulates the retry loop, timeout enforcement, and per-outcome
+/// observability so that `run_hooks` only has to aggregate counts.
+async fn execute_single_hook(hook: &ShutdownHook, default_timeout: Duration) -> HookOutcome {
+    let hook_timeout = hook.timeout.unwrap_or(default_timeout);
+    let max_attempts = hook.max_retries.saturating_add(1); // retries + initial attempt
+
+    let retry_info = if hook.max_retries > 0 {
+        format!(", max_retries={}", hook.max_retries)
+    } else {
+        String::new()
+    };
+
+    observe::debug(
+        "shutdown_hook_executing",
+        format!(
+            "Executing shutdown hook '{}' with {}ms timeout{}",
+            hook.name,
+            hook_timeout.as_millis(),
+            retry_info
+        ),
+    );
+
+    let hook_start = std::time::Instant::now();
+    let mut last_error = None;
+
+    for attempt in 0..max_attempts {
+        if attempt > 0 {
+            observe::debug(
+                "shutdown_hook_retry",
+                format!(
+                    "Retrying shutdown hook '{}' (attempt {}/{})",
+                    hook.name,
+                    attempt.saturating_add(1),
+                    max_attempts
+                ),
+            );
+            tokio::time::sleep(hook.retry_delay).await;
+        }
+
+        match tokio::time::timeout(hook_timeout, (hook.func)()).await {
+            Ok(Ok(())) => {
+                observe::info(
+                    "shutdown_hook_completed",
+                    format!(
+                        "Shutdown hook '{}' completed successfully in {}ms",
+                        hook.name,
+                        hook_start.elapsed().as_millis()
+                    ),
+                );
+                return HookOutcome::Succeeded;
+            }
+            Ok(Err(e)) => {
+                last_error = Some(e);
+                // Continue to retry if we have attempts left
+            }
+            Err(_) => {
+                // Timeout - don't retry, timeouts are usually not transient
+                observe::warn(
+                    "shutdown_hook_timeout",
+                    format!(
+                        "Shutdown hook '{}' timed out after {}ms",
+                        hook.name,
+                        hook_timeout.as_millis()
+                    ),
+                );
+                return HookOutcome::TimedOut;
+            }
+        }
+    }
+
+    let retry_msg = if hook.max_retries > 0 {
+        format!(" after {} retries", hook.max_retries)
+    } else {
+        String::new()
+    };
+    let error_display = last_error
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "no error captured".to_string());
+    observe::error(
+        "shutdown_hook_failed",
+        format!(
+            "Shutdown hook '{}' failed{} in {}ms: {}",
+            hook.name,
+            retry_msg,
+            hook_start.elapsed().as_millis(),
+            error_display
+        ),
+    );
+    HookOutcome::Failed
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Collapses four high-complexity functions flagged by codebase audit (cognitive
complexity ~14–20) into table-driven or helper-based implementations. This is
a pure behavioural-parity refactor — all existing tests pass unchanged and no
public APIs changed.

- **`detect_by_extension`** (`primitives/data/paths/filetype/detection.rs`) —
  18-branch if-chain replaced with `EXTENSION_RULES` static slice +
  `.iter().find()`. Security-sensitive ordering preserved.
- **`detect_by_filename`** (same file) — 5 `is_*_filename` predicates
  extracted into `FILENAME_RULES` table with `fn(&str) -> bool` pointers
  (heterogeneous operators: `ends_with` / `starts_with` / `contains` /
  equality). Incidental fix: `is_hidden_filename` rewritten via char
  iterator so it no longer trips `clippy::indexing_slicing`.
- **`run_hooks`** (`runtime/shutdown/hooks.rs`) — per-hook retry/timeout/
  logging block extracted into `async fn execute_single_hook` returning a
  private `HookOutcome` enum. Main loop now a 3-arm match on counts;
  outcome-specific observability lives inside the helper.
- **`validate_street_address`** (`primitives/identifiers/location/validation.rs`) —
  4 boolean predicates (`is_null_byte_present`, `is_path_traversal_present`,
  `is_street_number_present`, `is_street_name_present`) and
  `is_valid_address_character` extracted as private helpers.

Net diff: 3 files, +222 / −209.

## Test plan

- [x] `just test-mod primitives::data::paths::filetype::detection` — 42/42 pass
- [x] `just test-mod runtime::shutdown::hooks` — 14/14 pass
- [x] `just test-mod primitives::identifiers::location::validation` — 52/52 pass (includes 10 proptest strategies)
- [x] `just clippy` — clean under `-D warnings`
- [x] `just preflight` — 6405 unit tests + integration suites + 241 doctests, zero failures
- [x] Rule ordering preserved — `.key` still resolves to `Credential` (security-first); `.htpasswd` still wins over `.Hidden`; `.env.local` still resolves to `Credential`.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)