### PR TITLE
test(crypto, observe): add per-test tokio::time::timeout guards

### DIFF
--- a/crates/octarine/src/crypto/secrets/encrypted_storage.rs
+++ b/crates/octarine/src/crypto/secrets/encrypted_storage.rs
@@ -797,215 +797,268 @@ impl EncryptedStorageBuilder {
 mod tests {
     use super::*;
 
+    /// Per-test executor timeout. Prevents a stalled runtime or held lock
+    /// from hanging CI; longest legitimate internal deadline below is the
+    /// 5 s poll loop in `test_background_cleanup`.
+    const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
     #[tokio::test]
     async fn test_new() {
-        let storage = EncryptedSecretStorage::new();
-        assert!(storage.is_empty().await);
-        assert!(storage.id().is_none());
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
+            assert!(storage.is_empty().await);
+            assert!(storage.id().is_none());
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_builder() {
-        let storage = EncryptedSecretStorage::builder()
-            .with_id("test-encrypted")
-            .with_cleanup_interval(Duration::from_secs(30))
-            .build();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::builder()
+                .with_id("test-encrypted")
+                .with_cleanup_interval(Duration::from_secs(30))
+                .build();
 
-        assert_eq!(storage.id(), Some("test-encrypted"));
-        assert_eq!(storage.cleanup_interval(), Duration::from_secs(30));
+            assert_eq!(storage.id(), Some("test-encrypted"));
+            assert_eq!(storage.cleanup_interval(), Duration::from_secs(30));
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_insert_and_access() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        storage.insert("api_key", "sk-12345").await.expect("insert");
+            storage.insert("api_key", "sk-12345").await.expect("insert");
 
-        assert!(storage.contains("api_key").await);
-        assert_eq!(storage.len().await, 1);
+            assert!(storage.contains("api_key").await);
+            assert_eq!(storage.len().await, 1);
 
-        // Access via closure
-        let result = storage
-            .with_secret("api_key", "test", |value| {
-                assert_eq!(value, "sk-12345");
-                value.len()
-            })
-            .await
-            .expect("with_secret");
+            // Access via closure
+            let result = storage
+                .with_secret("api_key", "test", |value| {
+                    assert_eq!(value, "sk-12345");
+                    value.len()
+                })
+                .await
+                .expect("with_secret");
 
-        assert_eq!(result, 8);
+            assert_eq!(result, 8);
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_insert_typed() {
-        let storage = EncryptedSecretStorage::builder()
-            .with_id("typed-test")
-            .build();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::builder()
+                .with_id("typed-test")
+                .build();
 
-        storage
-            .insert_typed(
-                "password",
-                "hunter2",
-                SecretType::Password,
-                Classification::Restricted,
-                None,
-            )
-            .await
-            .expect("insert_typed");
+            storage
+                .insert_typed(
+                    "password",
+                    "hunter2",
+                    SecretType::Password,
+                    Classification::Restricted,
+                    None,
+                )
+                .await
+                .expect("insert_typed");
 
-        let result = storage
-            .with_secret("password", "auth", |value| value.to_string())
-            .await
-            .expect("with_secret");
+            let result = storage
+                .with_secret("password", "auth", |value| value.to_string())
+                .await
+                .expect("with_secret");
 
-        assert_eq!(result, "hunter2");
+            assert_eq!(result, "hunter2");
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_not_found() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        let result = storage.with_secret("missing", "test", |_| ()).await;
+            let result = storage.with_secret("missing", "test", |_| ()).await;
 
-        assert!(matches!(result, Err(EncryptedStorageError::NotFound(_))));
+            assert!(matches!(result, Err(EncryptedStorageError::NotFound(_))));
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_expired() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        storage
-            .insert_typed(
-                "ephemeral",
-                "temp",
-                SecretType::AuthToken,
-                Classification::Confidential,
-                Some(Duration::from_nanos(1)), // Instant expiration
-            )
-            .await
-            .expect("insert_typed");
+            storage
+                .insert_typed(
+                    "ephemeral",
+                    "temp",
+                    SecretType::AuthToken,
+                    Classification::Confidential,
+                    Some(Duration::from_nanos(1)), // Instant expiration
+                )
+                .await
+                .expect("insert_typed");
 
-        tokio::time::sleep(Duration::from_millis(1)).await;
+            tokio::time::sleep(Duration::from_millis(1)).await;
 
-        let result = storage.with_secret("ephemeral", "test", |_| ()).await;
+            let result = storage.with_secret("ephemeral", "test", |_| ()).await;
 
-        assert!(matches!(result, Err(EncryptedStorageError::Expired(_))));
+            assert!(matches!(result, Err(EncryptedStorageError::Expired(_))));
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_with_secret_bytes() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        storage.insert("binary", "hello").await.expect("insert");
+            storage.insert("binary", "hello").await.expect("insert");
 
-        let result = storage
-            .with_secret_bytes("binary", "test", |bytes| bytes.len())
-            .await
-            .expect("with_secret_bytes");
+            let result = storage
+                .with_secret_bytes("binary", "test", |bytes| bytes.len())
+                .await
+                .expect("with_secret_bytes");
 
-        assert_eq!(result, 5);
+            assert_eq!(result, 5);
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_remove() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        storage.insert("key", "value").await.expect("insert");
-        assert!(storage.contains("key").await);
+            storage.insert("key", "value").await.expect("insert");
+            assert!(storage.contains("key").await);
 
-        assert!(storage.remove("key").await);
-        assert!(!storage.contains("key").await);
-        assert!(!storage.remove("key").await);
+            assert!(storage.remove("key").await);
+            assert!(!storage.contains("key").await);
+            assert!(!storage.remove("key").await);
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_clear() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        storage.insert("key1", "value1").await.expect("insert");
-        storage.insert("key2", "value2").await.expect("insert");
+            storage.insert("key1", "value1").await.expect("insert");
+            storage.insert("key2", "value2").await.expect("insert");
 
-        storage.clear().await;
+            storage.clear().await;
 
-        assert!(storage.is_empty().await);
+            assert!(storage.is_empty().await);
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_names() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        storage.insert("key1", "value1").await.expect("insert");
-        storage.insert("key2", "value2").await.expect("insert");
+            storage.insert("key1", "value1").await.expect("insert");
+            storage.insert("key2", "value2").await.expect("insert");
 
-        let names = storage.names().await;
-        assert_eq!(names.len(), 2);
-        assert!(names.contains(&"key1".to_string()));
-        assert!(names.contains(&"key2".to_string()));
+            let names = storage.names().await;
+            assert_eq!(names.len(), 2);
+            assert!(names.contains(&"key1".to_string()));
+            assert!(names.contains(&"key2".to_string()));
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_purge_expired() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        // Add expiring secret
-        storage
-            .insert_typed(
-                "expired",
-                "temp",
-                SecretType::AuthToken,
-                Classification::Confidential,
-                Some(Duration::from_nanos(1)),
-            )
-            .await
-            .expect("insert_typed");
+            // Add expiring secret
+            storage
+                .insert_typed(
+                    "expired",
+                    "temp",
+                    SecretType::AuthToken,
+                    Classification::Confidential,
+                    Some(Duration::from_nanos(1)),
+                )
+                .await
+                .expect("insert_typed");
 
-        // Add permanent secret
-        storage.insert("permanent", "value").await.expect("insert");
+            // Add permanent secret
+            storage.insert("permanent", "value").await.expect("insert");
 
-        tokio::time::sleep(Duration::from_millis(1)).await;
+            tokio::time::sleep(Duration::from_millis(1)).await;
 
-        let purged = storage.purge_expired().await;
-        assert_eq!(purged, 1);
-        assert_eq!(storage.len().await, 1);
-        assert!(storage.contains("permanent").await);
+            let purged = storage.purge_expired().await;
+            assert_eq!(purged, 1);
+            assert_eq!(storage.len().await, 1);
+            assert!(storage.contains("permanent").await);
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_background_cleanup() {
-        let storage = EncryptedSecretStorage::builder()
-            .with_id("bg-test")
-            .with_cleanup_interval(Duration::from_millis(10))
-            .build();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::builder()
+                .with_id("bg-test")
+                .with_cleanup_interval(Duration::from_millis(10))
+                .build();
 
-        // Add expiring secret
-        storage
-            .insert_typed(
-                "ephemeral",
-                "temp",
-                SecretType::AuthToken,
-                Classification::Confidential,
-                Some(Duration::from_nanos(1)),
-            )
-            .await
-            .expect("insert_typed");
+            // Add expiring secret
+            storage
+                .insert_typed(
+                    "ephemeral",
+                    "temp",
+                    SecretType::AuthToken,
+                    Classification::Confidential,
+                    Some(Duration::from_nanos(1)),
+                )
+                .await
+                .expect("insert_typed");
 
-        storage.insert("permanent", "value").await.expect("insert");
+            storage.insert("permanent", "value").await.expect("insert");
 
-        storage.start_cleanup().await;
-        assert!(storage.is_cleanup_running().await);
+            storage.start_cleanup().await;
+            assert!(storage.is_cleanup_running().await);
 
-        // Poll until cleanup runs (with timeout) - more reliable than fixed sleep
-        let start = std::time::Instant::now();
-        let timeout = Duration::from_secs(5);
-        while storage.len().await > 1 && start.elapsed() < timeout {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+            // Poll until cleanup runs (with timeout) - more reliable than fixed sleep
+            let start = std::time::Instant::now();
+            let timeout = Duration::from_secs(5);
+            while storage.len().await > 1 && start.elapsed() < timeout {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
 
-        assert_eq!(storage.len().await, 1);
-        assert!(storage.contains("permanent").await);
+            assert_eq!(storage.len().await, 1);
+            assert!(storage.contains("permanent").await);
 
-        storage.stop_cleanup().await;
-        assert!(!storage.is_cleanup_running().await);
+            storage.stop_cleanup().await;
+            assert!(!storage.is_cleanup_running().await);
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[test]
@@ -1023,19 +1076,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_debug_shows_encrypted() {
-        let storage = EncryptedSecretStorage::builder()
-            .with_id("debug-test")
-            .build();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::builder()
+                .with_id("debug-test")
+                .build();
 
-        storage
-            .insert("secret", "super-secret")
-            .await
-            .expect("insert");
+            storage
+                .insert("secret", "super-secret")
+                .await
+                .expect("insert");
 
-        let debug = format!("{:?}", storage);
-        assert!(debug.contains("[ENCRYPTED]"));
-        assert!(debug.contains("debug-test"));
-        assert!(!debug.contains("super-secret"));
+            let debug = format!("{:?}", storage);
+            assert!(debug.contains("[ENCRYPTED]"));
+            assert!(debug.contains("debug-test"));
+            assert!(!debug.contains("super-secret"));
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[test]
@@ -1055,32 +1112,40 @@ mod tests {
 
     #[tokio::test]
     async fn test_with_secret_bytes_not_found() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        let result = storage.with_secret_bytes("missing", "test", |_| ()).await;
+            let result = storage.with_secret_bytes("missing", "test", |_| ()).await;
 
-        assert!(matches!(result, Err(EncryptedStorageError::NotFound(_))));
+            assert!(matches!(result, Err(EncryptedStorageError::NotFound(_))));
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 
     #[tokio::test]
     async fn test_with_secret_bytes_expired() {
-        let storage = EncryptedSecretStorage::new();
+        tokio::time::timeout(TEST_TIMEOUT, async {
+            let storage = EncryptedSecretStorage::new();
 
-        storage
-            .insert_typed(
-                "ephemeral",
-                "temp",
-                SecretType::AuthToken,
-                Classification::Confidential,
-                Some(Duration::from_nanos(1)),
-            )
-            .await
-            .expect("insert_typed");
+            storage
+                .insert_typed(
+                    "ephemeral",
+                    "temp",
+                    SecretType::AuthToken,
+                    Classification::Confidential,
+                    Some(Duration::from_nanos(1)),
+                )
+                .await
+                .expect("insert_typed");
 
-        tokio::time::sleep(Duration::from_millis(1)).await;
+            tokio::time::sleep(Duration::from_millis(1)).await;
 
-        let result = storage.with_secret_bytes("ephemeral", "test", |_| ()).await;
+            let result = storage.with_secret_bytes("ephemeral", "test", |_| ()).await;
 
-        assert!(matches!(result, Err(EncryptedStorageError::Expired(_))));
+            assert!(matches!(result, Err(EncryptedStorageError::Expired(_))));
+        })
+        .await
+        .expect("test timed out after 30s");
     }
 }

--- a/crates/octarine/tests/crypto/encrypted_storage.rs
+++ b/crates/octarine/tests/crypto/encrypted_storage.rs
@@ -3,6 +3,11 @@
 use std::time::Duration;
 
 use octarine::crypto::secrets::{Classification, EncryptedSecretStorage, SecretType};
+use tokio::time::timeout;
+
+/// Per-test executor timeout. Prevents a stalled runtime or held lock from
+/// hanging CI; longest legitimate internal deadline in this file is ~100 ms.
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 // =========================================================================
 // Basic insert and access (sync)
@@ -40,25 +45,29 @@ fn test_access_nonexistent_sync() {
 /// Insert typed with classification and access (async).
 #[tokio::test]
 async fn test_insert_typed_and_access_async() {
-    let storage = EncryptedSecretStorage::new();
+    timeout(TEST_TIMEOUT, async {
+        let storage = EncryptedSecretStorage::new();
 
-    storage
-        .insert_typed(
-            "db_password",
-            "hunter2",
-            SecretType::DatabaseCredential,
-            Classification::Restricted,
-            None,
-        )
-        .await
-        .expect("insert typed");
+        storage
+            .insert_typed(
+                "db_password",
+                "hunter2",
+                SecretType::DatabaseCredential,
+                Classification::Restricted,
+                None,
+            )
+            .await
+            .expect("insert typed");
 
-    let value = storage
-        .with_secret("db_password", "db_connect", |v| v.to_string())
-        .await
-        .expect("access");
+        let value = storage
+            .with_secret("db_password", "db_connect", |v| v.to_string())
+            .await
+            .expect("access");
 
-    assert_eq!(value, "hunter2");
+        assert_eq!(value, "hunter2");
+    })
+    .await
+    .expect("test timed out after 30s");
 }
 
 // =========================================================================
@@ -68,74 +77,82 @@ async fn test_insert_typed_and_access_async() {
 /// Insert with short TTL → wait → access fails.
 #[tokio::test]
 async fn test_ttl_expiration() {
-    let storage = EncryptedSecretStorage::new();
+    timeout(TEST_TIMEOUT, async {
+        let storage = EncryptedSecretStorage::new();
 
-    storage
-        .insert_typed(
-            "temp_token",
-            "short-lived-value",
-            SecretType::AuthToken,
-            Classification::Confidential,
-            Some(Duration::from_millis(50)),
-        )
-        .await
-        .expect("insert with TTL");
+        storage
+            .insert_typed(
+                "temp_token",
+                "short-lived-value",
+                SecretType::AuthToken,
+                Classification::Confidential,
+                Some(Duration::from_millis(50)),
+            )
+            .await
+            .expect("insert with TTL");
 
-    // Should be accessible immediately
-    let value = storage
-        .with_secret("temp_token", "immediate_read", |v| v.to_string())
-        .await
-        .expect("immediate access");
-    assert_eq!(value, "short-lived-value");
+        // Should be accessible immediately
+        let value = storage
+            .with_secret("temp_token", "immediate_read", |v| v.to_string())
+            .await
+            .expect("immediate access");
+        assert_eq!(value, "short-lived-value");
 
-    // Wait for expiration
-    tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait for expiration
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
-    // Should now be expired
-    let result = storage
-        .with_secret("temp_token", "expired_read", |v| v.to_string())
-        .await;
-    assert!(result.is_err(), "Expired secret should not be accessible");
+        // Should now be expired
+        let result = storage
+            .with_secret("temp_token", "expired_read", |v| v.to_string())
+            .await;
+        assert!(result.is_err(), "Expired secret should not be accessible");
+    })
+    .await
+    .expect("test timed out after 30s");
 }
 
 /// purge_expired removes expired entries.
 #[tokio::test]
 async fn test_purge_expired() {
-    let storage = EncryptedSecretStorage::new();
+    timeout(TEST_TIMEOUT, async {
+        let storage = EncryptedSecretStorage::new();
 
-    storage
-        .insert_typed(
-            "short",
-            "expires-soon",
-            SecretType::Generic,
-            Classification::Internal,
-            Some(Duration::from_millis(10)),
-        )
-        .await
-        .expect("insert short TTL");
+        storage
+            .insert_typed(
+                "short",
+                "expires-soon",
+                SecretType::Generic,
+                Classification::Internal,
+                Some(Duration::from_millis(10)),
+            )
+            .await
+            .expect("insert short TTL");
 
-    storage
-        .insert_typed(
-            "long",
-            "lives-forever",
-            SecretType::Generic,
-            Classification::Internal,
-            None,
-        )
-        .await
-        .expect("insert no TTL");
+        storage
+            .insert_typed(
+                "long",
+                "lives-forever",
+                SecretType::Generic,
+                Classification::Internal,
+                None,
+            )
+            .await
+            .expect("insert no TTL");
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let purged = storage.purge_expired().await;
-    assert!(purged >= 1, "Should purge at least 1 expired secret");
+        let purged = storage.purge_expired().await;
+        assert!(purged >= 1, "Should purge at least 1 expired secret");
 
-    // Long-lived secret still accessible
-    let value = storage
-        .with_secret("long", "read", |v| v.to_string())
-        .await
-        .expect("long-lived should still work");
-    assert_eq!(value, "lives-forever");
+        // Long-lived secret still accessible
+        let value = storage
+            .with_secret("long", "read", |v| v.to_string())
+            .await
+            .expect("long-lived should still work");
+        assert_eq!(value, "lives-forever");
+    })
+    .await
+    .expect("test timed out after 30s");
 }
 
 // =========================================================================
@@ -145,19 +162,23 @@ async fn test_purge_expired() {
 /// Remove → contains returns false.
 #[tokio::test]
 async fn test_remove() {
-    let storage = EncryptedSecretStorage::new();
+    timeout(TEST_TIMEOUT, async {
+        let storage = EncryptedSecretStorage::new();
 
-    storage.insert("removable", "value").await.expect("insert");
+        storage.insert("removable", "value").await.expect("insert");
 
-    assert!(storage.contains("removable").await);
+        assert!(storage.contains("removable").await);
 
-    let removed = storage.remove("removable").await;
-    assert!(removed, "Should report removal");
+        let removed = storage.remove("removable").await;
+        assert!(removed, "Should report removal");
 
-    assert!(
-        !storage.contains("removable").await,
-        "Should no longer contain removed secret"
-    );
+        assert!(
+            !storage.contains("removable").await,
+            "Should no longer contain removed secret"
+        );
+    })
+    .await
+    .expect("test timed out after 30s");
 }
 
 // =========================================================================
@@ -167,45 +188,53 @@ async fn test_remove() {
 /// Store multiple secrets, verify each independently.
 #[tokio::test]
 async fn test_multiple_secrets() {
-    let storage = EncryptedSecretStorage::new();
+    timeout(TEST_TIMEOUT, async {
+        let storage = EncryptedSecretStorage::new();
 
-    storage.insert("key1", "value1").await.expect("insert 1");
-    storage.insert("key2", "value2").await.expect("insert 2");
-    storage.insert("key3", "value3").await.expect("insert 3");
+        storage.insert("key1", "value1").await.expect("insert 1");
+        storage.insert("key2", "value2").await.expect("insert 2");
+        storage.insert("key3", "value3").await.expect("insert 3");
 
-    assert_eq!(storage.len().await, 3);
+        assert_eq!(storage.len().await, 3);
 
-    let v1 = storage
-        .with_secret("key1", "read", |v| v.to_string())
-        .await
-        .expect("read 1");
-    let v2 = storage
-        .with_secret("key2", "read", |v| v.to_string())
-        .await
-        .expect("read 2");
-    let v3 = storage
-        .with_secret("key3", "read", |v| v.to_string())
-        .await
-        .expect("read 3");
+        let v1 = storage
+            .with_secret("key1", "read", |v| v.to_string())
+            .await
+            .expect("read 1");
+        let v2 = storage
+            .with_secret("key2", "read", |v| v.to_string())
+            .await
+            .expect("read 2");
+        let v3 = storage
+            .with_secret("key3", "read", |v| v.to_string())
+            .await
+            .expect("read 3");
 
-    assert_eq!(v1, "value1");
-    assert_eq!(v2, "value2");
-    assert_eq!(v3, "value3");
+        assert_eq!(v1, "value1");
+        assert_eq!(v2, "value2");
+        assert_eq!(v3, "value3");
 
-    let names = storage.names().await;
-    assert_eq!(names.len(), 3);
+        let names = storage.names().await;
+        assert_eq!(names.len(), 3);
+    })
+    .await
+    .expect("test timed out after 30s");
 }
 
 /// clear removes all secrets.
 #[tokio::test]
 async fn test_clear() {
-    let storage = EncryptedSecretStorage::new();
+    timeout(TEST_TIMEOUT, async {
+        let storage = EncryptedSecretStorage::new();
 
-    storage.insert("a", "1").await.expect("insert a");
-    storage.insert("b", "2").await.expect("insert b");
+        storage.insert("a", "1").await.expect("insert a");
+        storage.insert("b", "2").await.expect("insert b");
 
-    storage.clear().await;
-    assert!(storage.is_empty().await, "Should be empty after clear");
+        storage.clear().await;
+        assert!(storage.is_empty().await, "Should be empty after clear");
+    })
+    .await
+    .expect("test timed out after 30s");
 }
 
 /// Builder configures storage with ID.

--- a/crates/octarine/tests/observe/async_dispatch.rs
+++ b/crates/octarine/tests/observe/async_dispatch.rs
@@ -14,6 +14,11 @@ use octarine::observe::writers::{
 };
 use octarine::{debug, error, info, warn};
 use std::time::Duration;
+use tokio::time::timeout;
+
+/// Per-test executor timeout. Prevents a stalled runtime or held lock from
+/// hanging CI; longest legitimate internal sleep in this file is 100 ms.
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ============================================================================
 // Basic Dispatch Tests
@@ -190,62 +195,70 @@ fn test_health_thresholds() {
 
 #[tokio::test]
 async fn test_dispatch_from_async_context() {
-    super::ensure_test_dispatcher();
+    timeout(TEST_TIMEOUT, async {
+        super::ensure_test_dispatcher();
 
-    let stats_before = dispatcher_stats();
+        let stats_before = dispatcher_stats();
 
-    // Queue events from async context
-    for i in 0..10 {
-        info("async_test", format!("Async event {}", i));
-    }
+        // Queue events from async context
+        for i in 0..10 {
+            info("async_test", format!("Async event {}", i));
+        }
 
-    // Brief pause
-    tokio::time::sleep(Duration::from_millis(50)).await;
+        // Brief pause
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let stats_after = dispatcher_stats();
+        let stats_after = dispatcher_stats();
 
-    let queued = stats_after.total_written - stats_before.total_written;
-    assert!(
-        queued >= 10,
-        "Expected 10 events from async context, got {}",
-        queued
-    );
+        let queued = stats_after.total_written - stats_before.total_written;
+        assert!(
+            queued >= 10,
+            "Expected 10 events from async context, got {}",
+            queued
+        );
+    })
+    .await
+    .expect("test timed out after 30s");
 }
 
 #[tokio::test]
 async fn test_concurrent_dispatch_from_tasks() {
-    super::ensure_test_dispatcher();
+    timeout(TEST_TIMEOUT, async {
+        super::ensure_test_dispatcher();
 
-    let stats_before = dispatcher_stats();
+        let stats_before = dispatcher_stats();
 
-    // Spawn multiple tasks that all log concurrently
-    let mut handles = vec![];
+        // Spawn multiple tasks that all log concurrently
+        let mut handles = vec![];
 
-    for task_id in 0..5 {
-        handles.push(tokio::spawn(async move {
-            for i in 0..10 {
-                info("concurrent_test", format!("Task {} event {}", task_id, i));
-            }
-        }));
-    }
+        for task_id in 0..5 {
+            handles.push(tokio::spawn(async move {
+                for i in 0..10 {
+                    info("concurrent_test", format!("Task {} event {}", task_id, i));
+                }
+            }));
+        }
 
-    // Wait for all tasks
-    for handle in handles {
-        handle.await.expect("Task should complete");
-    }
+        // Wait for all tasks
+        for handle in handles {
+            handle.await.expect("Task should complete");
+        }
 
-    // Brief pause for queuing
-    tokio::time::sleep(Duration::from_millis(100)).await;
+        // Brief pause for queuing
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let stats_after = dispatcher_stats();
+        let stats_after = dispatcher_stats();
 
-    // Should have queued 50 events (5 tasks * 10 events each)
-    let queued = stats_after.total_written - stats_before.total_written;
-    assert!(
-        queued >= 45,
-        "Expected at least 45 events from concurrent tasks, got {}",
-        queued
-    );
+        // Should have queued 50 events (5 tasks * 10 events each)
+        let queued = stats_after.total_written - stats_before.total_written;
+        assert!(
+            queued >= 45,
+            "Expected at least 45 events from concurrent tasks, got {}",
+            queued
+        );
+    })
+    .await
+    .expect("test timed out after 30s");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Wrap 23 `#[tokio::test]` async functions with a 30 s `tokio::time::timeout` so a stalled runtime or held lock fails fast with `"test timed out after 30s"` instead of hanging until the outer CI job timeout.
- Three files affected: `tests/crypto/encrypted_storage.rs` (6 tests), `tests/observe/async_dispatch.rs` (2 tests), `src/crypto/secrets/encrypted_storage.rs` inline tests (15 tests).
- Each file gets a single `const TEST_TIMEOUT: Duration = Duration::from_secs(30);`. The inline test module uses fully qualified `tokio::time::timeout` to avoid shadowing the local `timeout` variable inside `test_background_cleanup`'s 5 s poll loop.
- Out of scope (filed separately as #93): replacing fixed sleeps with polling loops in some of the same files. This PR only adds the executor-level guardrail.

## Test plan

- [x] `just preflight` (fmt + clippy + arch-check + tests) — clean
- [x] `cargo test -p octarine --test crypto_integration -- crypto::encrypted_storage` — 9/9 pass
- [x] `cargo test -p octarine --test observe_integration -- observe::async_dispatch` — 31/31 pass
- [x] `just test-mod "crypto::secrets::encrypted_storage"` — 18/18 pass
- [x] Manual sanity check: forced 60 s sleep inside a tightened 50 ms wrapper — test panicked with `"test timed out after 30s: Elapsed(())"` in ~0.2 s, confirming the timeout fires correctly.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)