### PR TITLE
chore(ci): wire cargo-audit and route deny job through just

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
       - '**.md'
       - 'docs/**'
       - 'LICENSE*'
+  schedule:
+    # Daily dependency-health sweep against main: surfaces new RustSec
+    # advisories within 24h even when no PRs are open. Off-mark minute to
+    # avoid the :00 stampede on the GitHub Actions runners.
+    - cron: '17 6 * * *'
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,6 +27,7 @@ jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -33,6 +39,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -46,6 +53,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -58,6 +66,7 @@ jobs:
   doc:
     name: Doc
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -68,6 +77,18 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  audit:
+    name: Cargo Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+      - uses: taiki-e/install-action@cargo-audit
+      - uses: taiki-e/install-action@just
+      - run: just deps-audit
+
   deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
@@ -77,11 +98,13 @@ jobs:
         with:
           toolchain: "1.94"
       - uses: taiki-e/install-action@cargo-deny
-      - run: cargo deny check
+      - uses: taiki-e/install-action@just
+      - run: just deps-deny
 
   semver:
     name: SemVer
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -100,6 +123,7 @@ jobs:
   arch:
     name: Architecture
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@just
@@ -108,6 +132,7 @@ jobs:
   check-windows:
     name: Check (Windows)
     runs-on: windows-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -121,6 +146,7 @@ jobs:
   check-macos:
     name: Check (macOS)
     runs-on: macos-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -134,6 +160,7 @@ jobs:
   test-nightly:
     name: Test (nightly)
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds a dedicated `audit` job that runs `just deps-audit`, so new RustSec advisories surface even when no PRs are open.
- Routes the existing `deny` job through `just deps-deny` instead of calling `cargo deny check` directly — keeps CI aligned with local behavior and the `RUSTSEC-2023-0071` ignore in one place.
- Adds a daily schedule trigger (`cron: '17 6 * * *'` UTC) so dependency-health runs land within 24h on `main`.
- Gates every non-security job (`fmt`, `clippy`, `test`, `doc`, `semver`, `arch`, `check-windows`, `check-macos`, `test-nightly`) with `if: github.event_name != 'schedule'` so the daily cron only fires the `audit` + `deny` pair, not the full matrix.

## Test plan

- [x] `just deps-audit` exits 0 locally (RUSTSEC-2023-0071 ignored, RUSTSEC-2026-0097 currently a warning)
- [x] `just deps-deny` exits 0 locally
- [x] `actionlint .github/workflows/ci.yml` passes
- [x] YAML structure verified: `audit` and `deny` run on `push`/`pull_request`/`schedule`; all other jobs gated to skip `schedule`
- [ ] PR CI confirms the `audit` and `deny` checks appear and pass alongside the rest of the matrix

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)