### PR TITLE
fix(observe): add metrics instrumentation to 5 Layer 3 builders

### DIFF
--- a/crates/octarine/src/data/formats/builder.rs
+++ b/crates/octarine/src/data/formats/builder.rs
@@ -2,29 +2,62 @@
 //!
 //! Wraps the primitives FormatBuilder with audit trails.
 
+use std::time::Instant;
+
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 
+use crate::observe::metrics::record;
 use crate::observe::{debug, warn};
 use crate::primitives::data::formats::{FormatBuilder as PrimBuilder, FormatType, XmlDocument};
 use crate::primitives::types::Result;
+
+crate::define_metrics! {
+    parse_ms => "data.formats.parse_ms",
+    serialize_ms => "data.formats.serialize_ms",
+    detect_ms => "data.formats.detect_ms",
+}
 
 /// Builder for format parsing and serialization with observability
 ///
 /// This is the Layer 3 wrapper that adds observe instrumentation
 /// to the primitives FormatBuilder.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct FormatBuilder {
     inner: PrimBuilder,
+    emit_events: bool,
+}
+
+impl Default for FormatBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl FormatBuilder {
-    /// Create a new format builder
+    /// Create a new format builder with observe events enabled
     #[must_use]
     pub fn new() -> Self {
         Self {
             inner: PrimBuilder::new(),
+            emit_events: true,
         }
+    }
+
+    /// Create a builder without observe events (for internal use)
+    #[must_use]
+    pub fn silent() -> Self {
+        Self {
+            inner: PrimBuilder::new(),
+            emit_events: false,
+        }
+    }
+
+    /// Enable or disable observe events
+    #[must_use]
+    pub fn with_events(mut self, emit: bool) -> Self {
+        self.emit_events = emit;
+        self
     }
 
     // ========================================================================
@@ -33,8 +66,15 @@ impl FormatBuilder {
 
     /// Parse JSON content
     pub fn parse_json(&self, input: &str) -> Result<JsonValue> {
+        let start = Instant::now();
         debug("format.parse", "Parsing JSON content");
         let result = self.inner.parse_json(input);
+        if self.emit_events {
+            record(
+                metric_names::parse_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             warn("format.parse", "JSON parsing failed");
         }
@@ -43,14 +83,30 @@ impl FormatBuilder {
 
     /// Serialize value to JSON
     pub fn serialize_json<T: Serialize>(&self, value: &T) -> Result<String> {
+        let start = Instant::now();
         debug("format.serialize", "Serializing to JSON");
-        self.inner.serialize_json(value)
+        let result = self.inner.serialize_json(value);
+        if self.emit_events {
+            record(
+                metric_names::serialize_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
+        result
     }
 
     /// Serialize value to pretty JSON
     pub fn serialize_json_pretty<T: Serialize>(&self, value: &T) -> Result<String> {
+        let start = Instant::now();
         debug("format.serialize", "Serializing to pretty JSON");
-        self.inner.serialize_json_pretty(value)
+        let result = self.inner.serialize_json_pretty(value);
+        if self.emit_events {
+            record(
+                metric_names::serialize_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
+        result
     }
 
     // ========================================================================
@@ -59,8 +115,15 @@ impl FormatBuilder {
 
     /// Parse XML content
     pub fn parse_xml(&self, input: &str) -> Result<XmlDocument> {
+        let start = Instant::now();
         debug("format.parse", "Parsing XML content");
         let result = self.inner.parse_xml(input);
+        if self.emit_events {
+            record(
+                metric_names::parse_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             warn("format.parse", "XML parsing failed");
         }
@@ -69,8 +132,16 @@ impl FormatBuilder {
 
     /// Serialize XML document to string
     pub fn serialize_xml(&self, doc: &XmlDocument) -> Result<String> {
+        let start = Instant::now();
         debug("format.serialize", "Serializing to XML");
-        self.inner.serialize_xml(doc)
+        let result = self.inner.serialize_xml(doc);
+        if self.emit_events {
+            record(
+                metric_names::serialize_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
+        result
     }
 
     // ========================================================================
@@ -79,8 +150,15 @@ impl FormatBuilder {
 
     /// Parse YAML content
     pub fn parse_yaml(&self, input: &str) -> Result<serde_yaml::Value> {
+        let start = Instant::now();
         debug("format.parse", "Parsing YAML content");
         let result = self.inner.parse_yaml(input);
+        if self.emit_events {
+            record(
+                metric_names::parse_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             warn("format.parse", "YAML parsing failed");
         }
@@ -89,8 +167,16 @@ impl FormatBuilder {
 
     /// Serialize value to YAML
     pub fn serialize_yaml<T: Serialize>(&self, value: &T) -> Result<String> {
+        let start = Instant::now();
         debug("format.serialize", "Serializing to YAML");
-        self.inner.serialize_yaml(value)
+        let result = self.inner.serialize_yaml(value);
+        if self.emit_events {
+            record(
+                metric_names::serialize_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
+        result
     }
 
     // ========================================================================
@@ -100,8 +186,15 @@ impl FormatBuilder {
     /// Detect format from content
     #[must_use]
     pub fn detect_format(&self, input: &str) -> Option<FormatType> {
+        let start = Instant::now();
         debug("format.detect", "Detecting format from content");
         let format = self.inner.detect_from_content(input);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if format.is_none() {
             debug("format.detect", "Could not detect format");
         }
@@ -123,6 +216,28 @@ impl FormatBuilder {
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
+    use crate::observe::metrics::{flush_for_testing, snapshot};
+    use std::sync::Mutex;
+
+    static METRICS_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn test_builder_creation() {
+        let builder = FormatBuilder::new();
+        assert!(builder.emit_events);
+
+        let silent = FormatBuilder::silent();
+        assert!(!silent.emit_events);
+    }
+
+    #[test]
+    fn test_with_events_toggle() {
+        let builder = FormatBuilder::new().with_events(false);
+        assert!(!builder.emit_events);
+
+        let builder = FormatBuilder::silent().with_events(true);
+        assert!(builder.emit_events);
+    }
 
     #[test]
     fn test_builder_parse_json() {
@@ -160,6 +275,86 @@ mod tests {
         assert!(matches!(
             builder.detect_format("key: value"),
             Some(FormatType::Yaml)
+        ));
+    }
+
+    #[test]
+    fn test_metrics_parse_ms_recorded() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = FormatBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .histograms
+            .get("data.formats.parse_ms")
+            .map_or(0, |h| h.count);
+
+        let _ = builder.parse_json(r#"{"key": "value"}"#);
+        flush_for_testing();
+
+        let after = snapshot()
+            .histograms
+            .get("data.formats.parse_ms")
+            .map_or(0, |h| h.count);
+        assert!(
+            after > before,
+            "parse_ms histogram should record at least one sample"
+        );
+    }
+
+    #[test]
+    fn test_metrics_serialize_ms_recorded() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = FormatBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .histograms
+            .get("data.formats.serialize_ms")
+            .map_or(0, |h| h.count);
+
+        let _ = builder.serialize_json(&serde_json::json!({"k": "v"}));
+        flush_for_testing();
+
+        let after = snapshot()
+            .histograms
+            .get("data.formats.serialize_ms")
+            .map_or(0, |h| h.count);
+        assert!(after > before, "serialize_ms histogram should record");
+    }
+
+    #[test]
+    fn test_metrics_detect_ms_recorded() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = FormatBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .histograms
+            .get("data.formats.detect_ms")
+            .map_or(0, |h| h.count);
+
+        let _ = builder.detect_format(r#"{"k": "v"}"#);
+        flush_for_testing();
+
+        let after = snapshot()
+            .histograms
+            .get("data.formats.detect_ms")
+            .map_or(0, |h| h.count);
+        assert!(after > before, "detect_ms histogram should record");
+    }
+
+    #[test]
+    fn test_silent_mode_emits_no_metrics() {
+        // Structural test: `silent()` returns a builder with emit_events=false,
+        // and every metric call site in this module is gated by `if self.emit_events`.
+        // A behavioral delta-assertion would race with concurrent tests across the
+        // workspace that hit these same global metric names.
+        let builder = FormatBuilder::silent();
+        assert!(!builder.emit_events);
+
+        // Sanity: invoking through the silent builder still works functionally.
+        let _ = builder.parse_json(r#"{"k": "v"}"#);
+        assert!(matches!(
+            builder.detect_format(r#"{"k": "v"}"#),
+            Some(FormatType::Json)
         ));
     }
 }

--- a/crates/octarine/src/data/text/builder.rs
+++ b/crates/octarine/src/data/text/builder.rs
@@ -10,12 +10,19 @@
 #![allow(dead_code)]
 
 use std::borrow::Cow;
+use std::time::Instant;
 
 use crate::observe::event;
+use crate::observe::metrics::{increment_by, record};
 use crate::primitives::data::text::TextBuilder as PrimitiveTextBuilder;
 use crate::primitives::data::text::TextConfig as PrimitiveTextConfig;
 
 use super::types::TextConfig;
+
+crate::define_metrics! {
+    sanitize_ms => "data.text.sanitize_ms",
+    threats_detected => "data.text.threats_detected",
+}
 
 // ============================================================================
 // TextBuilder
@@ -152,6 +159,7 @@ impl<'a> TextBuilder<'a> {
         let result = self.inner.is_dangerous_control_chars_present();
         if self.emit_events && result {
             event::warn("text.dangerous_control_chars_detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -161,6 +169,7 @@ impl<'a> TextBuilder<'a> {
         let result = self.inner.is_null_bytes_present();
         if self.emit_events && result {
             event::warn("text.null_bytes_detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -197,6 +206,7 @@ impl<'a> TextBuilder<'a> {
         let result = self.inner.is_cursor_controls_present();
         if self.emit_events && result {
             event::warn("text.cursor_controls_detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -224,6 +234,7 @@ impl<'a> TextBuilder<'a> {
         let result = self.inner.is_zero_width_chars_present();
         if self.emit_events && result {
             event::warn("text.zero_width_chars_detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -233,6 +244,7 @@ impl<'a> TextBuilder<'a> {
         let result = self.inner.is_bidi_overrides_present();
         if self.emit_events && result {
             event::warn("text.bidi_overrides_detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -252,6 +264,7 @@ impl<'a> TextBuilder<'a> {
         let result = self.inner.is_mixed_script_present();
         if self.emit_events && result {
             event::warn("text.mixed_script_detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -267,6 +280,7 @@ impl<'a> TextBuilder<'a> {
         let result = self.inner.is_confusable_chars_present();
         if self.emit_events && result {
             event::warn("text.confusable_chars_detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -276,6 +290,7 @@ impl<'a> TextBuilder<'a> {
         let result = self.inner.is_format_chars_present();
         if self.emit_events && result {
             event::warn("text.format_chars_detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -285,6 +300,7 @@ impl<'a> TextBuilder<'a> {
         let result = self.inner.is_private_use_present();
         if self.emit_events && result {
             event::warn("text.private_use_chars_detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -342,7 +358,14 @@ impl<'a> TextBuilder<'a> {
     /// Sanitize text for safe log output using current config
     #[must_use]
     pub fn sanitize_for_log(mut self) -> Self {
+        let start = Instant::now();
         self.inner = self.inner.sanitize_for_log();
+        if self.emit_events {
+            record(
+                metric_names::sanitize_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         self
     }
 
@@ -425,7 +448,14 @@ impl<'a> TextBuilder<'a> {
     /// Normalizes to NFC, strips format chars, zero-width chars, and bidi overrides.
     #[must_use]
     pub fn sanitize_unicode(mut self) -> Self {
+        let start = Instant::now();
         self.inner = self.inner.sanitize_unicode();
+        if self.emit_events {
+            record(
+                metric_names::sanitize_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         self
     }
 
@@ -460,9 +490,14 @@ impl<'a> TextBuilder<'a> {
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
+    use crate::observe::metrics::{flush_for_testing, snapshot};
+    use std::sync::Mutex;
+
+    static METRICS_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_detection_with_events() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Events are enabled by default
         let builder = TextBuilder::new("hello\x00world");
         assert!(builder.is_null_bytes_present());
@@ -477,7 +512,7 @@ mod tests {
 
     #[test]
     fn test_sanitize_chain() {
-        let result = TextBuilder::new("input\n\x1B[31mred\x00text")
+        let result = TextBuilder::silent("input\n\x1B[31mred\x00text")
             .strip_ansi()
             .strip_control_chars()
             .sanitize_for_log()
@@ -489,13 +524,16 @@ mod tests {
     #[test]
     fn test_from_string() {
         let owned = String::from("owned input\nwith newline");
-        let result = TextBuilder::from_string(owned).sanitize_for_log().finish();
+        let result = TextBuilder::from_string(owned)
+            .with_events(false)
+            .sanitize_for_log()
+            .finish();
         assert_eq!(result, "owned input\\nwith newline");
     }
 
     #[test]
     fn test_with_strict_config() {
-        let result = TextBuilder::new("Tab\there")
+        let result = TextBuilder::silent("Tab\there")
             .with_strict_config()
             .sanitize_for_log()
             .finish();
@@ -504,7 +542,7 @@ mod tests {
 
     #[test]
     fn test_with_relaxed_config() {
-        let result = TextBuilder::new("line1\nline2")
+        let result = TextBuilder::silent("line1\nline2")
             .with_relaxed_config()
             .sanitize_for_log()
             .finish();
@@ -525,7 +563,9 @@ mod tests {
 
     #[test]
     fn test_into_string() {
-        let result = TextBuilder::new("hello").sanitize_for_log().into_string();
+        let result = TextBuilder::silent("hello")
+            .sanitize_for_log()
+            .into_string();
         assert_eq!(result, "hello");
     }
 
@@ -542,11 +582,11 @@ mod tests {
     #[test]
     fn test_mixed_script_detection() {
         // Cyrillic 'а' mixed with Latin
-        let builder = TextBuilder::new("аpple"); // Cyrillic а + Latin pple
+        let builder = TextBuilder::silent("аpple"); // Cyrillic а + Latin pple
         assert!(builder.is_mixed_script_present());
 
         // Pure ASCII
-        let builder = TextBuilder::new("apple");
+        let builder = TextBuilder::silent("apple");
         assert!(!builder.is_mixed_script_present());
     }
 
@@ -568,7 +608,7 @@ mod tests {
     #[test]
     fn test_zero_width_detection() {
         let zwj = "test\u{200D}data"; // Zero-width joiner
-        let builder = TextBuilder::new(zwj);
+        let builder = TextBuilder::silent(zwj);
         assert!(builder.is_zero_width_chars_present());
     }
 
@@ -582,7 +622,7 @@ mod tests {
     #[test]
     fn test_bidi_override_detection() {
         let bidi = "hello\u{202E}world"; // Right-to-left override
-        let builder = TextBuilder::new(bidi);
+        let builder = TextBuilder::silent(bidi);
         assert!(builder.is_bidi_overrides_present());
     }
 
@@ -597,31 +637,98 @@ mod tests {
     fn test_sanitize_unicode_chain() {
         // Combine multiple threats
         let input = "test\u{200D}\u{202E}data"; // ZWJ + RLO
-        let result = TextBuilder::new(input).sanitize_unicode().into_string();
+        let result = TextBuilder::silent(input).sanitize_unicode().into_string();
         assert!(!result.contains('\u{200D}'));
         assert!(!result.contains('\u{202E}'));
     }
 
     #[test]
     fn test_unicode_secure() {
-        let safe = TextBuilder::new("hello world");
+        let safe = TextBuilder::silent("hello world");
         assert!(safe.is_unicode_secure());
 
-        let unsafe_text = TextBuilder::new("hello\u{202E}world");
+        let unsafe_text = TextBuilder::silent("hello\u{202E}world");
         assert!(!unsafe_text.is_unicode_secure());
     }
 
     #[test]
     fn test_is_identifier_safe() {
-        let safe = TextBuilder::new("valid_identifier");
+        let safe = TextBuilder::silent("valid_identifier");
         assert!(safe.is_identifier_safe());
 
         // Single script Cyrillic is safe
-        let cyrillic = TextBuilder::new("Москва");
+        let cyrillic = TextBuilder::silent("Москва");
         assert!(cyrillic.is_identifier_safe());
 
         // Format control characters are not safe for identifiers
-        let with_zwj = TextBuilder::new("test\u{200D}abc"); // Zero-width joiner
+        let with_zwj = TextBuilder::silent("test\u{200D}abc"); // Zero-width joiner
         assert!(!with_zwj.is_identifier_safe());
+    }
+
+    // ========================================================================
+    // Metrics Tests
+    // ========================================================================
+
+    #[test]
+    fn test_metrics_sanitize_ms_recorded() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        flush_for_testing();
+        let before = snapshot()
+            .histograms
+            .get("data.text.sanitize_ms")
+            .map_or(0, |h| h.count);
+
+        let _ = TextBuilder::new("test\x1B[31mred")
+            .sanitize_for_log()
+            .into_string();
+        flush_for_testing();
+
+        let after = snapshot()
+            .histograms
+            .get("data.text.sanitize_ms")
+            .map_or(0, |h| h.count);
+        assert!(
+            after > before,
+            "sanitize_ms histogram should record at least one sample"
+        );
+    }
+
+    #[test]
+    fn test_metrics_threats_detected_counter() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        flush_for_testing();
+        let before = snapshot()
+            .counters
+            .get("data.text.threats_detected")
+            .map_or(0, |c| c.value);
+
+        let builder = TextBuilder::new("hello\x00world");
+        assert!(builder.is_null_bytes_present());
+        flush_for_testing();
+
+        let after = snapshot()
+            .counters
+            .get("data.text.threats_detected")
+            .map_or(0, |c| c.value);
+        assert!(
+            after > before,
+            "threats_detected counter should increment on null-byte detection"
+        );
+    }
+
+    #[test]
+    fn test_silent_mode_emits_no_metrics() {
+        // Structural test: `silent()` returns a builder with emit_events=false,
+        // and every metric call site in this module is gated by `if self.emit_events`.
+        // A behavioral delta-assertion would race with concurrent tests across the
+        // workspace that hit these same global metric names.
+        let builder = TextBuilder::silent("hello\x00world");
+        assert!(!builder.emit_events);
+
+        // Sanity: invoking through the silent builder still works functionally.
+        assert!(builder.is_null_bytes_present());
+        let _ = TextBuilder::silent("test\x1B[31mred")
+            .sanitize_for_log()
+            .into_string();
     }
 }

--- a/crates/octarine/src/security/formats/builder.rs
+++ b/crates/octarine/src/security/formats/builder.rs
@@ -2,6 +2,9 @@
 //!
 //! Wraps the primitives FormatSecurityBuilder with audit trails.
 
+use std::time::Instant;
+
+use crate::observe::metrics::{increment_by, record};
 use crate::observe::{debug, warn};
 use crate::primitives::data::formats::FormatType;
 use crate::primitives::security::formats::{
@@ -9,22 +12,52 @@ use crate::primitives::security::formats::{
 };
 use crate::primitives::types::Result;
 
+crate::define_metrics! {
+    validate_ms => "security.formats.validate_ms",
+    detect_ms => "security.formats.detect_ms",
+    threats_detected => "security.formats.threats_detected",
+}
+
 /// Builder for format security detection and validation with observability
 ///
 /// This is the Layer 3 wrapper that adds observe instrumentation
 /// to the primitives FormatSecurityBuilder.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct FormatSecurityBuilder {
     inner: PrimBuilder,
+    emit_events: bool,
+}
+
+impl Default for FormatSecurityBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl FormatSecurityBuilder {
-    /// Create a new format security builder
+    /// Create a new format security builder with observe events enabled
     #[must_use]
     pub fn new() -> Self {
         Self {
             inner: PrimBuilder::new(),
+            emit_events: true,
         }
+    }
+
+    /// Create a builder without observe events (for internal use)
+    #[must_use]
+    pub fn silent() -> Self {
+        Self {
+            inner: PrimBuilder::new(),
+            emit_events: false,
+        }
+    }
+
+    /// Enable or disable observe events
+    #[must_use]
+    pub fn with_events(mut self, emit: bool) -> Self {
+        self.emit_events = emit;
+        self
     }
 
     // ========================================================================
@@ -37,10 +70,13 @@ impl FormatSecurityBuilder {
     #[must_use]
     pub fn is_xxe_present(&self, input: &str) -> bool {
         let result = self.inner.is_xxe_present(input);
-        if result {
-            warn("security.format", "XXE pattern detected in XML input");
-        } else {
-            debug("security.format", "No XXE patterns found");
+        if self.emit_events {
+            if result {
+                warn("security.format", "XXE pattern detected in XML input");
+                increment_by(metric_names::threats_detected(), 1);
+            } else {
+                debug("security.format", "No XXE patterns found");
+            }
         }
         result
     }
@@ -49,8 +85,9 @@ impl FormatSecurityBuilder {
     #[must_use]
     pub fn is_dtd_present(&self, input: &str) -> bool {
         let result = self.inner.is_dtd_present(input);
-        if result {
+        if self.emit_events && result {
             debug("security.format", "DTD declaration found in XML");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -59,8 +96,9 @@ impl FormatSecurityBuilder {
     #[must_use]
     pub fn is_external_entity_present(&self, input: &str) -> bool {
         let result = self.inner.is_external_entity_present(input);
-        if result {
+        if self.emit_events && result {
             warn("security.format", "External entity declaration detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -68,20 +106,35 @@ impl FormatSecurityBuilder {
     /// Detect all XML threats in input
     #[must_use]
     pub fn detect_xml_threats(&self, input: &str) -> Vec<FormatThreat> {
+        let start = Instant::now();
         let threats = self.inner.detect_xml_threats(input);
-        if !threats.is_empty() {
-            warn(
-                "security.format",
-                format!("Detected {} XML threat(s)", threats.len()),
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
             );
+            if !threats.is_empty() {
+                warn(
+                    "security.format",
+                    format!("Detected {} XML threat(s)", threats.len()),
+                );
+                increment_by(metric_names::threats_detected(), threats.len() as u64);
+            }
         }
         threats
     }
 
     /// Validate XML input against policy
     pub fn validate_xml(&self, input: &str, policy: &XmlPolicy) -> Result<()> {
+        let start = Instant::now();
         debug("security.format", "Validating XML against policy");
         let result = self.inner.validate_xml(input, policy);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             warn("security.format", "XML validation failed");
         }
@@ -96,11 +149,12 @@ impl FormatSecurityBuilder {
     #[must_use]
     pub fn is_json_depth_exceeded(&self, input: &str, max_depth: usize) -> bool {
         let result = self.inner.is_json_depth_exceeded(input, max_depth);
-        if result {
+        if self.emit_events && result {
             warn(
                 "security.format",
                 format!("JSON exceeds depth limit of {}", max_depth),
             );
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -109,11 +163,12 @@ impl FormatSecurityBuilder {
     #[must_use]
     pub fn is_json_size_exceeded(&self, input: &str, max_size: usize) -> bool {
         let result = self.inner.is_json_size_exceeded(input, max_size);
-        if result {
+        if self.emit_events && result {
             warn(
                 "security.format",
                 format!("JSON exceeds size limit of {} bytes", max_size),
             );
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -121,20 +176,35 @@ impl FormatSecurityBuilder {
     /// Detect all JSON threats according to policy
     #[must_use]
     pub fn detect_json_threats(&self, input: &str, policy: &JsonPolicy) -> Vec<FormatThreat> {
+        let start = Instant::now();
         let threats = self.inner.detect_json_threats(input, policy);
-        if !threats.is_empty() {
-            warn(
-                "security.format",
-                format!("Detected {} JSON threat(s)", threats.len()),
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
             );
+            if !threats.is_empty() {
+                warn(
+                    "security.format",
+                    format!("Detected {} JSON threat(s)", threats.len()),
+                );
+                increment_by(metric_names::threats_detected(), threats.len() as u64);
+            }
         }
         threats
     }
 
     /// Validate JSON input against policy
     pub fn validate_json(&self, input: &str, policy: &JsonPolicy) -> Result<()> {
+        let start = Instant::now();
         debug("security.format", "Validating JSON against policy");
         let result = self.inner.validate_json(input, policy);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             warn("security.format", "JSON validation failed");
         }
@@ -149,10 +219,13 @@ impl FormatSecurityBuilder {
     #[must_use]
     pub fn is_yaml_unsafe(&self, input: &str) -> bool {
         let result = self.inner.is_yaml_unsafe(input);
-        if result {
-            warn("security.format", "Unsafe pattern detected in YAML input");
-        } else {
-            debug("security.format", "No unsafe patterns found in YAML");
+        if self.emit_events {
+            if result {
+                warn("security.format", "Unsafe pattern detected in YAML input");
+                increment_by(metric_names::threats_detected(), 1);
+            } else {
+                debug("security.format", "No unsafe patterns found in YAML");
+            }
         }
         result
     }
@@ -161,11 +234,12 @@ impl FormatSecurityBuilder {
     #[must_use]
     pub fn is_unsafe_yaml_tag_present(&self, input: &str) -> bool {
         let result = self.inner.is_unsafe_yaml_tag_present(input);
-        if result {
+        if self.emit_events && result {
             warn(
                 "security.format",
                 "Unsafe YAML tag detected (code execution risk)",
             );
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -174,11 +248,12 @@ impl FormatSecurityBuilder {
     #[must_use]
     pub fn is_yaml_anchor_bomb_present(&self, input: &str) -> bool {
         let result = self.inner.is_yaml_anchor_bomb_present(input);
-        if result {
+        if self.emit_events && result {
             warn(
                 "security.format",
                 "YAML anchor bomb pattern detected (DoS risk)",
             );
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -186,20 +261,35 @@ impl FormatSecurityBuilder {
     /// Detect all YAML threats according to policy
     #[must_use]
     pub fn detect_yaml_threats(&self, input: &str, policy: &YamlPolicy) -> Vec<FormatThreat> {
+        let start = Instant::now();
         let threats = self.inner.detect_yaml_threats(input, policy);
-        if !threats.is_empty() {
-            warn(
-                "security.format",
-                format!("Detected {} YAML threat(s)", threats.len()),
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
             );
+            if !threats.is_empty() {
+                warn(
+                    "security.format",
+                    format!("Detected {} YAML threat(s)", threats.len()),
+                );
+                increment_by(metric_names::threats_detected(), threats.len() as u64);
+            }
         }
         threats
     }
 
     /// Validate YAML input against policy
     pub fn validate_yaml(&self, input: &str, policy: &YamlPolicy) -> Result<()> {
+        let start = Instant::now();
         debug("security.format", "Validating YAML against policy");
         let result = self.inner.validate_yaml(input, policy);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             warn("security.format", "YAML validation failed");
         }
@@ -213,24 +303,44 @@ impl FormatSecurityBuilder {
     /// Detect threats for a specific format type
     #[must_use]
     pub fn detect_threats(&self, input: &str, format: FormatType) -> Vec<FormatThreat> {
+        let start = Instant::now();
         debug("security.format", "Detecting format threats");
-        self.inner.detect_threats(input, format)
+        let threats = self.inner.detect_threats(input, format);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !threats.is_empty() {
+                increment_by(metric_names::threats_detected(), threats.len() as u64);
+            }
+        }
+        threats
     }
 
     /// Check if input contains any threats for the specified format
     #[must_use]
     pub fn is_dangerous(&self, input: &str, format: FormatType) -> bool {
         let result = self.inner.is_dangerous(input, format);
-        if result {
+        if self.emit_events && result {
             warn("security.format", "Dangerous content detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
 
     /// Validate input with default strict policies
     pub fn validate_strict(&self, input: &str, format: FormatType) -> Result<()> {
+        let start = Instant::now();
         debug("security.format", "Validating with strict policy");
-        self.inner.validate_strict(input, format)
+        let result = self.inner.validate_strict(input, format);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
+        result
     }
 }
 
@@ -242,10 +352,31 @@ impl FormatSecurityBuilder {
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
+    use crate::observe::metrics::{flush_for_testing, snapshot};
+    use std::sync::Mutex;
+
+    /// Serializes metrics-touching tests within this file so they don't race
+    /// each other on the shared global registry.
+    static METRICS_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn test_builder_creation() {
+        let builder = FormatSecurityBuilder::new();
+        assert!(builder.emit_events);
+
+        let silent = FormatSecurityBuilder::silent();
+        assert!(!silent.emit_events);
+    }
+
+    #[test]
+    fn test_with_events_toggle() {
+        let builder = FormatSecurityBuilder::new().with_events(false);
+        assert!(!builder.emit_events);
+    }
 
     #[test]
     fn test_builder_xxe_detection() {
-        let builder = FormatSecurityBuilder::new();
+        let builder = FormatSecurityBuilder::silent();
 
         let xxe = r#"<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>"#;
         assert!(builder.is_xxe_present(xxe));
@@ -254,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_builder_yaml_unsafe() {
-        let builder = FormatSecurityBuilder::new();
+        let builder = FormatSecurityBuilder::silent();
 
         assert!(builder.is_yaml_unsafe("!!python/exec 'import os'"));
         assert!(!builder.is_yaml_unsafe("key: value"));
@@ -262,9 +393,69 @@ mod tests {
 
     #[test]
     fn test_builder_json_depth() {
-        let builder = FormatSecurityBuilder::new();
+        let builder = FormatSecurityBuilder::silent();
 
         assert!(builder.is_json_depth_exceeded(r#"{"a":{"b":{"c":1}}}"#, 2));
         assert!(!builder.is_json_depth_exceeded(r#"{"a":{"b":1}}"#, 2));
+    }
+
+    #[test]
+    fn test_metrics_validate_ms_recorded() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = FormatSecurityBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .histograms
+            .get("security.formats.validate_ms")
+            .map_or(0, |h| h.count);
+
+        let _ = builder.validate_xml("<root/>", &XmlPolicy::default());
+        flush_for_testing();
+
+        let after = snapshot()
+            .histograms
+            .get("security.formats.validate_ms")
+            .map_or(0, |h| h.count);
+        assert!(after > before, "validate_ms should record");
+    }
+
+    #[test]
+    fn test_metrics_threats_detected_counter() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = FormatSecurityBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .counters
+            .get("security.formats.threats_detected")
+            .map_or(0, |c| c.value);
+
+        let xxe = r#"<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>"#;
+        assert!(builder.is_xxe_present(xxe));
+        flush_for_testing();
+
+        let after = snapshot()
+            .counters
+            .get("security.formats.threats_detected")
+            .map_or(0, |c| c.value);
+        assert!(after > before, "threats_detected should increment");
+    }
+
+    #[test]
+    fn test_silent_mode_emits_no_metrics() {
+        // Structural test: `silent()` returns a builder with emit_events=false,
+        // and every metric call site in this module is gated by `if self.emit_events`.
+        // A behavioral delta-assertion would race with concurrent tests across the
+        // workspace that hit these same global metric names via shortcuts/facade.
+        let builder = FormatSecurityBuilder::silent();
+        assert!(!builder.emit_events);
+
+        // Sanity: invoking through the silent builder still works functionally.
+        let xxe = r#"<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>"#;
+        assert!(builder.is_xxe_present(xxe));
+        assert!(
+            builder
+                .validate_xml("<root/>", &XmlPolicy::default())
+                .is_ok()
+        );
     }
 }

--- a/crates/octarine/src/security/network/builder.rs
+++ b/crates/octarine/src/security/network/builder.rs
@@ -9,10 +9,18 @@
 // Allow dead_code: This is a new module that will be used by consumers
 #![allow(dead_code)]
 
+use std::time::Instant;
+
+use crate::observe::metrics::{increment_by, record};
 use crate::observe::{Problem, event};
 use crate::primitives::security::network::NetworkSecurityBuilder as PrimitiveNetworkSecurityBuilder;
 
 use super::types::{HostType, NetworkSecurityHostnameConfig, NetworkSecurityUrlConfig, PortRange};
+
+crate::define_metrics! {
+    validate_ms => "security.network.validate_ms",
+    threats_detected => "security.network.threats_detected",
+}
 
 // ============================================================================
 // NetworkSecurityBuilder
@@ -130,6 +138,7 @@ impl NetworkSecurityBuilder {
 
         if self.emit_events && result {
             event::warn(format!("Dangerous scheme detected: {}", url));
+            increment_by(metric_names::threats_detected(), 1);
         }
 
         result
@@ -232,6 +241,7 @@ impl NetworkSecurityBuilder {
 
         if self.emit_events && result {
             event::critical(format!("Cloud metadata access detected: {}", url));
+            increment_by(metric_names::threats_detected(), 1);
         }
 
         result
@@ -279,6 +289,7 @@ impl NetworkSecurityBuilder {
 
         if self.emit_events && result {
             event::critical(format!("SSRF detected: {}", url_or_host));
+            increment_by(metric_names::threats_detected(), 1);
         }
 
         result
@@ -300,9 +311,14 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if any SSRF risk is detected.
     pub fn validate_ssrf_safe(&self, url: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_ssrf_safe(url);
 
         if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
             if result.is_err() {
                 event::critical(format!("SSRF validation failed: {}", url));
             } else {
@@ -319,10 +335,17 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the URL targets internal resources.
     pub fn validate_not_internal(&self, url: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_not_internal(url);
 
-        if self.emit_events && result.is_err() {
-            event::critical(format!("Internal URL blocked: {}", url));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::critical(format!("Internal URL blocked: {}", url));
+            }
         }
 
         result
@@ -334,10 +357,17 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the scheme is dangerous.
     pub fn validate_safe_scheme(&self, url: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_safe_scheme(url);
 
-        if self.emit_events && result.is_err() {
-            event::critical(format!("Dangerous scheme blocked: {}", url));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::critical(format!("Dangerous scheme blocked: {}", url));
+            }
         }
 
         result
@@ -349,10 +379,17 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the URL targets cloud metadata.
     pub fn validate_not_cloud_metadata(&self, url: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_not_cloud_metadata(url);
 
-        if self.emit_events && result.is_err() {
-            event::critical(format!("Cloud metadata blocked: {}", url));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::critical(format!("Cloud metadata blocked: {}", url));
+            }
         }
 
         result
@@ -364,10 +401,17 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the URL is a shortener.
     pub fn validate_not_url_shortener(&self, url: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_not_url_shortener(url);
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!("URL shortener blocked: {}", url));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!("URL shortener blocked: {}", url));
+            }
         }
 
         result
@@ -383,10 +427,17 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the URL is malformed or uses dangerous schemes.
     pub fn validate_url_format(&self, url: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_url_format(url);
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!("Invalid URL format: {}", url));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!("Invalid URL format: {}", url));
+            }
         }
 
         result
@@ -398,11 +449,18 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the scheme is not in the allowed list.
     pub fn validate_url_scheme(&self, url: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let config = NetworkSecurityUrlConfig::default();
         let result = self.inner.validate_url_scheme(url, &(&config).into());
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!("URL scheme not allowed: {}", url));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!("URL scheme not allowed: {}", url));
+            }
         }
 
         result
@@ -414,11 +472,18 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the URL is not HTTPS.
     pub fn validate_https_required(&self, url: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let config = NetworkSecurityUrlConfig::https_only();
         let result = self.inner.validate_url_scheme(url, &(&config).into());
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!("HTTPS required: {}", url));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!("HTTPS required: {}", url));
+            }
         }
 
         result
@@ -434,10 +499,17 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the hostname is invalid.
     pub fn validate_hostname(&self, hostname: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_hostname(hostname);
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!("Invalid hostname: {}", hostname));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!("Invalid hostname: {}", hostname));
+            }
         }
 
         result
@@ -449,13 +521,20 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the hostname is invalid.
     pub fn validate_hostname_lenient(&self, hostname: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let config = NetworkSecurityHostnameConfig::lenient();
         let result = self
             .inner
             .validate_hostname_with_config(hostname, &(&config).into());
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!("Invalid hostname: {}", hostname));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!("Invalid hostname: {}", hostname));
+            }
         }
 
         result
@@ -471,14 +550,21 @@ impl NetworkSecurityBuilder {
         hostname: &str,
         max_length: usize,
     ) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_hostname_length(hostname, max_length);
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!(
-                "Hostname too long: {} (max {})",
-                hostname.len(),
-                max_length
-            ));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!(
+                    "Hostname too long: {} (max {})",
+                    hostname.len(),
+                    max_length
+                ));
+            }
         }
 
         result
@@ -494,10 +580,17 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the port is invalid.
     pub fn validate_port(&self, port: u16) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_port(port);
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!("Invalid port: {}", port));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!("Invalid port: {}", port));
+            }
         }
 
         result
@@ -509,10 +602,17 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the port is outside the range.
     pub fn validate_port_range(&self, port: u16, range: PortRange) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_port_range(port, range.into());
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!("Port {} out of range", port));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!("Port {} out of range", port));
+            }
         }
 
         result
@@ -524,10 +624,17 @@ impl NetworkSecurityBuilder {
     ///
     /// Returns `Problem::validation` if the string is not a valid port.
     pub fn parse_port(&self, s: &str) -> Result<u16, Problem> {
+        let start = Instant::now();
         let result = self.inner.parse_port(s);
 
-        if self.emit_events && result.is_err() {
-            event::warn(format!("Invalid port string: {}", s));
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                event::warn(format!("Invalid port string: {}", s));
+            }
         }
 
         result
@@ -540,7 +647,12 @@ impl NetworkSecurityBuilder {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
+    use crate::observe::metrics::{flush_for_testing, snapshot};
+    use std::sync::Mutex;
+
+    static METRICS_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_builder_creation() {
@@ -606,5 +718,65 @@ mod tests {
         assert!(builder.validate_port(80).is_ok());
         assert!(builder.validate_port(443).is_ok());
         assert!(builder.validate_port(0).is_err());
+    }
+
+    #[test]
+    fn test_with_events_toggle() {
+        let builder = NetworkSecurityBuilder::new().with_events(false);
+        assert!(!builder.emit_events);
+    }
+
+    #[test]
+    fn test_metrics_validate_ms_recorded() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = NetworkSecurityBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .histograms
+            .get("security.network.validate_ms")
+            .map_or(0, |h| h.count);
+
+        let _ = builder.validate_url_format("https://example.com");
+        flush_for_testing();
+
+        let after = snapshot()
+            .histograms
+            .get("security.network.validate_ms")
+            .map_or(0, |h| h.count);
+        assert!(after > before, "validate_ms should record");
+    }
+
+    #[test]
+    fn test_metrics_threats_detected_counter() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = NetworkSecurityBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .counters
+            .get("security.network.threats_detected")
+            .map_or(0, |c| c.value);
+
+        assert!(builder.is_potential_ssrf("http://localhost/admin"));
+        flush_for_testing();
+
+        let after = snapshot()
+            .counters
+            .get("security.network.threats_detected")
+            .map_or(0, |c| c.value);
+        assert!(after > before, "threats_detected should increment");
+    }
+
+    #[test]
+    fn test_silent_mode_emits_no_metrics() {
+        // Structural test: `silent()` returns a builder with emit_events=false,
+        // and every metric call site in this module is gated by `if self.emit_events`.
+        // A behavioral delta-assertion would race with concurrent tests across the
+        // workspace that hit these same global metric names via shortcuts/facade.
+        let builder = NetworkSecurityBuilder::silent();
+        assert!(!builder.emit_events);
+
+        // Sanity: invoking through the silent builder still works functionally.
+        assert!(builder.is_potential_ssrf("http://localhost/admin"));
+        assert!(builder.validate_url_format("https://example.com").is_ok());
     }
 }

--- a/crates/octarine/src/security/queries/builder.rs
+++ b/crates/octarine/src/security/queries/builder.rs
@@ -2,12 +2,21 @@
 //!
 //! Wraps the primitives query security builder with observe instrumentation.
 
+use std::time::Instant;
+
 use crate::observe::event;
+use crate::observe::metrics::{increment_by, record};
 use crate::primitives::security::queries::{
     GraphqlAnalysis, GraphqlConfig, GraphqlSchema, QuerySecurityBuilder as PrimitiveBuilder,
     QueryThreat, QueryType,
 };
 use crate::primitives::types::Problem;
+
+crate::define_metrics! {
+    validate_ms => "security.queries.validate_ms",
+    detect_ms => "security.queries.detect_ms",
+    threats_detected => "security.queries.threats_detected",
+}
 
 /// Query security builder with observability
 ///
@@ -27,18 +36,42 @@ use crate::primitives::types::Problem;
 /// // Escape if parameterization isn't possible
 /// let safe = builder.escape_sql_string(user_input);
 /// ```
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct QueryBuilder {
     inner: PrimitiveBuilder,
+    emit_events: bool,
+}
+
+impl Default for QueryBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl QueryBuilder {
-    /// Create a new query security builder
+    /// Create a new query security builder with observe events enabled
     #[must_use]
     pub fn new() -> Self {
         Self {
             inner: PrimitiveBuilder::new(),
+            emit_events: true,
         }
+    }
+
+    /// Create a builder without observe events (for internal use)
+    #[must_use]
+    pub fn silent() -> Self {
+        Self {
+            inner: PrimitiveBuilder::new(),
+            emit_events: false,
+        }
+    }
+
+    /// Enable or disable observe events
+    #[must_use]
+    pub fn with_events(mut self, emit: bool) -> Self {
+        self.emit_events = emit;
+        self
     }
 
     // ========================================================================
@@ -49,8 +82,9 @@ impl QueryBuilder {
     #[must_use]
     pub fn is_sql_injection_present(&self, input: &str) -> bool {
         let result = self.inner.is_sql_injection_present(input);
-        if result {
+        if self.emit_events && result {
             event::warn("security: SQL injection pattern detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -58,19 +92,34 @@ impl QueryBuilder {
     /// Detect all SQL injection threats in input
     #[must_use]
     pub fn detect_sql_threats(&self, input: &str) -> Vec<QueryThreat> {
+        let start = Instant::now();
         let threats = self.inner.detect_sql_threats(input);
-        if !threats.is_empty() {
-            event::warn(format!(
-                "security: Detected {} SQL injection threats",
-                threats.len()
-            ));
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !threats.is_empty() {
+                event::warn(format!(
+                    "security: Detected {} SQL injection threats",
+                    threats.len()
+                ));
+                increment_by(metric_names::threats_detected(), threats.len() as u64);
+            }
         }
         threats
     }
 
     /// Validate that a SQL parameter is safe
     pub fn validate_sql_parameter(&self, param: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_sql_parameter(param);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             event::warn("security: SQL parameter validation failed");
         }
@@ -97,8 +146,9 @@ impl QueryBuilder {
     #[must_use]
     pub fn is_nosql_injection_present(&self, input: &str) -> bool {
         let result = self.inner.is_nosql_injection_present(input);
-        if result {
+        if self.emit_events && result {
             event::warn("security: NoSQL injection pattern detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -106,19 +156,34 @@ impl QueryBuilder {
     /// Detect all NoSQL injection threats in input
     #[must_use]
     pub fn detect_nosql_threats(&self, input: &str) -> Vec<QueryThreat> {
+        let start = Instant::now();
         let threats = self.inner.detect_nosql_threats(input);
-        if !threats.is_empty() {
-            event::warn(format!(
-                "security: Detected {} NoSQL injection threats",
-                threats.len()
-            ));
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !threats.is_empty() {
+                event::warn(format!(
+                    "security: Detected {} NoSQL injection threats",
+                    threats.len()
+                ));
+                increment_by(metric_names::threats_detected(), threats.len() as u64);
+            }
         }
         threats
     }
 
     /// Validate that a NoSQL value is safe
     pub fn validate_nosql_value(&self, value: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_nosql_value(value);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             event::warn("security: NoSQL value validation failed");
         }
@@ -157,8 +222,9 @@ impl QueryBuilder {
     #[must_use]
     pub fn is_ldap_injection_present(&self, input: &str) -> bool {
         let result = self.inner.is_ldap_injection_present(input);
-        if result {
+        if self.emit_events && result {
             event::warn("security: LDAP injection pattern detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -166,19 +232,34 @@ impl QueryBuilder {
     /// Detect all LDAP injection threats in input
     #[must_use]
     pub fn detect_ldap_threats(&self, input: &str) -> Vec<QueryThreat> {
+        let start = Instant::now();
         let threats = self.inner.detect_ldap_threats(input);
-        if !threats.is_empty() {
-            event::warn(format!(
-                "security: Detected {} LDAP injection threats",
-                threats.len()
-            ));
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !threats.is_empty() {
+                event::warn(format!(
+                    "security: Detected {} LDAP injection threats",
+                    threats.len()
+                ));
+                increment_by(metric_names::threats_detected(), threats.len() as u64);
+            }
         }
         threats
     }
 
     /// Validate that an LDAP filter is safe
     pub fn validate_ldap_filter(&self, filter: &str) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_ldap_filter(filter);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             event::warn("security: LDAP filter validation failed");
         }
@@ -205,8 +286,9 @@ impl QueryBuilder {
     #[must_use]
     pub fn is_graphql_injection_present(&self, query: &str) -> bool {
         let result = self.inner.is_graphql_injection_present(query);
-        if result {
+        if self.emit_events && result {
             event::warn("security: GraphQL abuse pattern detected");
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -214,12 +296,20 @@ impl QueryBuilder {
     /// Detect all GraphQL threats in query
     #[must_use]
     pub fn detect_graphql_threats(&self, query: &str) -> Vec<QueryThreat> {
+        let start = Instant::now();
         let threats = self.inner.detect_graphql_threats(query);
-        if !threats.is_empty() {
-            event::warn(format!(
-                "security: Detected {} GraphQL threats",
-                threats.len()
-            ));
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !threats.is_empty() {
+                event::warn(format!(
+                    "security: Detected {} GraphQL threats",
+                    threats.len()
+                ));
+                increment_by(metric_names::threats_detected(), threats.len() as u64);
+            }
         }
         threats
     }
@@ -237,7 +327,14 @@ impl QueryBuilder {
         schema: &GraphqlSchema,
         config: &GraphqlConfig,
     ) -> Result<(), Problem> {
+        let start = Instant::now();
         let result = self.inner.validate_graphql_query(query, schema, config);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         if result.is_err() {
             event::warn("security: GraphQL query validation failed");
         }
@@ -251,13 +348,21 @@ impl QueryBuilder {
     /// Detect threats for a specific query type
     #[must_use]
     pub fn detect_threats(&self, input: &str, query_type: QueryType) -> Vec<QueryThreat> {
+        let start = Instant::now();
         let threats = self.inner.detect_threats(input, query_type);
-        if !threats.is_empty() {
-            event::warn(format!(
-                "security: Detected {} {} threats",
-                threats.len(),
-                query_type
-            ));
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !threats.is_empty() {
+                event::warn(format!(
+                    "security: Detected {} {} threats",
+                    threats.len(),
+                    query_type
+                ));
+                increment_by(metric_names::threats_detected(), threats.len() as u64);
+            }
         }
         threats
     }
@@ -266,11 +371,12 @@ impl QueryBuilder {
     #[must_use]
     pub fn is_injection_present(&self, input: &str, query_type: QueryType) -> bool {
         let result = self.inner.is_injection_present(input, query_type);
-        if result {
+        if self.emit_events && result {
             event::warn(format!(
                 "security: {} injection pattern detected",
                 query_type
             ));
+            increment_by(metric_names::threats_detected(), 1);
         }
         result
     }
@@ -282,46 +388,120 @@ impl QueryBuilder {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
+    use crate::observe::metrics::{flush_for_testing, snapshot};
+    use std::sync::Mutex;
+
+    static METRICS_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn test_builder_creation() {
+        let builder = QueryBuilder::new();
+        assert!(builder.emit_events);
+
+        let silent = QueryBuilder::silent();
+        assert!(!silent.emit_events);
+    }
+
+    #[test]
+    fn test_with_events_toggle() {
+        let builder = QueryBuilder::new().with_events(false);
+        assert!(!builder.emit_events);
+    }
 
     #[test]
     fn test_builder_sql_detection() {
-        let builder = QueryBuilder::new();
+        let builder = QueryBuilder::silent();
         assert!(builder.is_sql_injection_present("' OR 1=1 --"));
         assert!(!builder.is_sql_injection_present("hello"));
     }
 
     #[test]
     fn test_builder_sql_validation() {
-        let builder = QueryBuilder::new();
+        let builder = QueryBuilder::silent();
         assert!(builder.validate_sql_parameter("hello").is_ok());
         assert!(builder.validate_sql_parameter("' OR 1=1 --").is_err());
     }
 
     #[test]
     fn test_builder_sql_escaping() {
-        let builder = QueryBuilder::new();
+        let builder = QueryBuilder::silent();
         assert_eq!(builder.escape_sql_string("O'Brien"), "O''Brien");
     }
 
     #[test]
     fn test_builder_nosql_detection() {
-        let builder = QueryBuilder::new();
+        let builder = QueryBuilder::silent();
         assert!(builder.is_nosql_injection_present(r#"{ "$gt": "" }"#));
         assert!(!builder.is_nosql_injection_present("hello"));
     }
 
     #[test]
     fn test_builder_ldap_detection() {
-        let builder = QueryBuilder::new();
+        let builder = QueryBuilder::silent();
         assert!(builder.is_ldap_injection_present("admin)("));
         assert!(!builder.is_ldap_injection_present("admin"));
     }
 
     #[test]
     fn test_builder_graphql_detection() {
-        let builder = QueryBuilder::new();
+        let builder = QueryBuilder::silent();
         assert!(builder.is_graphql_injection_present("{ __schema { types { name } } }"));
         assert!(!builder.is_graphql_injection_present("{ user { name } }"));
+    }
+
+    #[test]
+    fn test_metrics_validate_ms_recorded() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = QueryBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .histograms
+            .get("security.queries.validate_ms")
+            .map_or(0, |h| h.count);
+
+        let _ = builder.validate_sql_parameter("hello");
+        flush_for_testing();
+
+        let after = snapshot()
+            .histograms
+            .get("security.queries.validate_ms")
+            .map_or(0, |h| h.count);
+        assert!(after > before);
+    }
+
+    #[test]
+    fn test_metrics_threats_detected_counter() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = QueryBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .counters
+            .get("security.queries.threats_detected")
+            .map_or(0, |c| c.value);
+
+        assert!(builder.is_sql_injection_present("' OR 1=1 --"));
+        flush_for_testing();
+
+        let after = snapshot()
+            .counters
+            .get("security.queries.threats_detected")
+            .map_or(0, |c| c.value);
+        assert!(after > before);
+    }
+
+    #[test]
+    fn test_silent_mode_emits_no_metrics() {
+        // Structural test: `silent()` returns a builder with emit_events=false,
+        // and every metric call site in this module is gated by `if self.emit_events`.
+        // A behavioral delta-assertion would race with concurrent tests across the
+        // workspace that hit these same global metric names via shortcuts/facade.
+        let builder = QueryBuilder::silent();
+        assert!(!builder.emit_events);
+
+        // Sanity: invoking through the silent builder still works functionally.
+        assert!(builder.is_sql_injection_present("' OR 1=1 --"));
+        assert!(builder.validate_sql_parameter("hello").is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Five Layer 3 builders had **zero** metrics — no timing histograms, no threat counters — leaving these hot paths invisible to operators. This change brings them in line with the convention established by `security/paths/builder.rs` and used across the rest of Layer 3.

| Builder | Metrics added |
|---|---|
| `security/formats` | `validate_ms`, `detect_ms`, `threats_detected` |
| `security/network` | `validate_ms`, `threats_detected` |
| `security/queries` | `validate_ms`, `detect_ms`, `threats_detected` |
| `data/text` | `sanitize_ms`, `threats_detected` |
| `data/formats` | `parse_ms`, `serialize_ms`, `detect_ms` |

All declared via `crate::define_metrics! { ... }` and gated by `if self.emit_events`.

### Where each metric is recorded
- `validate_*` methods: time the inner call, record `validate_ms`
- `detect_*` (`Vec<Threat>`) dispatchers: record `detect_ms` and `increment_by(threats_detected, vec.len())`
- `is_*_present` bool detectors that already emit a `warn`: also `increment_by(threats_detected, 1)`
- `data/text`: only `sanitize_for_log` and `sanitize_unicode` time their work (the rest are cheap chainable transforms)
- `data/formats`: parsing failures aren't threats — no `threats_detected` counter
- `security/network`: classification booleans (`is_localhost`, `is_private_ipv4_range`, etc.) are NOT counted as threats — they classify, not threat-detect

### Partial #87
This PR also adds `emit_events: bool` + `silent()` + `with_events()` to **security/formats**, **security/queries**, and **data/formats** — required to gate metric emission. This unblocks half of #87. Remaining #87 targets: `security/commands`, `identifiers/builder/mod.rs` facade.

## Test plan

- 15 new tests verify each metric records via global-snapshot before/after deltas
- Each test file declares a per-file `METRICS_LOCK: Mutex<()>` so same-file metric tests serialize against the shared global registry
- Silent-mode tests are structural (`assert!(!builder.emit_events)` + functional sanity) — behavioral delta assertions race with concurrent tests in `shortcuts.rs` / `facade.rs` that hit the same global metric names via `::new()`
- Several pre-existing detection/transform tests converted from `::new()` to `silent()` to avoid polluting the shared histograms during cross-file test runs
- `just preflight` (fmt + clippy + arch-check + 6453 tests) passes locally

Closes #189