### PR TITLE
chore(ci): adopt cargo-semver-checks as advisory PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,24 @@ jobs:
       - uses: taiki-e/install-action@cargo-deny
       - run: cargo deny check
 
+  semver:
+    name: SemVer
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: semver
+      - uses: taiki-e/install-action@cargo-semver-checks
+      - uses: taiki-e/install-action@just
+      - run: just semver-check
+
   arch:
     name: Architecture
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to octarine
+
+octarine is the foundation library providing security primitives and
+observability tools for Rust applications. See [README.md](README.md) for an
+overview and [docs/architecture/](docs/architecture/) for the three-layer
+design.
+
+This file is deliberately minimal — it covers dev setup and the SemVer policy.
+Branching, commit conventions, and the full PR workflow are documented in
+[CLAUDE.md](CLAUDE.md) and the project skills under `.claude/skills/`.
+
+## Development Setup
+
+```bash
+git clone git@github.com:joshjhall/octarine.git
+cd octarine
+just preflight    # fmt + clippy + shellcheck + arch-check + tests
+```
+
+Run `just --list` to discover the full recipe set. All tooling is invoked
+through `just` — never invoke `cargo test`, `cargo clippy`, or scripts
+directly, as recipes encode the correct feature flags and arguments.
+
+## SemVer Policy
+
+octarine is a foundational library. Downstream crates depend on a stable
+public API, so we track SemVer discipline closely.
+
+### Current status: pre-release (0.x)
+
+The workspace is at `0.3.0-beta.1` and is not yet published to crates.io.
+While we're on `0.x`:
+
+- Breaking public-API changes are **allowed** within minor version bumps.
+- Every breaking change **must** be recorded in [CHANGELOG.md](CHANGELOG.md)
+  under the release entry.
+
+### After 1.0
+
+Once the crate ships its first `1.0` release:
+
+- No breaking public-API changes within minor or patch versions.
+- Breaking changes require either:
+  - a major version bump, **or**
+  - an explicit intent annotation in [CHANGELOG.md](CHANGELOG.md) under an
+    `### Intentional Breaking Changes` subheading, naming the affected APIs
+    and the rationale.
+
+### Automated checks
+
+[cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) runs
+on every pull request as an **advisory** gate — it compares the rustdoc JSON
+of the PR branch against `origin/main` and flags SemVer-incompatible changes
+(new `pub fn`, changed return types, removed re-exports, etc.).
+
+The check is currently `continue-on-error: true`; findings do not block
+merge. After one release cycle of calibration, the gate will flip to required.
+
+**Running locally:**
+
+```bash
+git fetch origin main
+just semver-check
+```
+
+When the tool reports findings:
+
+1. Read the output — it names each affected item.
+2. If the change is accidental, revert it or add a non-breaking alternative.
+3. If the change is intentional, follow the policy above (version bump or
+   CHANGELOG.md annotation).
+
+## Getting Help
+
+- Open an issue: <https://github.com/joshjhall/octarine/issues>
+- Architecture questions: see `docs/architecture/layer-architecture.md`
+- Security patterns: see `docs/security/patterns/`

--- a/justfile
+++ b/justfile
@@ -34,6 +34,13 @@ fmt:
 # Run all formatters and file fixers via pre-commit on every file in the repo
 fmt-all: pre-commit
 
+# ─── SemVer ──────────────────────────────────────────────────────────────────
+
+# Check for breaking public-API changes vs. the main branch baseline.
+# Requires origin/main to be fetched (CI uses fetch-depth: 0).
+semver-check:
+    cargo semver-checks check-release --workspace --baseline-rev origin/main
+
 # ─── Test ────────────────────────────────────────────────────────────────────
 
 # Run all workspace tests (all features — matches `just clippy`)


### PR DESCRIPTION
## Summary

- Add `just semver-check` recipe running `cargo semver-checks check-release --workspace --baseline-rev origin/main` — catches accidental public-API churn (new `pub fn`, changed return types, dropped re-exports) that slips past `cargo check` and clippy.
- Add advisory `semver` CI job on `pull_request` with `continue-on-error: true` and `fetch-depth: 0` (needed so `origin/main` is reachable as baseline).
- Create `CONTRIBUTING.md` (did not exist) with a focused SemVer policy for the current `0.x` pre-release and post-1.0 rules.

## Why now

octarine is at `0.3.0-beta.1` and not yet on crates.io. The issue calls for putting the SemVer gate in place **before** first publication so downstream consumers are protected from day one. The first release cycle is advisory — maintainer reads output, calibrates noise — then a follow-up flips `continue-on-error: false`.

## Key decisions

- **Baseline is `origin/main`, not crates.io** — crate isn't published yet, so the default baseline would fail.
- **Installer via `taiki-e/install-action@cargo-semver-checks`** matches the existing `deny` job pattern and keeps the check logic in the justfile for local/CI parity, rather than `obi1kenobi/cargo-semver-checks-action@v2` which would duplicate that logic.
- **Not added to `just preflight`** — requires network access to fetch `origin/main`; keep `preflight` local-fast. Contributors and CI invoke `just semver-check` explicitly.
- **`shared-key: semver`** gives the job an isolated rust-cache bucket so rustdoc-JSON generation doesn't collide with `test` / `clippy` caches.

## Test plan

- [x] `just --list` shows `semver-check` under the new SemVer section
- [x] `cargo-semver-checks v0.47.0` installed via `cargo install --locked`
- [x] `just semver-check` runs end-to-end: 252 checks evaluated, 0 findings (expected — branch touches no Rust API)
- [x] `octarine-derive` correctly skipped (proc-macro crates have no SemVer-analyzable surface)
- [x] `just fmt-check`, `just arch-check`, `just shellcheck` pass
- [x] `ci.yml` job list confirmed: `fmt, clippy, test, doc, deny, semver, arch, check-windows, check-macos, test-nightly`
- [ ] CI `SemVer` job appears in this PR's status list and runs without blocking merge (to verify on this PR)

## Out of scope (follow-ups)

- Flipping `continue-on-error: false` — after one release cycle of calibration
- Running against crates.io baseline — after first published release
- Auto-bumping workspace version from semver-checks output — separate release-tooling discussion

Closes #264