### PR TITLE
fix(auth): zeroize plaintext token buffers for reset and remember-me

### DIFF
--- a/crates/octarine/src/auth/remember/manager.rs
+++ b/crates/octarine/src/auth/remember/manager.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides persistent login operations with audit logging for ASVS V3.5 compliance.
 
+use crate::crypto::secrets::{Secret, SecretString};
 use crate::observe;
 use crate::primitives::auth::remember::{
     RememberConfig, RememberToken, RememberTokenPair, generate_remember_token, parse_cookie_value,
@@ -37,7 +38,7 @@ use super::store::RememberTokenStore;
 ///
 /// // Issue a remember-me token on login
 /// let pair = manager.issue_token("user123", None)?;
-/// // Set cookie: pair.cookie_value()
+/// // Set cookie: manager.cookie_value(&pair).expose_secret()
 ///
 /// // Later, validate the cookie and get a new session
 /// let user_id = manager.validate_and_refresh(&cookie_value)?;
@@ -58,6 +59,25 @@ impl<S: RememberTokenStore> RememberManager<S> {
     #[must_use]
     pub fn with_store(store: S) -> Self {
         Self::new(store, RememberConfig::default())
+    }
+
+    /// Build the wire-format remember-me cookie value (`selector:validator`)
+    /// for a freshly issued [`RememberTokenPair`].
+    ///
+    /// The returned [`SecretString`] zeroizes its backing buffer on drop
+    /// and redacts itself in `Debug`/`Display` output. Callers should
+    /// expose the inner string via `.expose_secret()` only at the
+    /// HTTP-cookie boundary and avoid copying it into long-lived
+    /// `String`s.
+    ///
+    /// This helper lives at Layer 3 because it composes a new owned
+    /// `String` from the pair's plaintext validator. Layer 1 deliberately
+    /// does not expose a plaintext-`String` cookie helper — the leaky
+    /// intermediate buffer was the original defense-in-depth gap that
+    /// motivated this method (see issue #208).
+    #[must_use]
+    pub fn cookie_value(&self, pair: &RememberTokenPair) -> SecretString {
+        Secret::new(format!("{}:{}", pair.selector(), pair.validator()))
     }
 
     /// Issue a new remember-me token
@@ -328,6 +348,7 @@ impl<S: RememberTokenStore> RememberManager<S> {
 mod tests {
     use super::*;
     use crate::auth::remember::store::MemoryRememberStore;
+    use crate::crypto::secrets::ExposeSecret;
     use std::time::Duration;
 
     fn create_manager() -> RememberManager<MemoryRememberStore> {
@@ -342,7 +363,7 @@ mod tests {
         let pair = manager
             .issue_token("user@example.com", None)
             .expect("should succeed");
-        assert!(!pair.cookie_value().is_empty());
+        assert!(!manager.cookie_value(&pair).expose_secret().is_empty());
         assert_eq!(pair.token().user_id(), "user@example.com");
     }
 
@@ -363,8 +384,9 @@ mod tests {
         let pair = manager
             .issue_token("user@example.com", None)
             .expect("should succeed");
+        let cookie = manager.cookie_value(&pair);
         let user_id = manager
-            .validate(&pair.cookie_value())
+            .validate(cookie.expose_secret())
             .expect("should succeed");
         assert_eq!(user_id, "user@example.com");
     }
@@ -387,8 +409,9 @@ mod tests {
             .issue_token("user@example.com", None)
             .expect("should succeed");
 
+        let cookie = manager.cookie_value(&pair);
         let (user_id, new_pair) = manager
-            .validate_and_refresh(&pair.cookie_value())
+            .validate_and_refresh(cookie.expose_secret())
             .expect("should succeed");
 
         assert_eq!(user_id, "user@example.com");
@@ -402,20 +425,21 @@ mod tests {
         let pair = manager
             .issue_token("user@example.com", None)
             .expect("should succeed");
-        let old_cookie = pair.cookie_value();
+        let old_cookie = manager.cookie_value(&pair);
 
         let (user_id, new_pair) = manager
-            .validate_and_refresh(&old_cookie)
+            .validate_and_refresh(old_cookie.expose_secret())
             .expect("should succeed");
 
         assert_eq!(user_id, "user@example.com");
         assert!(new_pair.is_some()); // Rotation happened
 
         let new_pair = new_pair.unwrap();
-        assert_ne!(new_pair.cookie_value(), old_cookie);
+        let new_cookie = manager.cookie_value(&new_pair);
+        assert_ne!(new_cookie.expose_secret(), old_cookie.expose_secret());
 
         // Old cookie should no longer be valid
-        let result = manager.validate(&old_cookie);
+        let result = manager.validate(old_cookie.expose_secret());
         assert!(result.is_err());
     }
 
@@ -426,13 +450,15 @@ mod tests {
         let pair = manager
             .issue_token("user@example.com", None)
             .expect("should succeed");
-        let cookie = pair.cookie_value();
+        let cookie = manager.cookie_value(&pair);
 
-        let revoked = manager.revoke(&cookie).expect("should succeed");
+        let revoked = manager
+            .revoke(cookie.expose_secret())
+            .expect("should succeed");
         assert!(revoked);
 
         // Cookie should no longer be valid
-        let result = manager.validate(&cookie);
+        let result = manager.validate(cookie.expose_secret());
         assert!(result.is_err());
     }
 
@@ -532,7 +558,7 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(20));
 
-        let result = manager.validate(&pair.cookie_value());
+        let result = manager.validate(manager.cookie_value(&pair).expose_secret());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("expired"));
     }

--- a/crates/octarine/src/auth/reset/mod.rs
+++ b/crates/octarine/src/auth/reset/mod.rs
@@ -25,7 +25,9 @@
 //!
 //! // Request a reset (sends email to user)
 //! let token = manager.request_reset("user@example.com")?;
-//! // Send token.value() to user via email
+//! // Send token.value() to user via email — the returned `&str` is a
+//! // borrow of a zeroizing buffer, so do not copy it into a long-lived
+//! // `String` beyond the send operation.
 //!
 //! // When user submits the reset form:
 //! manager.validate_and_consume(&submitted_token, "user@example.com")?;

--- a/crates/octarine/src/auth/reset/store.rs
+++ b/crates/octarine/src/auth/reset/store.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
+use zeroize::Zeroize;
 
 use crate::primitives::auth::reset::ResetToken;
 use crate::primitives::types::Problem;
@@ -144,6 +145,17 @@ struct ResetEntry {
 /// In-memory reset token store for development and testing
 ///
 /// Not suitable for production multi-instance deployments.
+///
+/// # Security note
+///
+/// This in-memory store uses the plaintext token as the `HashMap` lookup
+/// key for simplicity. Production stores should hash the lookup key
+/// (e.g., HMAC with a per-deployment secret) so the database never holds
+/// reusable plaintext credentials. The token bytes embedded inside each
+/// stored `ResetToken` are zeroized on drop because `ResetToken` wraps
+/// them in a zeroizing buffer; the lookup-key copies maintained by this
+/// store are zeroized when the store itself is dropped (see the `Drop`
+/// impl below).
 #[derive(Debug, Default)]
 pub struct MemoryResetStore {
     /// Tokens indexed by token value
@@ -162,6 +174,29 @@ impl MemoryResetStore {
             tokens: RwLock::new(HashMap::new()),
             user_tokens: RwLock::new(HashMap::new()),
             last_requests: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl Drop for MemoryResetStore {
+    fn drop(&mut self) {
+        // Zeroize the plaintext lookup keys held by this store. The
+        // `ResetToken` values inside each entry zeroize themselves via
+        // their internal `SecretStringCore` wrapper, but the `HashMap`
+        // keys are owned `String`s — we wipe them on store drop so the
+        // plaintext is not left in heap memory after the store dies.
+        if let Ok(tokens) = self.tokens.get_mut() {
+            for (key, _) in tokens.drain() {
+                let mut key = key;
+                key.zeroize();
+            }
+        }
+        if let Ok(user_tokens) = self.user_tokens.get_mut() {
+            for (_, mut values) in user_tokens.drain() {
+                for value in &mut values {
+                    value.zeroize();
+                }
+            }
         }
     }
 }

--- a/crates/octarine/src/primitives/auth/remember/token.rs
+++ b/crates/octarine/src/primitives/auth/remember/token.rs
@@ -10,6 +10,7 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::time::{Duration, Instant};
 
+use crate::primitives::crypto::secrets::{ExposeSecretCore, SecretCore, SecretStringCore};
 use crate::primitives::types::Problem;
 
 // ============================================================================
@@ -275,14 +276,25 @@ impl std::fmt::Display for RememberToken {
 /// This is what gets sent to the client in the cookie.
 /// The format is `selector:validator` (both base64 encoded).
 ///
-/// `Debug` is implemented manually to redact the plaintext `validator` —
-/// derived `Debug` would leak the secret via logs, panics, or test output.
+/// The plaintext `validator` is stored in a zeroizing `SecretStringCore`
+/// buffer so the secret bytes are wiped from heap memory when the pair
+/// is dropped. `Debug` is implemented manually to redact the plaintext.
+///
+/// # Cookie assembly
+///
+/// To build the wire-format cookie value (`selector:validator`), use
+/// `octarine::auth::remember::RememberManager::cookie_value(&pair)`,
+/// which returns a `Secret<String>` so the assembled cookie string also
+/// zeroizes on drop. Layer 1 deliberately does not expose a
+/// plaintext-`String` cookie helper: a leaky intermediate buffer was the
+/// original defense-in-depth gap (see issue #208).
 #[derive(Clone)]
 pub struct RememberTokenPair {
     /// The stored token (with hashed validator)
     token: RememberToken,
-    /// The plaintext validator (only available at generation time)
-    validator: String,
+    /// The plaintext validator (only available at generation time),
+    /// zeroized on drop.
+    validator: SecretStringCore,
 }
 
 impl std::fmt::Debug for RememberTokenPair {
@@ -297,12 +309,6 @@ impl std::fmt::Debug for RememberTokenPair {
 }
 
 impl RememberTokenPair {
-    /// Get the cookie value (selector:validator)
-    #[must_use]
-    pub fn cookie_value(&self) -> String {
-        format!("{}:{}", self.token.selector, self.validator)
-    }
-
     /// Get the stored token
     #[must_use]
     pub fn token(&self) -> &RememberToken {
@@ -316,9 +322,16 @@ impl RememberTokenPair {
     }
 
     /// Get the validator (only available at generation time)
+    ///
+    /// Returns a borrowed view into the zeroizing buffer. Callers should
+    /// avoid copying the returned `&str` into long-lived `String`
+    /// allocations — the zeroization guarantee only applies to bytes that
+    /// stay inside the pair's buffer. Use
+    /// `octarine::auth::remember::RememberManager::cookie_value` to
+    /// produce a wire-format cookie value that is itself zeroizing.
     #[must_use]
     pub fn validator(&self) -> &str {
-        &self.validator
+        self.validator.expose_secret()
     }
 }
 
@@ -368,7 +381,10 @@ pub fn generate_remember_token(
         device_info.map(String::from),
     );
 
-    RememberTokenPair { token, validator }
+    RememberTokenPair {
+        token,
+        validator: SecretCore::new(validator),
+    }
 }
 
 /// Validate a remember-me token
@@ -558,11 +574,15 @@ mod tests {
     }
 
     #[test]
-    fn test_cookie_value() {
+    fn test_cookie_value_format() {
+        // Layer 1 no longer exposes a `cookie_value()` helper (it leaked
+        // plaintext into a fresh `String`). Verify the format invariant
+        // by assembling the cookie inline — Layer 3 (`RememberManager`)
+        // is responsible for the zeroizing public helper.
         let config = RememberConfig::default();
         let pair = generate_remember_token("user123", &config, None);
 
-        let cookie = pair.cookie_value();
+        let cookie = format!("{}:{}", pair.selector(), pair.validator());
         assert!(cookie.contains(':'));
 
         let parts: Vec<&str> = cookie.split(':').collect();
@@ -586,7 +606,8 @@ mod tests {
         let config = RememberConfig::default();
         let pair = generate_remember_token("user123", &config, None);
 
-        let result = validate_remember_token(&pair.cookie_value(), pair.token());
+        let cookie = format!("{}:{}", pair.selector(), pair.validator());
+        let result = validate_remember_token(&cookie, pair.token());
         assert!(result.is_ok());
     }
 
@@ -623,7 +644,8 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(20));
 
-        let result = validate_remember_token(&pair.cookie_value(), pair.token());
+        let cookie = format!("{}:{}", pair.selector(), pair.validator());
+        let result = validate_remember_token(&cookie, pair.token());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("expired"));
     }
@@ -635,7 +657,8 @@ mod tests {
         let mut token = pair.token().clone();
         token.revoke();
 
-        let result = validate_remember_token(&pair.cookie_value(), &token);
+        let cookie = format!("{}:{}", pair.selector(), pair.validator());
+        let result = validate_remember_token(&cookie, &token);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("revoked"));
     }
@@ -777,5 +800,17 @@ mod tests {
         assert!(!constant_time_compare("abc", "abd"));
         assert!(!constant_time_compare("abc", "ab"));
         assert!(!constant_time_compare("ab", "abc"));
+    }
+
+    #[test]
+    fn test_validator_zeroized_on_drop() {
+        // Smoke test: building, exposing, and dropping a RememberTokenPair
+        // does not panic and the SecretStringCore wrapper is in place.
+        // Memory zeroization is covered by SecretCore's own test suite —
+        // we just verify the wiring here.
+        let config = RememberConfig::default();
+        let pair = generate_remember_token("user123", &config, None);
+        assert!(!pair.validator().is_empty());
+        drop(pair);
     }
 }

--- a/crates/octarine/src/primitives/auth/reset/token.rs
+++ b/crates/octarine/src/primitives/auth/reset/token.rs
@@ -9,6 +9,7 @@ use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use rand::RngCore;
 use std::time::{Duration, Instant};
 
+use crate::primitives::crypto::secrets::{ExposeSecretCore, SecretCore, SecretStringCore};
 use crate::primitives::types::Problem;
 
 // ============================================================================
@@ -106,12 +107,14 @@ impl ResetConfigBuilder {
 /// Reset tokens are secure, time-limited, single-use tokens for password
 /// reset flows. Each token has 256 bits of entropy by default.
 ///
-/// `Debug` is implemented manually to mask the plaintext `token` field —
+/// The plaintext token value is stored in a zeroizing `SecretStringCore`
+/// wrapper so the secret bytes are wiped from heap memory when the token
+/// is dropped. `Debug` is implemented manually to mask the plaintext —
 /// derived `Debug` would leak the secret via logs, panics, or test output.
 #[derive(Clone)]
 pub struct ResetToken {
-    /// The token value (URL-safe base64)
-    token: String,
+    /// The token value (URL-safe base64), zeroized on drop.
+    token: SecretStringCore,
     /// The user this token is for
     user_id: String,
     /// When the token was created
@@ -126,7 +129,7 @@ impl ResetToken {
     /// Create a new reset token
     fn new(token: String, user_id: String, lifetime: Duration) -> Self {
         Self {
-            token,
+            token: SecretCore::new(token),
             user_id,
             created_at: Instant::now(),
             lifetime,
@@ -150,7 +153,7 @@ impl ResetToken {
         used: bool,
     ) -> Self {
         Self {
-            token,
+            token: SecretCore::new(token),
             user_id,
             created_at: Instant::now(),
             lifetime: remaining_lifetime,
@@ -159,9 +162,14 @@ impl ResetToken {
     }
 
     /// Get the token value
+    ///
+    /// Returns a borrowed view into the zeroizing buffer. Callers should
+    /// avoid copying the returned `&str` into long-lived `String`
+    /// allocations — the zeroization guarantee only applies to bytes that
+    /// stay inside the `ResetToken`'s buffer.
     #[must_use]
     pub fn value(&self) -> &str {
-        &self.token
+        self.token.expose_secret()
     }
 
     /// Get the user ID
@@ -211,10 +219,11 @@ impl ResetToken {
 impl std::fmt::Display for ResetToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Only show first 8 chars for security in logs
-        if self.token.len() > 8 {
-            write!(f, "{}...", &self.token[..8])
+        let token = self.token.expose_secret();
+        if let Some(prefix) = token.get(..8) {
+            write!(f, "{prefix}...")
         } else {
-            write!(f, "{}", &self.token)
+            write!(f, "{token}")
         }
     }
 }
@@ -222,10 +231,10 @@ impl std::fmt::Display for ResetToken {
 impl std::fmt::Debug for ResetToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Mask the plaintext token — same first-8-char scheme as Display.
-        let masked = self
-            .token
+        let token = self.token.expose_secret();
+        let masked = token
             .get(..8)
-            .map_or_else(|| self.token.clone(), |prefix| format!("{prefix}..."));
+            .map_or_else(|| token.clone(), |prefix| format!("{prefix}..."));
         f.debug_struct("ResetToken")
             .field("token", &masked)
             .field("user_id", &self.user_id)
@@ -239,7 +248,8 @@ impl std::fmt::Debug for ResetToken {
 impl PartialEq for ResetToken {
     fn eq(&self, other: &Self) -> bool {
         // Constant-time comparison to prevent timing attacks
-        constant_time_compare(&self.token, &other.token) && self.user_id == other.user_id
+        constant_time_compare(self.token.expose_secret(), other.token.expose_secret())
+            && self.user_id == other.user_id
     }
 }
 
@@ -645,5 +655,17 @@ mod tests {
         assert!(!constant_time_compare("abc", "abd"));
         assert!(!constant_time_compare("abc", "ab"));
         assert!(!constant_time_compare("ab", "abc"));
+    }
+
+    #[test]
+    fn test_token_zeroized_on_drop() {
+        // Smoke test: building, exposing, and dropping a ResetToken does
+        // not panic and the SecretStringCore wrapper is in place. Actual
+        // memory zeroization is covered by SecretCore's own test suite —
+        // we just verify the wiring here.
+        let config = ResetConfig::default();
+        let token = generate_reset_token("user123", &config);
+        assert!(!token.value().is_empty());
+        drop(token);
     }
 }

--- a/crates/octarine/tests/auth/remember.rs
+++ b/crates/octarine/tests/auth/remember.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::panic, clippy::expect_used)]
 
 use octarine::auth::{MemoryRememberStore, RememberConfig, RememberManager};
+use octarine::crypto::secrets::ExposeSecret;
 
 fn make_manager_with_rotation() -> RememberManager<MemoryRememberStore> {
     let store = MemoryRememberStore::new();
@@ -22,9 +23,9 @@ fn test_issue_and_validate() {
     let pair = manager
         .issue_token("alice", Some("Chrome on Mac"))
         .expect("issue token");
-    let cookie = pair.cookie_value();
+    let cookie = manager.cookie_value(&pair);
 
-    let user_id = manager.validate(&cookie).expect("validate");
+    let user_id = manager.validate(cookie.expose_secret()).expect("validate");
     assert_eq!(user_id, "alice");
 }
 
@@ -34,11 +35,11 @@ fn test_token_rotation_on_use() {
     let manager = make_manager_with_rotation();
 
     let pair = manager.issue_token("alice", None).expect("issue token");
-    let old_cookie = pair.cookie_value();
+    let old_cookie = manager.cookie_value(&pair);
 
     // validate_and_refresh should return new token pair
     let (user_id, new_pair) = manager
-        .validate_and_refresh(&old_cookie)
+        .validate_and_refresh(old_cookie.expose_secret())
         .expect("validate and refresh");
     assert_eq!(user_id, "alice");
     assert!(
@@ -46,16 +47,18 @@ fn test_token_rotation_on_use() {
         "Should return new token pair when rotation is enabled"
     );
 
-    let new_cookie = new_pair.expect("new pair").cookie_value();
+    let new_cookie = manager.cookie_value(&new_pair.expect("new pair"));
 
     // Old cookie should now be invalid
     assert!(
-        manager.validate(&old_cookie).is_err(),
+        manager.validate(old_cookie.expose_secret()).is_err(),
         "Old cookie should be invalid after rotation"
     );
 
     // New cookie should work
-    let user_id2 = manager.validate(&new_cookie).expect("validate new cookie");
+    let user_id2 = manager
+        .validate(new_cookie.expose_secret())
+        .expect("validate new cookie");
     assert_eq!(user_id2, "alice");
 }
 
@@ -65,10 +68,10 @@ fn test_no_rotation_when_disabled() {
     let manager = make_manager_without_rotation();
 
     let pair = manager.issue_token("bob", None).expect("issue token");
-    let cookie = pair.cookie_value();
+    let cookie = manager.cookie_value(&pair);
 
     let (user_id, new_pair) = manager
-        .validate_and_refresh(&cookie)
+        .validate_and_refresh(cookie.expose_secret())
         .expect("validate and refresh");
     assert_eq!(user_id, "bob");
     assert!(
@@ -77,7 +80,9 @@ fn test_no_rotation_when_disabled() {
     );
 
     // Original cookie still works
-    let user_id2 = manager.validate(&cookie).expect("validate again");
+    let user_id2 = manager
+        .validate(cookie.expose_secret())
+        .expect("validate again");
     assert_eq!(user_id2, "bob");
 }
 
@@ -93,13 +98,16 @@ fn test_revoke_single_token() {
         .issue_token("alice", Some("Device 2"))
         .expect("token 2");
 
+    let cookie1 = manager.cookie_value(&pair1);
+    let cookie2 = manager.cookie_value(&pair2);
+
     // Revoke first token
-    let revoked = manager.revoke(&pair1.cookie_value()).expect("revoke");
+    let revoked = manager.revoke(cookie1.expose_secret()).expect("revoke");
     assert!(revoked);
 
     // First token invalid, second still valid
-    assert!(manager.validate(&pair1.cookie_value()).is_err());
-    assert!(manager.validate(&pair2.cookie_value()).is_ok());
+    assert!(manager.validate(cookie1.expose_secret()).is_err());
+    assert!(manager.validate(cookie2.expose_secret()).is_ok());
 }
 
 /// revoke_all for user invalidates all tokens.
@@ -117,15 +125,19 @@ fn test_revoke_all_for_user() {
         .issue_token("bob", Some("Device 1"))
         .expect("bob token");
 
+    let cookie1 = manager.cookie_value(&pair1);
+    let cookie2 = manager.cookie_value(&pair2);
+    let bob_cookie = manager.cookie_value(&bob_pair);
+
     let count = manager.revoke_all("alice").expect("revoke all");
     assert_eq!(count, 2, "Should revoke 2 tokens for alice");
 
     // Alice's tokens invalid
-    assert!(manager.validate(&pair1.cookie_value()).is_err());
-    assert!(manager.validate(&pair2.cookie_value()).is_err());
+    assert!(manager.validate(cookie1.expose_secret()).is_err());
+    assert!(manager.validate(cookie2.expose_secret()).is_err());
 
     // Bob's token still valid
-    assert!(manager.validate(&bob_pair.cookie_value()).is_ok());
+    assert!(manager.validate(bob_cookie.expose_secret()).is_ok());
 }
 
 /// get_active_tokens returns correct set.


### PR DESCRIPTION
## Summary

- `ResetToken.token` and `RememberTokenPair.validator` are now wrapped in the project's existing `SecretStringCore` Layer 1 zeroizing buffer, so plaintext token bytes are wiped from heap memory on drop instead of lingering until the allocator reuses the slot.
- Removes the documented leak point `RememberTokenPair::cookie_value() -> String` (was a fresh `format!()` `String` outliving the pair's zeroizing scope) and replaces it with `RememberManager::cookie_value(&pair) -> SecretString` at Layer 3.
- `MemoryResetStore` now has a `Drop` impl that zeroizes leftover plaintext lookup keys, plus a doc note recommending production stores HMAC their lookup keys.
- Layer boundaries respected: Layer 1 uses `SecretCore`/`SecretStringCore`; Layer 3 uses public `Secret`/`SecretString`.

## Breaking change

`octarine::auth::remember::RememberTokenPair::cookie_value` is removed. External callers must migrate to `RememberManager::cookie_value(&pair).expose_secret()` to obtain the HTTP-cookie wire value (which itself zeroizes on drop).

## Test plan

- [x] `just fmt` clean
- [x] `just clippy` clean (zero warnings, all-features)
- [x] `just arch-check` clean (layer + naming + lint rules)
- [x] `just preflight` — full workspace test suite green: 6422 unit + integration + doctests, 0 failed
- [x] Added `test_token_zeroized_on_drop` (reset) and `test_validator_zeroized_on_drop` (remember) smoke tests
- [x] All ~30 call sites in unit / manager / integration tests updated to use the new Layer 3 helper or in-test inline assembly

## Pre-review findings

- 1x `missing-test-file` for `crates/octarine/src/auth/reset/mod.rs` — false positive; the file is module re-exports + docs (no executable code added by this change).

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)