### PR TITLE
feat(identifiers): add dedicated UK NINO identifier

### DIFF
--- a/crates/octarine/src/identifiers/builder/government.rs
+++ b/crates/octarine/src/identifiers/builder/government.rs
@@ -475,6 +475,88 @@ impl GovernmentBuilder {
     }
 
     // ========================================================================
+    // UK NINO Operations
+    // ========================================================================
+
+    /// Check if value is a valid UK National Insurance Number (NINO)
+    #[must_use]
+    pub fn is_uk_ni(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_uk_ni(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all UK NINOs in text
+    #[must_use]
+    pub fn find_uk_nis_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let results = self.inner.find_uk_nis_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !results.is_empty() {
+                increment_by(metric_names::detected(), results.len() as u64);
+                increment_by(metric_names::government_data_found(), results.len() as u64);
+                event::debug(format!("Found {} UK NINO(s) in text", results.len()));
+            }
+        }
+        results
+    }
+
+    /// Redact a UK NINO with explicit strategy
+    #[must_use]
+    pub fn redact_uk_ni_with_strategy(
+        &self,
+        ni: &str,
+        strategy: NationalIdRedactionStrategy,
+    ) -> String {
+        let start = Instant::now();
+        let result = self.inner.redact_uk_ni_with_strategy(ni, strategy);
+        if self.emit_events {
+            record(
+                metric_names::redact_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
+        result
+    }
+
+    /// Redact all UK NINOs in text with explicit strategy
+    ///
+    /// Only NINOs that pass HMRC prefix/suffix validation are redacted;
+    /// labels ("NI: ", "NINO ", ...) are preserved.
+    #[must_use]
+    pub fn redact_uk_nis_in_text_with_strategy(
+        &self,
+        text: &str,
+        strategy: NationalIdRedactionStrategy,
+    ) -> String {
+        let start = Instant::now();
+        let result = self
+            .inner
+            .redact_uk_nis_in_text_with_strategy(text, strategy);
+        if self.emit_events {
+            record(
+                metric_names::redact_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
+        result
+    }
+
+    // ========================================================================
     // Vehicle ID Operations
     // ========================================================================
 

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -137,7 +137,8 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             | PiiType::PolandPesel
             | PiiType::ItalyFiscalCode
             | PiiType::SpainNif
-            | PiiType::SpainNie => {
+            | PiiType::SpainNie
+            | PiiType::UkNi => {
                 // Generic government ID redaction routes through
                 // redact_all_government_ids_in_text_with_policy, which already
                 // covers all country-specific finders.

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -120,6 +120,9 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
     if !government.find_spain_nies_in_text(text).is_empty() {
         pii_types.push(PiiType::SpainNie);
     }
+    if !government.find_uk_nis_in_text(text).is_empty() {
+        pii_types.push(PiiType::UkNi);
+    }
 }
 
 /// Scan for medical PII (MRN, NPI, insurance, ICD codes, prescriptions)

--- a/crates/octarine/src/observe/pii/types.rs
+++ b/crates/octarine/src/observe/pii/types.rs
@@ -90,6 +90,8 @@ pub enum PiiType {
     SpainNif,
     /// Spanish NIE (Numero de Identidad de Extranjero)
     SpainNie,
+    /// UK National Insurance Number (NINO)
+    UkNi,
 
     // =========================================================================
     // Medical Domain (PHI - Protected Health Information)
@@ -240,6 +242,7 @@ impl PiiType {
             Self::ItalyFiscalCode => "italy_fiscal_code",
             Self::SpainNif => "spain_nif",
             Self::SpainNie => "spain_nie",
+            Self::UkNi => "uk_ni",
             // Medical
             Self::Mrn => "mrn",
             Self::Npi => "npi",
@@ -318,7 +321,8 @@ impl PiiType {
             | Self::PolandPesel
             | Self::ItalyFiscalCode
             | Self::SpainNif
-            | Self::SpainNie => "government",
+            | Self::SpainNie
+            | Self::UkNi => "government",
             Self::Mrn
             | Self::Npi
             | Self::InsuranceNumber
@@ -369,7 +373,7 @@ impl PiiType {
             Self::Ssn | Self::DriverLicense | Self::Passport | Self::Ein | Self::TaxId | Self::NationalId | Self::Vin |
             Self::KoreaRrn | Self::AustraliaTfn | Self::AustraliaAbn | Self::IndiaAadhaar | Self::IndiaPan |
             Self::SingaporeNric | Self::FinlandHetu | Self::PolandPesel | Self::ItalyFiscalCode |
-            Self::SpainNif | Self::SpainNie |
+            Self::SpainNif | Self::SpainNie | Self::UkNi |
             // Medical (HIPAA)
             Self::Mrn | Self::Npi | Self::InsuranceNumber | Self::DeaNumber | Self::IcdCode | Self::PrescriptionNumber |
             // Biometric (irreplaceable)
@@ -393,7 +397,7 @@ impl PiiType {
             // EU-member country-specific government IDs (non-EU IDs like KoreaRrn,
             // AustraliaTfn/Abn, IndiaAadhaar/Pan, SingaporeNric are protected by
             // their own regimes — PIPA/Privacy Act 1988/DPDPA/PDPA — not GDPR)
-            Self::FinlandHetu | Self::PolandPesel | Self::ItalyFiscalCode | Self::SpainNif | Self::SpainNie |
+            Self::FinlandHetu | Self::PolandPesel | Self::ItalyFiscalCode | Self::SpainNif | Self::SpainNie | Self::UkNi |
             // Financial — IBAN identifies an EU account holder (Recital 30 /
             // Art. 4(1)). Crypto addresses are pseudonymous by design and are
             // excluded unless linked to an identifiable person upstream.
@@ -540,6 +544,7 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::ItalyFiscalCode => Self::ItalyFiscalCode,
             IdentifierType::SpainNif => Self::SpainNif,
             IdentifierType::SpainNie => Self::SpainNie,
+            IdentifierType::UkNi => Self::UkNi,
 
             // Organizational
             IdentifierType::EmployeeId => Self::EmployeeId,
@@ -755,17 +760,18 @@ mod tests {
 
     #[test]
     fn test_country_specific_government_classifications() {
-        // EU-member IDs are GDPR-protected
+        // EU-member (and UK GDPR) IDs are GDPR-protected
         for pii in [
             PiiType::FinlandHetu,
             PiiType::PolandPesel,
             PiiType::ItalyFiscalCode,
             PiiType::SpainNif,
             PiiType::SpainNie,
+            PiiType::UkNi,
         ] {
             assert_eq!(pii.domain(), "government", "{pii:?} domain");
             assert!(pii.is_high_risk(), "{pii:?} should be high-risk");
-            assert!(pii.is_gdpr_protected(), "{pii:?} is EU, expect GDPR");
+            assert!(pii.is_gdpr_protected(), "{pii:?} is EU/UK, expect GDPR");
             assert!(!pii.is_pci_protected(), "{pii:?} not PCI");
             assert!(!pii.is_hipaa_protected(), "{pii:?} not HIPAA");
             assert!(!pii.is_secret(), "{pii:?} not a secret");
@@ -793,6 +799,7 @@ mod tests {
         assert_eq!(PiiType::KoreaRrn.name(), "korea_rrn");
         assert_eq!(PiiType::ItalyFiscalCode.name(), "italy_fiscal_code");
         assert_eq!(PiiType::SpainNie.name(), "spain_nie");
+        assert_eq!(PiiType::UkNi.name(), "uk_ni");
     }
 
     #[test]
@@ -1003,6 +1010,7 @@ mod tests {
         );
         assert_eq!(PiiType::from(IdentifierType::SpainNif), PiiType::SpainNif);
         assert_eq!(PiiType::from(IdentifierType::SpainNie), PiiType::SpainNie);
+        assert_eq!(PiiType::from(IdentifierType::UkNi), PiiType::UkNi);
 
         // Organizational
         assert_eq!(

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -39,7 +39,7 @@ pub use network::{email, phone, username};
 pub use personal::{
     australia_abn, australia_tfn, birthdate, driver_license, employee_id, finland_hetu,
     india_aadhaar, india_pan, italy_fiscal_code, korea_rrn, national_id, passport, personal_name,
-    poland_pesel, singapore_nric, spain_nie, spain_nif, ssn, student_id, tax_id,
+    poland_pesel, singapore_nric, spain_nie, spain_nif, ssn, student_id, tax_id, uk_ni,
 };
 
 // medical, biometric, location, and vehicle modules are already accessible via pub mod declarations

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal.rs
@@ -397,6 +397,35 @@ pub mod finland_hetu {
     }
 }
 
+/// UK National Insurance Number (NINO) patterns
+///
+/// Format: 2 letters + 6 digits + 1 suffix letter, e.g. `AB123456C`.
+/// The `is_uk_ni` / `find_uk_nis_in_text` detection functions apply HMRC
+/// prefix/suffix validation (BG, GB, NK, KN, TN, NT, ZZ excluded; suffix
+/// must be A-D) on top of these shape-only patterns.
+pub mod uk_ni {
+    use super::*;
+
+    /// Bare UK NINO shape: 2 letters + 6 digits + 1 letter
+    /// Example: `AB123456C`
+    pub static STANDARD: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\b[A-Z]{2}\d{6}[A-Z]\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// UK NINO with explicit label (two capture groups: label prefix, NINO value)
+    /// Example: `NI: AB123456C`, `NINO AB123456C`, `National Insurance: AB123456C`
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(\b(?i:NINO|NI(?:[\s-]?Number)?|National[\s-]?Insurance(?:[\s-]?Number)?)[\s:#-]*)((?i:[A-Z]{2}\d{6}[A-Z]))\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
+    }
+}
+
 /// Spain NIF (Numero de Identificacion Fiscal) patterns
 pub mod spain_nif {
     use super::*;

--- a/crates/octarine/src/primitives/identifiers/government/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder.rs
@@ -472,6 +472,53 @@ impl GovernmentIdentifierBuilder {
     }
 
     // ========================================================================
+    // UK National Insurance Number (NINO) Operations
+    // ========================================================================
+
+    /// Check if value is a valid UK National Insurance Number (NINO)
+    ///
+    /// Applies HMRC prefix/suffix rules on top of the format check, so
+    /// matches like `BG123456A` (invalid prefix) return false.
+    #[must_use]
+    pub fn is_uk_ni(&self, value: &str) -> bool {
+        detection::is_uk_ni(value)
+    }
+
+    /// Find all UK NINOs in text (with validation filtering)
+    #[must_use]
+    pub fn find_uk_nis_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_uk_nis_in_text(text)
+    }
+
+    /// Redact a UK NINO with explicit strategy
+    ///
+    /// Delegates to the shared national-ID redaction since NINOs share the
+    /// 9-character shape expected by that redactor.
+    #[must_use]
+    pub fn redact_uk_ni_with_strategy(
+        &self,
+        ni: &str,
+        strategy: NationalIdRedactionStrategy,
+    ) -> String {
+        sanitization::redact_national_id_with_strategy(ni, strategy)
+    }
+
+    /// Redact all UK NINOs in text with explicit strategy
+    ///
+    /// Scans for UK-specific NINO patterns (filtered by prefix/suffix rules),
+    /// then redacts only the NINO value — preserving any label prefix
+    /// ("NI: ", "NINO ", ...) around it. Invalid NINOs (bad prefix or
+    /// suffix) are left unchanged.
+    #[must_use]
+    pub fn redact_uk_nis_in_text_with_strategy(
+        &self,
+        text: &str,
+        strategy: NationalIdRedactionStrategy,
+    ) -> String {
+        sanitization::redact_uk_nis_in_text_with_strategy(text, strategy).into_owned()
+    }
+
+    // ========================================================================
     // Australia TFN Operations
     // ========================================================================
 

--- a/crates/octarine/src/primitives/identifiers/government/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection.rs
@@ -27,6 +27,7 @@
 use super::super::common::patterns;
 use super::super::types::{DetectionConfidence, IdentifierMatch, IdentifierType};
 use super::common::{is_itin_area, is_test_ssn};
+use super::validation::validate_uk_ni;
 
 // ============================================================================
 // Constants
@@ -473,6 +474,79 @@ pub fn find_finland_hetus_in_text(text: &str) -> Vec<IdentifierMatch> {
     deduplicate_matches(matches)
 }
 
+/// Check if a value is a valid UK National Insurance Number (NINO)
+///
+/// Format: 2 letters + 6 digits + 1 suffix letter (e.g. `AB123456C`).
+/// Applies HMRC prefix/suffix rules — invalid prefixes
+/// (BG, GB, NK, KN, TN, NT, ZZ), reserved first letters (D, F, I, Q, U, V),
+/// and non A-D suffixes are rejected. Test patterns (AA000000A, etc.) are
+/// also rejected.
+///
+/// This detection function combines a regex shape check with the full
+/// validator, so it has no false positives for bare NINOs.
+#[must_use]
+pub fn is_uk_ni(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    if !patterns::uk_ni::STANDARD.is_match(value) {
+        return false;
+    }
+    validate_uk_ni(value).is_ok()
+}
+
+/// Find all UK NINO patterns in text with HMRC validation
+///
+/// Scans for UK National Insurance Number patterns and filters out any
+/// regex match whose prefix/suffix rules fail (invalid prefixes, reserved
+/// first letters, non A-D suffix, test patterns).
+///
+/// Labeled patterns (`"NI: AB123456C"`) get High confidence; bare patterns
+/// get Medium. The returned match text is the full regex match including
+/// the label for labeled patterns — consistent with SSN text scanning.
+#[must_use]
+pub fn find_uk_nis_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for (pattern_idx, pattern) in patterns::uk_ni::all().iter().enumerate() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+
+            // For LABELED (index 0) the NINO is in capture group 2; for
+            // STANDARD the full match is the NINO itself.
+            let nino_text = if pattern_idx == 0 {
+                capture.get(2).map_or(full_match.as_str(), |m| m.as_str())
+            } else {
+                full_match.as_str()
+            };
+
+            if validate_uk_ni(nino_text).is_err() {
+                continue;
+            }
+
+            let confidence = if pattern_idx == 0 {
+                DetectionConfidence::High
+            } else {
+                DetectionConfidence::Medium
+            };
+
+            matches.push(IdentifierMatch::new(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::UkNi,
+                confidence,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
 /// Check if a value matches Spain NIF format
 #[must_use]
 pub fn is_spain_nif(value: &str) -> bool {
@@ -658,6 +732,8 @@ pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
         Some(IdentifierType::SpainNif)
     } else if is_spain_nie(value) {
         Some(IdentifierType::SpainNie)
+    } else if is_uk_ni(value) {
+        Some(IdentifierType::UkNi)
     } else if is_national_id(value) {
         Some(IdentifierType::NationalId)
     } else if is_vehicle_id(value) {
@@ -1112,6 +1188,7 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
     all_matches.extend(find_italy_fiscal_codes_in_text(text));
     all_matches.extend(find_spain_nifs_in_text(text));
     all_matches.extend(find_spain_nies_in_text(text));
+    all_matches.extend(find_uk_nis_in_text(text));
     all_matches.extend(find_national_ids_in_text(text));
     all_matches.extend(find_vehicle_ids_in_text(text));
 
@@ -1483,5 +1560,111 @@ mod tests {
         let second = deduped.get(1).expect("Should have second match");
         assert_eq!(first.matched_text, "test1long");
         assert_eq!(second.matched_text, "test2");
+    }
+
+    // ========================================================================
+    // UK NINO detection tests
+    // ========================================================================
+
+    #[test]
+    fn test_is_uk_ni_valid() {
+        assert!(is_uk_ni("AB123456C"));
+        assert!(is_uk_ni("CE123456A"));
+        assert!(is_uk_ni("HJ987654B"));
+        assert!(is_uk_ni("LA456789D"));
+    }
+
+    #[test]
+    fn test_is_uk_ni_rejects_invalid_prefix() {
+        // HMRC-prohibited prefix pairs
+        assert!(!is_uk_ni("BG123456A"));
+        assert!(!is_uk_ni("GB123456A"));
+        assert!(!is_uk_ni("NK123456A"));
+        assert!(!is_uk_ni("KN123456A"));
+        assert!(!is_uk_ni("ZZ999999A")); // ZZ (also a test pattern)
+    }
+
+    #[test]
+    fn test_is_uk_ni_rejects_reserved_first_letter() {
+        // Reserved temporary-prefix first letters
+        for first in ['D', 'F', 'I', 'Q', 'U', 'V'] {
+            let candidate = format!("{first}A123456C");
+            assert!(!is_uk_ni(&candidate), "{candidate} should be rejected");
+        }
+    }
+
+    #[test]
+    fn test_is_uk_ni_rejects_invalid_suffix() {
+        assert!(!is_uk_ni("AB123456E"));
+        assert!(!is_uk_ni("AB123456Z"));
+    }
+
+    #[test]
+    fn test_is_uk_ni_rejects_wrong_shape() {
+        assert!(!is_uk_ni("not a nino"));
+        assert!(!is_uk_ni("A1123456C")); // Only one letter prefix
+        assert!(!is_uk_ni("AB1234567")); // All digits after prefix
+        assert!(!is_uk_ni(""));
+    }
+
+    #[test]
+    fn test_find_uk_nis_in_text_labeled_high_confidence() {
+        let text = "Employee NI: AB123456C";
+        let matches = find_uk_nis_in_text(text);
+        assert_eq!(matches.len(), 1);
+        let m = matches.first().expect("one match");
+        assert_eq!(m.identifier_type, IdentifierType::UkNi);
+        assert_eq!(m.confidence, DetectionConfidence::High);
+        assert!(m.matched_text.contains("AB123456C"));
+    }
+
+    #[test]
+    fn test_find_uk_nis_in_text_bare_medium_confidence() {
+        let text = "The record is AB123456C overall.";
+        let matches = find_uk_nis_in_text(text);
+        assert_eq!(matches.len(), 1);
+        let m = matches.first().expect("one match");
+        assert_eq!(m.identifier_type, IdentifierType::UkNi);
+        assert_eq!(m.confidence, DetectionConfidence::Medium);
+        assert_eq!(m.matched_text, "AB123456C");
+    }
+
+    #[test]
+    fn test_find_uk_nis_rejects_invalid_in_text() {
+        // Regex shape matches but HMRC rules reject — expect no matches
+        let text = "Spurious value BG123456A in the doc";
+        assert!(find_uk_nis_in_text(text).is_empty());
+    }
+
+    #[test]
+    fn test_find_uk_nis_multiple() {
+        let text = "First NI: AB123456C, second HJ987654B.";
+        let matches = find_uk_nis_in_text(text);
+        assert_eq!(matches.len(), 2);
+        assert!(
+            matches
+                .iter()
+                .all(|m| m.identifier_type == IdentifierType::UkNi)
+        );
+    }
+
+    #[test]
+    fn test_detect_government_identifier_uk_ni() {
+        // The dedicated UkNi variant should win over the generic NationalId
+        assert_eq!(
+            detect_government_identifier("AB123456C"),
+            Some(IdentifierType::UkNi)
+        );
+    }
+
+    #[test]
+    fn test_find_all_government_ids_includes_uk_ni() {
+        let text = "NI: AB123456C";
+        let all = find_all_government_ids_in_text(text);
+        assert!(
+            all.iter()
+                .any(|m| m.identifier_type == IdentifierType::UkNi),
+            "expected at least one UkNi match in: {all:?}"
+        );
     }
 }

--- a/crates/octarine/src/primitives/identifiers/government/sanitization/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/sanitization/mod.rs
@@ -70,7 +70,7 @@ pub use text::{
     redact_all_government_ids_in_text_with_policy, redact_driver_licenses_in_text_with_strategy,
     redact_national_ids_in_text_with_strategy, redact_passports_in_text_with_strategy,
     redact_ssns_in_text_with_strategy, redact_tax_ids_in_text_with_strategy,
-    redact_vehicle_ids_in_text_with_strategy,
+    redact_uk_nis_in_text_with_strategy, redact_vehicle_ids_in_text_with_strategy,
 };
 
 // ============================================================================

--- a/crates/octarine/src/primitives/identifiers/government/sanitization/text.rs
+++ b/crates/octarine/src/primitives/identifiers/government/sanitization/text.rs
@@ -322,6 +322,76 @@ pub fn redact_national_ids_in_text_with_strategy(
 }
 
 // ============================================================================
+// UK NINO Text Redaction
+// ============================================================================
+
+/// Redact all UK National Insurance Number patterns in text with explicit strategy
+///
+/// Only NINOs that pass HMRC prefix/suffix validation are redacted —
+/// values with invalid prefixes (BG, GB, ZZ, ...) or non A-D suffixes are
+/// left untouched. Labels ("NI: ", "NINO ", ...) are preserved; only the
+/// NINO value is replaced.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::sanitization::{
+///     redact_uk_nis_in_text_with_strategy, NationalIdRedactionStrategy,
+/// };
+///
+/// let text = "Employee NI: AB123456C";
+/// let safe = redact_uk_nis_in_text_with_strategy(text, NationalIdRedactionStrategy::Token);
+/// assert_eq!(safe.as_ref(), "Employee NI: [NATIONAL_ID]");
+/// ```
+#[must_use]
+pub fn redact_uk_nis_in_text_with_strategy(
+    text: &str,
+    strategy: NationalIdRedactionStrategy,
+) -> Cow<'_, str> {
+    use super::super::validation::validate_uk_ni;
+
+    let mut result = Cow::Borrowed(text);
+
+    for (i, pattern) in patterns::uk_ni::all().iter().enumerate() {
+        if pattern.is_match(&result) {
+            if i == 0 {
+                // LABELED pattern: group 1 = label prefix, group 2 = NINO
+                result = Cow::Owned(
+                    pattern
+                        .replace_all(&result, |caps: &regex::Captures<'_>| {
+                            let prefix = caps.get(1).map_or("", |m| m.as_str());
+                            let nino = caps.get(2).map_or("", |m| m.as_str());
+                            if validate_uk_ni(nino).is_err() {
+                                return caps
+                                    .get(0)
+                                    .map_or(String::new(), |m| m.as_str().to_string());
+                            }
+                            let redacted = redact_national_id_with_strategy(nino, strategy);
+                            format!("{}{}", prefix, redacted)
+                        })
+                        .into_owned(),
+                );
+            } else {
+                // STANDARD pattern: full match is the NINO
+                result = Cow::Owned(
+                    pattern
+                        .replace_all(&result, |caps: &regex::Captures<'_>| {
+                            let nino = caps.get(0).map_or("", |m| m.as_str());
+                            if validate_uk_ni(nino).is_err() {
+                                return nino.to_string();
+                            }
+                            redact_national_id_with_strategy(nino, strategy)
+                        })
+                        .into_owned(),
+                );
+            }
+        }
+    }
+
+    result
+}
+
+// ============================================================================
 // Vehicle ID Text Redaction
 // ============================================================================
 
@@ -440,6 +510,11 @@ pub fn redact_all_government_ids_in_text_with_policy(
     let result = redact_tax_ids_in_text_with_strategy(&result, tax_id_strategy);
     let result = redact_driver_licenses_in_text_with_strategy(&result, driver_license_strategy);
     let result = redact_passports_in_text_with_strategy(&result, passport_strategy);
+    // UK NINOs first — label-preserving and prefix/suffix validated — so that
+    // `redact_national_ids_in_text_with_strategy` below (which uses the
+    // generic national_id regex set) does not over-match already-handled
+    // values.
+    let result = redact_uk_nis_in_text_with_strategy(&result, national_id_strategy);
     let result = redact_national_ids_in_text_with_strategy(&result, national_id_strategy);
     let result = redact_vehicle_ids_in_text_with_strategy(&result, vehicle_id_strategy);
 
@@ -596,5 +671,38 @@ mod tests {
         let text = "SSN: 900-00-0001";
         let result = redact_ssns_in_text_with_strategy(text, SsnRedactionStrategy::Token);
         assert!(matches!(result, Cow::Owned(_)));
+    }
+
+    // ========================================================================
+    // UK NINO Text Redaction Tests
+    // ========================================================================
+
+    #[test]
+    fn test_redact_uk_nis_preserves_label() {
+        let text = "Employee NI: AB123456C";
+        let result = redact_uk_nis_in_text_with_strategy(text, NationalIdRedactionStrategy::Token);
+        assert_eq!(result.as_ref(), "Employee NI: [NATIONAL_ID]");
+    }
+
+    #[test]
+    fn test_redact_uk_nis_bare_value() {
+        let text = "ref AB123456C end";
+        let result = redact_uk_nis_in_text_with_strategy(text, NationalIdRedactionStrategy::Token);
+        assert_eq!(result.as_ref(), "ref [NATIONAL_ID] end");
+    }
+
+    #[test]
+    fn test_redact_uk_nis_leaves_invalid_nino_alone() {
+        // Invalid HMRC prefix — not a real NINO, no redaction
+        let text = "junk BG123456A";
+        let result = redact_uk_nis_in_text_with_strategy(text, NationalIdRedactionStrategy::Token);
+        assert_eq!(result.as_ref(), "junk BG123456A");
+    }
+
+    #[test]
+    fn test_redact_uk_nis_multiple() {
+        let text = "one AB123456C, two HJ987654B.";
+        let result = redact_uk_nis_in_text_with_strategy(text, NationalIdRedactionStrategy::Token);
+        assert_eq!(result.as_ref(), "one [NATIONAL_ID], two [NATIONAL_ID].");
     }
 }

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -482,6 +482,13 @@ impl StreamingScanner {
                         total = total.saturating_add(1);
                     }
                 }
+                IdentifierType::UkNi => {
+                    let government = GovernmentIdentifierBuilder::new();
+                    for m in government.find_uk_nis_in_text(text) {
+                        let _ = self.buffer.push(m);
+                        total = total.saturating_add(1);
+                    }
+                }
                 IdentifierType::VehicleId => {
                     let government = GovernmentIdentifierBuilder::new();
                     for m in government.find_vehicle_ids_in_text(text) {

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -75,6 +75,7 @@ pub enum IdentifierType {
     ItalyFiscalCode, // Italian Codice Fiscale
     SpainNif,        // Spanish NIF (Numero de Identificacion Fiscal)
     SpainNie,        // Spanish NIE (Numero de Identidad de Extranjero)
+    UkNi,            // UK National Insurance Number (NINO)
 
     // Organizational identifiers
     EmployeeId,


### PR DESCRIPTION
## Summary

- Promotes UK National Insurance Number (NINO) from the generic `NationalId` bucket to a first-class identifier: `IdentifierType::UkNi`, `PiiType::UkNi` — on par with Finland HETU / Spain NIF / Spain NIE.
- Adds dedicated detection (`is_uk_ni`, `find_uk_nis_in_text`) with HMRC validation filtering — invalid prefixes (BG, GB, NK, KN, TN, NT, ZZ), reserved first letters (D, F, I, Q, U, V), and non A-D suffixes are rejected. `detect_government_identifier("AB123456C")` now returns `Some(UkNi)` instead of `Some(NationalId)`.
- Adds label-preserving text redaction (`redact_uk_nis_in_text_with_strategy`) — `"NI: AB123456C"` → `"NI: [NATIONAL_ID]"`. Wired into `redact_all_government_ids_in_text_with_policy` and the redactor routing.
- Adds Layer 3 observe-instrumented wrappers (metrics for `detect_ms`, `redact_ms`, counters for `detected` / `government_data_found`), scanner hook, and streaming dispatch branch.

## Implementation notes

- Reuses `NationalIdRedactionStrategy` instead of introducing a country-specific enum — matches the Finland HETU / Spain NIF precedent.
- `validate_uk_ni()` was already fully implemented in `validation/national_id.rs` — no validation logic changes; the new detection/find functions delegate to it.
- Follows the existing `uk_ni` naming throughout (functions, variants, PII name) for consistency with the pre-existing `validate_uk_ni`.
- `PiiType::UkNi` included in `is_gdpr_protected` (UK GDPR applies post-Brexit under the retained-EU-law framework).
- No crate-root shortcut added in `shortcuts.rs` — consistent with every other country-specific government identifier.
- Legacy `national_id::UK_NI` regex retained; still backs `find_national_ids_in_text` and existing tests. Optional follow-up cleanup.

## Test plan

- [x] `just test-mod "primitives::identifiers::government::detection"` — 12 new UK NI tests pass (valid/invalid prefix/reserved-letter/invalid-suffix/wrong-shape/labeled/bare/multiple/reject-invalid/detect priority/all-government-ids inclusion)
- [x] `just test-mod "primitives::identifiers::government::sanitization::text"` — 4 new label-preserving redaction tests pass
- [x] `just test-mod "observe::pii::types"` — `PiiType::UkNi` classification + `From<IdentifierType::UkNi>` tests pass
- [x] `just test-mod "observe::pii::scanner"` — scanner hook confirmed
- [x] `just preflight` — 6420 tests pass, clippy clean, fmt clean, arch-check clean

## Pre-review findings

Scanner flagged 3 `missing-test-file` entries — false positives: octarine uses inline `#[cfg(test)]` modules (Rust convention), all three files (`scanner/domains.rs`, `patterns/personal.rs`, `sanitization/mod.rs`) already contain inline tests.

Closes #28