### PR TITLE
test(http): add behavioral assertions for HTTP presets

### DIFF
--- a/crates/octarine/src/http/presets/compression.rs
+++ b/crates/octarine/src/http/presets/compression.rs
@@ -123,6 +123,12 @@ pub fn request_decompression() -> RequestDecompressionLayer {
 mod tests {
     use super::*;
 
+    // Construction smoke tests — confirm constructors do not panic on valid
+    // inputs. CompressionLayer exposes no public accessors, so behavioral
+    // assertions (Content-Encoding header, gzip-only encoding negotiation,
+    // request decompression round-trip) live in `tests/http/presets.rs` and
+    // exercise the layer via Router::oneshot().
+
     #[test]
     fn test_default_compression_creates_layer() {
         let _layer = default_compression();

--- a/crates/octarine/src/http/presets/cors.rs
+++ b/crates/octarine/src/http/presets/cors.rs
@@ -195,6 +195,11 @@ pub fn read_only(origins: &[&str]) -> CorsLayer {
 mod tests {
     use super::*;
 
+    // Construction smoke tests — confirm constructors do not panic on valid
+    // inputs. tower-http's CorsLayer exposes no public accessors, so behavioral
+    // assertions (Access-Control-* headers, allowed origins, max-age) live in
+    // `tests/http/presets.rs` and exercise the layer via Router::oneshot().
+
     #[test]
     fn test_development_creates_layer() {
         let _layer = development();

--- a/crates/octarine/src/http/presets/limits.rs
+++ b/crates/octarine/src/http/presets/limits.rs
@@ -141,6 +141,11 @@ pub fn custom_body(bytes: usize) -> RequestBodyLimitLayer {
 mod tests {
     use super::*;
 
+    // Construction smoke tests — confirm constructors do not panic on valid
+    // inputs. RequestBodyLimitLayer exposes no public accessors, so behavioral
+    // assertions (413 on oversized body, 200 on under-size body) live in
+    // `tests/http/presets.rs` and exercise the layer via Router::oneshot().
+
     #[test]
     fn test_default_body_creates_layer() {
         let _layer = default_body();

--- a/crates/octarine/src/http/presets/rate_limit.rs
+++ b/crates/octarine/src/http/presets/rate_limit.rs
@@ -35,6 +35,30 @@ pub use tower_governor::GovernorLayer;
 pub use tower_governor::GovernorError;
 
 // ============================================================================
+// Preset Rates
+// ============================================================================
+
+/// `api()` preset — ~100 requests/minute (2/sec with smoothing), burst 150.
+const API_RATE_PER_SEC: u64 = 2;
+const API_BURST: u32 = 150;
+
+/// `auth()` preset — 5 requests/minute (1/sec), burst 5. OWASP recommendation.
+const AUTH_RATE_PER_SEC: u64 = 1;
+const AUTH_BURST: u32 = 5;
+
+/// `search()` preset — 30 requests/minute (1/sec), burst 50.
+const SEARCH_RATE_PER_SEC: u64 = 1;
+const SEARCH_BURST: u32 = 50;
+
+/// `upload()` preset — 10 requests/minute (1/sec), burst 20.
+const UPLOAD_RATE_PER_SEC: u64 = 1;
+const UPLOAD_BURST: u32 = 20;
+
+/// `webhook()` preset — ~1000 requests/minute (20/sec), burst 1500.
+const WEBHOOK_RATE_PER_SEC: u64 = 20;
+const WEBHOOK_BURST: u32 = 1500;
+
+// ============================================================================
 // Preset Configurations
 // ============================================================================
 
@@ -60,8 +84,8 @@ pub fn api<ReqBody>() -> tower_governor::GovernorLayer<
     ReqBody,
 > {
     let config = GovernorConfigBuilder::default()
-        .per_second(2) // ~100 per minute with some smoothing
-        .burst_size(150)
+        .per_second(API_RATE_PER_SEC)
+        .burst_size(API_BURST)
         .finish();
 
     // SAFETY: These are hardcoded valid configuration values that cannot fail
@@ -94,8 +118,8 @@ pub fn auth<ReqBody>() -> tower_governor::GovernorLayer<
     ReqBody,
 > {
     let config = GovernorConfigBuilder::default()
-        .per_second(1)
-        .burst_size(5)
+        .per_second(AUTH_RATE_PER_SEC)
+        .burst_size(AUTH_BURST)
         .finish();
 
     // SAFETY: These are hardcoded valid configuration values that cannot fail
@@ -127,8 +151,8 @@ pub fn search<ReqBody>() -> tower_governor::GovernorLayer<
     ReqBody,
 > {
     let config = GovernorConfigBuilder::default()
-        .per_second(1)
-        .burst_size(50)
+        .per_second(SEARCH_RATE_PER_SEC)
+        .burst_size(SEARCH_BURST)
         .finish();
 
     // SAFETY: These are hardcoded valid configuration values that cannot fail
@@ -160,8 +184,8 @@ pub fn upload<ReqBody>() -> tower_governor::GovernorLayer<
     ReqBody,
 > {
     let config = GovernorConfigBuilder::default()
-        .per_second(1)
-        .burst_size(20)
+        .per_second(UPLOAD_RATE_PER_SEC)
+        .burst_size(UPLOAD_BURST)
         .finish();
 
     // SAFETY: These are hardcoded valid configuration values that cannot fail
@@ -193,8 +217,8 @@ pub fn webhook<ReqBody>() -> tower_governor::GovernorLayer<
     ReqBody,
 > {
     let config = GovernorConfigBuilder::default()
-        .per_second(20) // ~1000 per minute
-        .burst_size(1500)
+        .per_second(WEBHOOK_RATE_PER_SEC)
+        .burst_size(WEBHOOK_BURST)
         .finish();
 
     // SAFETY: These are hardcoded valid configuration values that cannot fail
@@ -282,6 +306,15 @@ impl RateLimitBuilder {
 
         tower_governor::GovernorLayer::new(Arc::new(config))
     }
+
+    /// Test-only accessor for builder state.
+    ///
+    /// Returns `(requests_per_second, burst_size)`. Used by unit tests to
+    /// assert builder behavior without needing access to private fields.
+    #[cfg(test)]
+    pub(crate) fn config(&self) -> (u64, u32) {
+        (self.requests_per_second, self.burst_size)
+    }
 }
 
 impl Default for RateLimitBuilder {
@@ -293,6 +326,37 @@ impl Default for RateLimitBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ------------------------------------------------------------------------
+    // Preset constant assertions — guard against accidental rate changes
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_preset_rates() {
+        // Convert per-second back to per-minute for human-readable assertions
+        // matching the documented values in the module table.
+        assert_eq!(API_RATE_PER_SEC, 2);
+        assert_eq!(API_BURST, 150);
+
+        assert_eq!(AUTH_RATE_PER_SEC, 1);
+        assert_eq!(AUTH_BURST, 5);
+
+        assert_eq!(SEARCH_RATE_PER_SEC, 1);
+        assert_eq!(SEARCH_BURST, 50);
+
+        assert_eq!(UPLOAD_RATE_PER_SEC, 1);
+        assert_eq!(UPLOAD_BURST, 20);
+
+        assert_eq!(WEBHOOK_RATE_PER_SEC, 20);
+        assert_eq!(WEBHOOK_BURST, 1500);
+    }
+
+    // ------------------------------------------------------------------------
+    // Preset smoke tests — confirm constructors succeed (don't panic on
+    // invalid governor config). Behavioral testing of GovernorLayer requires
+    // ConnectInfo<SocketAddr> in the request, which Router::oneshot() does
+    // not populate; preset rates are asserted via test_preset_rates above.
+    // ------------------------------------------------------------------------
 
     #[test]
     fn test_api_creates_layer() {
@@ -319,24 +383,81 @@ mod tests {
         let _layer = webhook::<axum::body::Body>();
     }
 
+    // ------------------------------------------------------------------------
+    // Builder state assertions — verify the public API actually mutates
+    // state. The cfg(test) `config()` accessor returns the internal pair.
+    // ------------------------------------------------------------------------
+
     #[test]
     fn test_builder_default() {
-        let _layer = RateLimitBuilder::new().build::<axum::body::Body>();
+        let builder = RateLimitBuilder::new();
+        assert_eq!(builder.config(), (2, 150));
+
+        // Default impl matches new()
+        assert_eq!(RateLimitBuilder::default().config(), (2, 150));
     }
 
     #[test]
-    fn test_builder_custom() {
-        let _layer = RateLimitBuilder::new()
+    fn test_builder_requests_per_minute_converts_to_per_second() {
+        // 60/min -> 1/sec
+        let builder = RateLimitBuilder::new().requests_per_minute(60);
+        assert_eq!(builder.config().0, 1);
+
+        // 600/min -> 10/sec
+        let builder = RateLimitBuilder::new().requests_per_minute(600);
+        assert_eq!(builder.config().0, 10);
+    }
+
+    #[test]
+    fn test_builder_requests_per_minute_below_60_clamps_to_one() {
+        // 30/min would round down to 0; setter must clamp to minimum 1
+        // because GovernorConfig rejects per_second(0).
+        let builder = RateLimitBuilder::new().requests_per_minute(30);
+        assert_eq!(builder.config().0, 1);
+
+        // Zero must also clamp.
+        let builder = RateLimitBuilder::new().requests_per_minute(0);
+        assert_eq!(builder.config().0, 1);
+    }
+
+    #[test]
+    fn test_builder_requests_per_second_clamps_to_one() {
+        let builder = RateLimitBuilder::new().requests_per_second(0);
+        assert_eq!(builder.config().0, 1);
+
+        let builder = RateLimitBuilder::new().requests_per_second(50);
+        assert_eq!(builder.config().0, 50);
+    }
+
+    #[test]
+    fn test_builder_burst_size_clamps_to_one() {
+        let builder = RateLimitBuilder::new().burst_size(0);
+        assert_eq!(builder.config().1, 1);
+
+        let builder = RateLimitBuilder::new().burst_size(200);
+        assert_eq!(builder.config().1, 200);
+    }
+
+    #[test]
+    fn test_builder_chained_setters_compose() {
+        let builder = RateLimitBuilder::new()
             .requests_per_minute(60)
-            .burst_size(100)
-            .build::<axum::body::Body>();
+            .burst_size(100);
+        assert_eq!(builder.config(), (1, 100));
+
+        let builder = RateLimitBuilder::new()
+            .requests_per_second(10)
+            .burst_size(50);
+        assert_eq!(builder.config(), (10, 50));
     }
 
     #[test]
-    fn test_builder_per_second() {
+    fn test_builder_build_does_not_panic() {
+        // The build() path uses .expect() — make sure clamped minimums
+        // produce a valid governor config rather than panicking.
         let _layer = RateLimitBuilder::new()
-            .requests_per_second(10)
-            .burst_size(50)
+            .requests_per_minute(0) // clamped
+            .burst_size(0) // clamped
             .build::<axum::body::Body>();
     }
 }

--- a/crates/octarine/src/http/presets/timeout.rs
+++ b/crates/octarine/src/http/presets/timeout.rs
@@ -149,6 +149,12 @@ pub fn custom_timeout(duration: Duration) -> TimeoutLayer {
 mod tests {
     use super::*;
 
+    // Construction smoke tests — confirm constructors do not panic on valid
+    // inputs. TimeoutLayer exposes no public accessors, so behavioral
+    // assertions (408 after deadline, 200 within deadline) live in
+    // `tests/http/presets.rs` and exercise the layer via Router::oneshot()
+    // with `tokio::time::pause()` for deterministic clock control.
+
     #[test]
     fn test_default_timeout_creates_layer() {
         let _layer = default_timeout();

--- a/crates/octarine/tests/http/mod.rs
+++ b/crates/octarine/tests/http/mod.rs
@@ -3,4 +3,5 @@
 mod context;
 mod error_response;
 mod extractors;
+mod presets;
 mod request_id;

--- a/crates/octarine/tests/http/presets.rs
+++ b/crates/octarine/tests/http/presets.rs
@@ -1,0 +1,531 @@
+//! Behavioral integration tests for HTTP preset middleware.
+//!
+//! These tests exercise each preset by routing a request through it and
+//! asserting on the resulting response. Unit tests in
+//! `src/http/presets/*.rs` only confirm constructors don't panic — these
+//! tests confirm the layers actually behave as documented.
+//!
+//! ## Conventions
+//!
+//! - `tokio::time::pause()` + `advance()` for timeout determinism
+//!   (no wall-clock sleeps; see `octarine-test-resilience` skill).
+//! - All requests are dispatched via `Router::oneshot()` from
+//!   `tower::ServiceExt` — same pattern as `tests/http/request_id.rs`.
+
+#![allow(clippy::panic, clippy::expect_used)]
+
+use std::io::Write;
+use std::time::Duration;
+
+use axum::{
+    Router,
+    body::Body,
+    http::{HeaderValue, Method, Request, StatusCode, header},
+    response::IntoResponse,
+    routing::{get, post},
+};
+use http_body_util::BodyExt;
+use octarine::http::presets::{compression, cors, limits, timeout};
+use tower::ServiceExt;
+
+// ============================================================================
+// CORS — Access-Control-* response headers
+// ============================================================================
+
+/// `development()` allows any origin and sets credentials to false (required
+/// when wildcards are used).
+#[tokio::test]
+async fn test_cors_development_allows_any_origin() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(cors::development());
+
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/")
+        .header(header::ORIGIN, "https://random.example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    let allow_origin = response
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .expect("should set Access-Control-Allow-Origin");
+
+    // development() uses AllowOrigin::any() which sets the wildcard
+    assert_eq!(allow_origin, HeaderValue::from_static("*"));
+
+    // development() must not enable credentials with a wildcard origin
+    assert!(
+        response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_CREDENTIALS)
+            .is_none(),
+        "development must not set Allow-Credentials with wildcard origin",
+    );
+}
+
+/// `production(&["https://allowed"])` echoes back only the configured origin
+/// and enables credentials.
+#[tokio::test]
+async fn test_cors_production_allows_configured_origin() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(cors::production(&["https://allowed.example.com"]));
+
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/")
+        .header(header::ORIGIN, "https://allowed.example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "POST")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    let allow_origin = response
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .expect("should echo allowed origin");
+    assert_eq!(
+        allow_origin,
+        HeaderValue::from_static("https://allowed.example.com"),
+    );
+
+    // production() must enable credentials
+    let allow_credentials = response
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_CREDENTIALS)
+        .expect("should enable credentials");
+    assert_eq!(allow_credentials, HeaderValue::from_static("true"));
+}
+
+/// `production(&["https://allowed"])` does NOT echo back disallowed origins.
+#[tokio::test]
+async fn test_cors_production_rejects_disallowed_origin() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(cors::production(&["https://allowed.example.com"]));
+
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/")
+        .header(header::ORIGIN, "https://attacker.example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "POST")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    // tower-http omits the Allow-Origin header entirely for non-matching origins
+    assert!(
+        response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none(),
+        "must not echo disallowed origin",
+    );
+}
+
+/// `read_only(&[])` allows any origin but only GET/OPTIONS methods.
+#[tokio::test]
+async fn test_cors_read_only_advertises_get_only() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(cors::read_only(&[]));
+
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/")
+        .header(header::ORIGIN, "https://anyone.example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    let allow_methods = response
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_METHODS)
+        .expect("should advertise allowed methods")
+        .to_str()
+        .expect("ASCII methods");
+
+    assert!(allow_methods.contains("GET"), "must allow GET");
+    assert!(allow_methods.contains("OPTIONS"), "must allow OPTIONS");
+    assert!(
+        !allow_methods.contains("POST"),
+        "read_only must not advertise POST: got {allow_methods}",
+    );
+    assert!(
+        !allow_methods.contains("DELETE"),
+        "read_only must not advertise DELETE: got {allow_methods}",
+    );
+}
+
+/// `read_only` advertises a 24-hour max-age (vs 1-hour for read/write
+/// presets) so browsers cache the preflight longer.
+#[tokio::test]
+async fn test_cors_read_only_advertises_long_max_age() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(cors::read_only(&[]));
+
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/")
+        .header(header::ORIGIN, "https://anyone.example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    let max_age = response
+        .headers()
+        .get(header::ACCESS_CONTROL_MAX_AGE)
+        .expect("should set Max-Age")
+        .to_str()
+        .expect("ASCII");
+
+    assert_eq!(max_age, "86400", "read_only must use 24h max-age");
+}
+
+/// `development` and `production` advertise a 1-hour max-age.
+#[tokio::test]
+async fn test_cors_default_advertises_one_hour_max_age() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(cors::development());
+
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/")
+        .header(header::ORIGIN, "https://anyone.example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    let max_age = response
+        .headers()
+        .get(header::ACCESS_CONTROL_MAX_AGE)
+        .expect("should set Max-Age")
+        .to_str()
+        .expect("ASCII");
+
+    assert_eq!(max_age, "3600", "development must use 1h max-age");
+}
+
+// ============================================================================
+// Body limits — 413 PAYLOAD_TOO_LARGE
+// ============================================================================
+
+async fn echo_body(body: Body) -> impl IntoResponse {
+    let bytes = body.collect().await.expect("collect body").to_bytes();
+    bytes.len().to_string()
+}
+
+/// `default_body()` (2 MB) rejects an oversized payload with 413.
+#[tokio::test]
+async fn test_limits_default_body_rejects_oversized() {
+    let app = Router::new()
+        .route("/", post(echo_body))
+        .layer(limits::default_body());
+
+    // 2 MB + 1 byte
+    let payload = vec![0_u8; (2 * 1024 * 1024) + 1];
+    let len = payload.len();
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(header::CONTENT_LENGTH, len.to_string())
+        .body(Body::from(payload))
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+/// `default_body()` (2 MB) admits a payload at the limit.
+#[tokio::test]
+async fn test_limits_default_body_admits_under_limit() {
+    let app = Router::new()
+        .route("/", post(echo_body))
+        .layer(limits::default_body());
+
+    // Just under the 2 MB limit.
+    let payload = vec![0_u8; 1024 * 1024];
+    let len = payload.len();
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(header::CONTENT_LENGTH, len.to_string())
+        .body(Body::from(payload))
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// `large_body()` (10 MB) admits a payload that `default_body()` would reject.
+#[tokio::test]
+async fn test_limits_large_body_admits_3mb() {
+    let app = Router::new()
+        .route("/", post(echo_body))
+        .layer(limits::large_body());
+
+    // 3 MB — would be rejected by default_body() (2 MB) but allowed by large_body() (10 MB).
+    let payload = vec![0_u8; 3 * 1024 * 1024];
+    let len = payload.len();
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(header::CONTENT_LENGTH, len.to_string())
+        .body(Body::from(payload))
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// `custom_body(N)` enforces exactly N bytes.
+#[tokio::test]
+async fn test_limits_custom_body_enforces_specified_limit() {
+    let app = Router::new()
+        .route("/", post(echo_body))
+        .layer(limits::custom_body(1024));
+
+    // 2 KB exceeds the 1 KB limit
+    let payload = vec![0_u8; 2048];
+    let len = payload.len();
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(header::CONTENT_LENGTH, len.to_string())
+        .body(Body::from(payload))
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+// ============================================================================
+// Timeout — 408 REQUEST_TIMEOUT after deadline
+// ============================================================================
+
+/// `quick_timeout()` (10 s) returns 408 when the handler runs longer than the
+/// deadline. Uses `tokio::time::pause()` + `advance()` to control time
+/// deterministically — no wall-clock sleeps.
+#[tokio::test(start_paused = true)]
+async fn test_timeout_quick_fires_after_deadline() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                // Sleep "longer than" the 10 s quick_timeout; with paused
+                // time this only resolves once the test advances the clock.
+                tokio::time::sleep(Duration::from_secs(11)).await;
+                "ok"
+            }),
+        )
+        .layer(timeout::quick_timeout());
+
+    let request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let pending = tokio::spawn(app.oneshot(request));
+
+    // Advance just past the 10 s deadline. tower-http's TimeoutLayer wakes
+    // and emits 408. The handler's 11 s sleep is still pending and gets
+    // cancelled.
+    tokio::time::advance(Duration::from_secs(11)).await;
+
+    let response = pending
+        .await
+        .expect("join handle")
+        .expect("response result");
+
+    assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+}
+
+/// Handler that completes promptly returns 200 even with a long timeout.
+#[tokio::test(start_paused = true)]
+async fn test_timeout_long_admits_fast_handler() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(timeout::long_timeout()); // 120 s
+
+    let request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// `quick_timeout()` (10 s) admits a handler that completes within 5 s.
+#[tokio::test(start_paused = true)]
+async fn test_timeout_quick_admits_within_deadline() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                "ok"
+            }),
+        )
+        .layer(timeout::quick_timeout());
+
+    let request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let pending = tokio::spawn(app.oneshot(request));
+
+    // Advance past the handler's 5 s sleep but well before the 10 s deadline.
+    tokio::time::advance(Duration::from_secs(6)).await;
+
+    let response = pending
+        .await
+        .expect("join handle")
+        .expect("response result");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ============================================================================
+// Compression — Content-Encoding response header
+// ============================================================================
+
+/// `default_compression()` honors `Accept-Encoding: gzip`.
+#[tokio::test]
+async fn test_compression_default_honors_gzip() {
+    let app = Router::new()
+        .route("/", get(|| async { vec![b'A'; 4096] }))
+        .layer(compression::default_compression());
+
+    let request = Request::builder()
+        .uri("/")
+        .header(header::ACCEPT_ENCODING, "gzip")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let encoding = response
+        .headers()
+        .get(header::CONTENT_ENCODING)
+        .expect("should set Content-Encoding")
+        .to_str()
+        .expect("ASCII");
+    assert_eq!(encoding, "gzip");
+}
+
+/// `gzip_only()` does NOT serve brotli even when the client prefers it,
+/// because br/deflate/zstd are explicitly disabled.
+#[tokio::test]
+async fn test_compression_gzip_only_rejects_brotli() {
+    let app = Router::new()
+        .route("/", get(|| async { vec![b'A'; 4096] }))
+        .layer(compression::gzip_only());
+
+    let request = Request::builder()
+        .uri("/")
+        .header(header::ACCEPT_ENCODING, "br")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    // No br support — the layer must serve the response uncompressed
+    // rather than emitting Content-Encoding: br.
+    let encoding = response.headers().get(header::CONTENT_ENCODING);
+    assert!(
+        encoding != Some(&HeaderValue::from_static("br")),
+        "gzip_only must not serve brotli; got {encoding:?}",
+    );
+}
+
+/// `gzip_only()` serves gzip when the client accepts it.
+#[tokio::test]
+async fn test_compression_gzip_only_serves_gzip() {
+    let app = Router::new()
+        .route("/", get(|| async { vec![b'A'; 4096] }))
+        .layer(compression::gzip_only());
+
+    let request = Request::builder()
+        .uri("/")
+        .header(header::ACCEPT_ENCODING, "gzip")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+
+    let encoding = response
+        .headers()
+        .get(header::CONTENT_ENCODING)
+        .expect("should set Content-Encoding")
+        .to_str()
+        .expect("ASCII");
+    assert_eq!(encoding, "gzip");
+}
+
+/// `request_decompression()` decodes a gzipped request body before the handler
+/// sees it.
+#[tokio::test]
+async fn test_request_decompression_inflates_gzipped_body() {
+    let app = Router::new()
+        .route("/", post(echo_body))
+        .layer(compression::request_decompression());
+
+    let plaintext = b"hello world".repeat(100);
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&plaintext).expect("gzip write");
+    let gzipped = encoder.finish().expect("gzip finish");
+
+    assert!(
+        gzipped.len() < plaintext.len(),
+        "test fixture must actually be compressed",
+    );
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(header::CONTENT_ENCODING, "gzip")
+        .body(Body::from(gzipped))
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let received_len: usize = std::str::from_utf8(&body)
+        .expect("ASCII length")
+        .parse()
+        .expect("parse usize");
+
+    // The handler must have seen the inflated payload, not the gzipped one.
+    assert_eq!(received_len, plaintext.len());
+}


### PR DESCRIPTION
## Summary

- Replaces ~26 construction-only preset tests (`let _layer = X::new()` with no assertions) with assertions that actually catch regressions. A swap between two preset constants (e.g., `QUICK_TIMEOUT` vs `LONG_TIMEOUT`) now fails tests rather than silently shipping.
- `rate_limit`: extracts preset rates into module constants matching the existing `limits.rs` / `timeout.rs` pattern; adds a `#[cfg(test)] pub(crate) fn config()` accessor on `RateLimitBuilder`; replaces 3 builder smoke tests with 8 assertions covering defaults, rpm→rps conversion, minimum-clamp invariants, and chained-setter composition; adds `test_preset_rates`.
- New `tests/http/presets.rs` — 17 behavioral integration tests dispatched via `Router::oneshot()` (matches the existing `tests/http/request_id.rs` pattern):
  - **CORS** (6): wildcard + no-credentials for `development`; origin echo + credentials for `production`; disallowed-origin rejection; GET/OPTIONS-only for `read_only`; 24h vs 1h `Access-Control-Max-Age`.
  - **Limits** (4): 413 on oversized; 200 on under-size; `large_body` admits 3 MB; `custom_body(N)` enforces specified bytes.
  - **Timeout** (3): 408 fires past `quick_timeout` deadline; 200 within deadline; 200 fast handler under `long_timeout` — all using `#[tokio::test(start_paused = true)]` + `tokio::time::advance()` (no wall-clock sleeps, per `octarine-test-resilience`).
  - **Compression** (4): `default` honors gzip; `gzip_only` rejects brotli but serves gzip; `request_decompression` round-trips a gzipped POST body.
- Other preset modules retain construction tests as smoke checks with a comment pointing at the integration file (prevents the next audit pass from re-flagging them).

## Why no behavioral test for `rate_limit::GovernorLayer`

`tower_governor::PeerIpKeyExtractor` reads `ConnectInfo<SocketAddr>` from request extensions, which `Router::oneshot()` does not populate. Faking it would primarily test `tower_governor` rather than our preset values. Builder-state assertions on `RateLimitBuilder` catch the realistic regression: someone changing `100/min` to `1000/min` in `api()`.

## Test plan

- [x] `just test-mod "http::presets::rate_limit" "http"` — 13 tests pass (was 8, all assertion-bearing now)
- [x] `just test-octarine` — 6427 unit + integration + doctests pass; 0 failures
- [x] `just clippy`, `just fmt-check`, `just arch-check` — all green
- [x] **Sanity check**: temporarily swapped `QUICK_TIMEOUT` and `LONG_TIMEOUT` constants — both `test_preset_durations` (unit) and `test_timeout_quick_fires_after_deadline` (integration) failed as expected; reverted.

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)