### PR TITLE
fix(deps): bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,9 +3917,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Unblock CI: `cargo update -p rustls-webpki` (0.103.12 → 0.103.13) to pull in the fix for [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) — a reachable panic in certificate revocation list parsing when handling a syntactically valid empty `BIT STRING` in an `IssuingDistributionPoint` CRL extension.

The panic occurs prior to CRL signature verification. `octarine` uses `rustls-webpki` transitively through `reqwest` (dev-dep), so the vulnerability is not reachable in first-party code paths — but the lockfile pin was blocking `cargo deny check` in CI, blocking all PRs against `main`.

## Diff

2-line `Cargo.lock` change — version string and checksum only.

## Test plan

- [x] `just deps-deny` locally: `advisories ok, bans ok, licenses ok, sources ok`
- [x] `cargo update -p rustls-webpki` lands the advisory's fix range (`>=0.103.13, <0.104.0-alpha.1`)
- [ ] CI `Cargo Deny` job passes on this PR

Once merged, #266 (cargo-semver-checks adoption) will rebase and go green.