### PR TITLE
test(http,runtime,io,observe): assertion density and missing-scenario coverage

### DIFF
--- a/crates/octarine/src/io/delete.rs
+++ b/crates/octarine/src/io/delete.rs
@@ -635,6 +635,62 @@ mod tests {
         assert!(result.verified);
     }
 
+    /// Async path against a missing file: must return an error with the
+    /// "does not exist" wording, leave no residue, and not panic. Mirrors
+    /// the existing sync test (`test_secure_delete_sync_nonexistent`)
+    /// but exercises the `secure_delete()` async entry point.
+    #[tokio::test]
+    async fn test_secure_delete_async_nonexistent() {
+        let dir = tempdir().expect("create temp dir");
+        let missing = dir.path().join("does_not_exist.txt");
+        // Sanity: the file must really not exist for this test to mean anything.
+        assert!(
+            !missing.exists(),
+            "test fixture must not pre-create the file"
+        );
+
+        let result = secure_delete(&missing).await;
+        let err = result.expect_err("missing file must produce an error");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("does not exist"),
+            "error should mention 'does not exist', got: {message}",
+        );
+
+        // No residue: the parent dir is untouched and no file was created
+        // at the rejected path.
+        assert!(dir.path().exists(), "parent tempdir must still exist");
+        assert!(
+            !missing.exists(),
+            "must not create the file we tried to delete"
+        );
+    }
+
+    /// Async path against a directory: must reject with the "not a file"
+    /// wording. Mirrors `test_secure_delete_sync_directory` for the async
+    /// API.
+    #[tokio::test]
+    async fn test_secure_delete_async_directory() {
+        let dir = tempdir().expect("create temp dir");
+
+        let result = secure_delete(dir.path()).await;
+        let err = result.expect_err("directory path must produce an error");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("not a file"),
+            "error should mention 'not a file', got: {message}",
+        );
+
+        // Directory must remain — secure_delete must reject before touching it.
+        assert!(dir.path().exists(), "directory must remain after rejection");
+        assert!(
+            dir.path().is_dir(),
+            "directory entry must still be a directory"
+        );
+    }
+
     // =========================================================================
     // Sync Tests
     // =========================================================================

--- a/crates/octarine/src/observe/pii/scanner/cache.rs
+++ b/crates/octarine/src/observe/pii/scanner/cache.rs
@@ -45,6 +45,30 @@ impl ScannerStats {
 /// Global scanner statistics
 pub(super) static SCANNER_STATS: ScannerStats = ScannerStats::new();
 
+/// Reset all scanner statistics to zero.
+///
+/// Test-only helper used by serial tests in `health.rs` that need to
+/// drive the scanner into specific states by populating the atomic
+/// counters directly.
+#[cfg(test)]
+pub(super) fn reset_stats() {
+    SCANNER_STATS
+        .total_scans
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+    SCANNER_STATS
+        .cache_hits
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+    SCANNER_STATS
+        .cache_misses
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+    SCANNER_STATS
+        .total_pii_found
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+    SCANNER_STATS
+        .total_scan_time_us
+        .store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// LRU cache entry for scan results
 struct CacheEntry {
     pii_types: Vec<PiiType>,

--- a/crates/octarine/src/observe/pii/scanner/health.rs
+++ b/crates/octarine/src/observe/pii/scanner/health.rs
@@ -127,3 +127,170 @@ pub fn scanner_cache_size() -> usize {
 pub fn clear_scanner_cache() {
     SCAN_CACHE.lock().clear();
 }
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::super::cache::{SCANNER_STATS, reset_stats};
+    use super::*;
+    use serial_test::serial;
+    use std::sync::atomic::Ordering;
+
+    /// Populate `SCANNER_STATS` to a specific shape so the health
+    /// thresholds can be exercised deterministically without running
+    /// real scans (which would have variable timing).
+    fn populate_stats(total_scans: u64, cache_hits: u64, cache_misses: u64, total_us: u64) {
+        SCANNER_STATS
+            .total_scans
+            .store(total_scans, Ordering::Relaxed);
+        SCANNER_STATS
+            .cache_hits
+            .store(cache_hits, Ordering::Relaxed);
+        SCANNER_STATS
+            .cache_misses
+            .store(cache_misses, Ordering::Relaxed);
+        SCANNER_STATS
+            .total_scan_time_us
+            .store(total_us, Ordering::Relaxed);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scanner_stats_reflects_populated_counters() {
+        reset_stats();
+        populate_stats(100, 80, 20, 5_000);
+
+        let stats = scanner_stats();
+        assert_eq!(stats.total_scans, 100);
+        assert_eq!(stats.cache_hits, 80);
+        assert_eq!(stats.cache_misses, 20);
+        assert!(
+            (stats.cache_hit_rate - 0.8).abs() < f64::EPSILON,
+            "cache_hit_rate = hits / (hits+misses) = 80/100 = 0.8, got {}",
+            stats.cache_hit_rate,
+        );
+        assert!(
+            (stats.avg_scan_time_us - 50.0).abs() < f64::EPSILON,
+            "avg_scan_time_us = total_us / total_scans = 5000/100 = 50.0, got {}",
+            stats.avg_scan_time_us,
+        );
+
+        reset_stats();
+    }
+
+    #[test]
+    #[serial]
+    fn test_scanner_stats_handles_zero_scans() {
+        reset_stats();
+
+        let stats = scanner_stats();
+        assert_eq!(stats.total_scans, 0);
+        // Division-by-zero guards must keep the derived metrics at 0.0.
+        assert_eq!(stats.cache_hit_rate, 0.0);
+        assert_eq!(stats.avg_scan_time_us, 0.0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_scanner_is_healthy_with_no_data_returns_true() {
+        reset_stats();
+        // Below the 10-scan minimum, `scanner_is_healthy` returns true
+        // because there isn't enough data to make a judgement.
+        assert!(scanner_is_healthy());
+        // ... and `scanner_is_degraded` returns false for the same reason.
+        assert!(!scanner_is_degraded());
+    }
+
+    #[test]
+    #[serial]
+    fn test_scanner_is_healthy_with_high_cache_hit_rate() {
+        reset_stats();
+        // 90% hit rate, 50μs avg — clearly inside the healthy band
+        // (cache_hit_rate > 20% AND avg_scan_time < 500μs).
+        populate_stats(20, 18, 2, 1_000);
+
+        assert!(scanner_is_healthy(), "should be healthy at 90% hits, 50μs");
+        assert!(
+            !scanner_is_degraded(),
+            "must not be degraded at 90% hits, 50μs",
+        );
+
+        reset_stats();
+    }
+
+    #[test]
+    #[serial]
+    fn test_scanner_is_degraded_with_low_cache_hit_rate() {
+        reset_stats();
+        // 5% hit rate (< 10% degraded threshold), 100μs avg.
+        populate_stats(20, 1, 19, 2_000);
+
+        assert!(
+            scanner_is_degraded(),
+            "should be degraded at 5% hit rate (< 10% threshold)",
+        );
+        assert!(
+            !scanner_is_healthy(),
+            "must not be healthy at 5% hit rate (< 20% threshold)",
+        );
+
+        reset_stats();
+    }
+
+    #[test]
+    #[serial]
+    fn test_scanner_is_degraded_with_slow_scans() {
+        reset_stats();
+        // 90% hit rate (above healthy floor) but 750μs avg scan time —
+        // crosses the > 200μs degraded threshold.
+        populate_stats(20, 18, 2, 15_000);
+
+        assert!(
+            scanner_is_degraded(),
+            "should be degraded at 750μs avg scan time (> 200μs threshold)",
+        );
+        // Slow scans also disqualify "healthy" (avg must be < 500μs).
+        assert!(
+            !scanner_is_healthy(),
+            "must not be healthy at 750μs avg scan time (>= 500μs)",
+        );
+
+        reset_stats();
+    }
+
+    #[test]
+    #[serial]
+    fn test_scanner_health_score_returns_one_with_no_data() {
+        reset_stats();
+        // No scans yet — score is 1.0 by definition (no data to penalize).
+        assert!(
+            (scanner_health_score() - 1.0).abs() < f64::EPSILON,
+            "health score must be 1.0 with no data, got {}",
+            scanner_health_score(),
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_scanner_health_score_higher_for_healthy_than_degraded() {
+        // Healthy snapshot: 90% hits, 50μs avg.
+        reset_stats();
+        populate_stats(20, 18, 2, 1_000);
+        let healthy_score = scanner_health_score();
+
+        // Degraded snapshot: 5% hits, 750μs avg.
+        reset_stats();
+        populate_stats(20, 1, 19, 15_000);
+        let degraded_score = scanner_health_score();
+
+        assert!(
+            healthy_score > degraded_score,
+            "healthy score ({healthy_score}) must exceed degraded score ({degraded_score})",
+        );
+        // Bounds check: scores live in [0.0, 1.0].
+        assert!((0.0..=1.0).contains(&healthy_score));
+        assert!((0.0..=1.0).contains(&degraded_score));
+
+        reset_stats();
+    }
+}

--- a/crates/octarine/src/runtime/async/builder.rs
+++ b/crates/octarine/src/runtime/async/builder.rs
@@ -295,4 +295,94 @@ mod tests {
         let executor = builder.executor("worker");
         assert_eq!(executor.name(), "service.worker");
     }
+
+    // ========================================================================
+    // Channel name-prefix and config propagation
+    //
+    // These tests exercise observable channel state via `.split()`, which
+    // exposes `sender.name()` / `receiver.name()`. They guard against
+    // regressions where `with_name_prefix` silently stops propagating into
+    // channel names, and lock in the documented quirk that
+    // `channel_with_config` does NOT apply the builder prefix (the config
+    // already carries its own name).
+    // ========================================================================
+
+    #[test]
+    fn test_with_name_prefix_propagates_to_channel() {
+        let builder = RuntimeBuilder::new().with_name_prefix("svc");
+        let channel: Channel<i32> = builder.channel("events", 100);
+
+        let (sender, receiver) = channel.split();
+        assert_eq!(sender.name(), "svc.events");
+        assert_eq!(receiver.name(), "svc.events");
+    }
+
+    #[test]
+    fn test_with_name_prefix_propagates_to_high_throughput_channel() {
+        let builder = RuntimeBuilder::new().with_name_prefix("svc");
+        let channel: Channel<i32> = builder.high_throughput_channel("ingest");
+
+        let (sender, _receiver) = channel.split();
+        assert_eq!(
+            sender.name(),
+            "svc.ingest",
+            "high_throughput_channel must apply the builder prefix",
+        );
+    }
+
+    #[test]
+    fn test_with_name_prefix_propagates_to_reliable_channel() {
+        let builder = RuntimeBuilder::new().with_name_prefix("svc");
+        let channel: Channel<i32> = builder.reliable_channel("queue");
+
+        let (sender, _receiver) = channel.split();
+        assert_eq!(sender.name(), "svc.queue");
+    }
+
+    #[test]
+    fn test_with_name_prefix_propagates_to_low_latency_channel() {
+        let builder = RuntimeBuilder::new().with_name_prefix("svc");
+        let channel: Channel<i32> = builder.low_latency_channel("rpc");
+
+        let (sender, _receiver) = channel.split();
+        assert_eq!(sender.name(), "svc.rpc");
+    }
+
+    #[test]
+    fn test_channel_with_config_uses_config_name_verbatim() {
+        // Documented behavior: channel_with_config does NOT apply the
+        // builder prefix because the config already carries its own name.
+        let builder = RuntimeBuilder::new().with_name_prefix("ignored");
+        let config = ChannelConfig::low_latency("explicit");
+
+        // Sanity: confirm the assertion below tracks the config's actual
+        // name and capacity. If `ChannelConfig::low_latency` is changed,
+        // these expectations need to follow.
+        assert_eq!(config.name(), "explicit");
+        assert_eq!(config.capacity(), 100);
+
+        let channel: Channel<i32> = builder.channel_with_config(config);
+        let (sender, receiver) = channel.split();
+        assert_eq!(
+            sender.name(),
+            "explicit",
+            "channel_with_config must NOT prepend the builder prefix",
+        );
+        assert_eq!(receiver.name(), "explicit");
+    }
+
+    #[test]
+    fn test_channel_with_config_preserves_capacity() {
+        // Verify that channel_with_config actually wires the supplied
+        // ChannelConfig through to channel construction. The builder is
+        // a thin passthrough to `Channel::with_config`, so we assert
+        // that the explicit config name and capacity survive.
+        let custom = ChannelConfig::new("custom", 8);
+        assert_eq!(custom.capacity(), 8, "sanity check on input config");
+
+        let builder = RuntimeBuilder::new();
+        let channel: Channel<u8> = builder.channel_with_config(custom);
+        let (sender, _receiver) = channel.split();
+        assert_eq!(sender.name(), "custom");
+    }
 }

--- a/crates/octarine/tests/http/presets.rs
+++ b/crates/octarine/tests/http/presets.rs
@@ -529,3 +529,290 @@ async fn test_request_decompression_inflates_gzipped_body() {
     // The handler must have seen the inflated payload, not the gzipped one.
     assert_eq!(received_len, plaintext.len());
 }
+
+// ============================================================================
+// CORS — additional preset coverage (issue #275)
+// ============================================================================
+
+/// `production(&[a, b])` echoes back any of the configured origins, not
+/// just the first. Guards against a regression where multi-origin allow
+/// lists silently collapse to a single match.
+#[tokio::test]
+async fn test_cors_production_multiple_origins_each_allowed() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(cors::production(&[
+            "https://app.example.com",
+            "https://admin.example.com",
+        ]));
+
+    for origin in ["https://app.example.com", "https://admin.example.com"] {
+        let request = Request::builder()
+            .method(Method::OPTIONS)
+            .uri("/")
+            .header(header::ORIGIN, origin)
+            .header(header::ACCESS_CONTROL_REQUEST_METHOD, "POST")
+            .body(Body::empty())
+            .expect("valid request");
+
+        let response = app.clone().oneshot(request).await.expect("response");
+        let allow_origin = response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .unwrap_or_else(|| panic!("origin {origin} should be allowed"))
+            .to_str()
+            .expect("ASCII");
+        assert_eq!(
+            allow_origin, origin,
+            "must echo the matching origin verbatim"
+        );
+    }
+}
+
+/// `read_only(&["x"])` echoes only the listed origin and rejects others
+/// (this preset is the read-only sibling of `production`, so it must
+/// honor the same allow-list semantics).
+#[tokio::test]
+async fn test_cors_read_only_specific_origins_rejects_others() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(cors::read_only(&["https://allowed.example.com"]));
+
+    // Allowed origin → echoed back.
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/")
+        .header(header::ORIGIN, "https://allowed.example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .body(Body::empty())
+        .expect("valid request");
+    let response = app.clone().oneshot(request).await.expect("response");
+    let allow_origin = response
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .expect("allowed origin should echo")
+        .to_str()
+        .expect("ASCII");
+    assert_eq!(allow_origin, "https://allowed.example.com");
+
+    // Disallowed origin → no Allow-Origin header.
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/")
+        .header(header::ORIGIN, "https://other.example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .body(Body::empty())
+        .expect("valid request");
+    let response = app.oneshot(request).await.expect("response");
+    assert!(
+        response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none(),
+        "read_only with explicit allow-list must not echo other origins",
+    );
+}
+
+// ============================================================================
+// Body limits — additional preset coverage (issue #275)
+// ============================================================================
+
+/// `upload_body()` (50 MB) admits a payload that `large_body()` (10 MB)
+/// would reject, confirming the higher ceiling actually applies.
+#[tokio::test]
+async fn test_limits_upload_body_admits_above_large_limit() {
+    let app = Router::new()
+        .route("/", post(echo_body))
+        .layer(limits::upload_body());
+
+    // 12 MB — would be rejected by large_body() (10 MB) but allowed by
+    // upload_body() (50 MB).
+    let payload = vec![0_u8; 12 * 1024 * 1024];
+    let len = payload.len();
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(header::CONTENT_LENGTH, len.to_string())
+        .body(Body::from(payload))
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// `ingestion_body()` (100 MB) admits a payload that `upload_body()`
+/// (50 MB) would reject, confirming the highest ceiling applies.
+#[tokio::test]
+async fn test_limits_ingestion_body_admits_above_upload_limit() {
+    let app = Router::new()
+        .route("/", post(echo_body))
+        .layer(limits::ingestion_body());
+
+    // 60 MB — would be rejected by upload_body() (50 MB) but allowed by
+    // ingestion_body() (100 MB).
+    let payload = vec![0_u8; 60 * 1024 * 1024];
+    let len = payload.len();
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/")
+        .header(header::CONTENT_LENGTH, len.to_string())
+        .body(Body::from(payload))
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ============================================================================
+// Timeout — additional preset coverage (issue #275)
+//
+// Each test uses `tokio::time::pause()` + `advance()` for deterministic
+// behavior under coverage tooling (no wall-clock sleeps; see
+// `octarine-test-resilience` skill).
+// ============================================================================
+
+/// `default_timeout()` (30 s) returns 408 when the handler runs longer
+/// than the deadline.
+#[tokio::test(start_paused = true)]
+async fn test_timeout_default_fires_after_deadline() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                tokio::time::sleep(Duration::from_secs(31)).await;
+                "ok"
+            }),
+        )
+        .layer(timeout::default_timeout());
+
+    let request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let pending = tokio::spawn(app.oneshot(request));
+    tokio::time::advance(Duration::from_secs(31)).await;
+
+    let response = pending
+        .await
+        .expect("join handle")
+        .expect("response result");
+
+    assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+}
+
+/// `upload_timeout()` (300 s) admits a handler that runs for 200 s —
+/// upload-style requests must not be cut off prematurely.
+#[tokio::test(start_paused = true)]
+async fn test_timeout_upload_admits_long_handler() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                tokio::time::sleep(Duration::from_secs(200)).await;
+                "ok"
+            }),
+        )
+        .layer(timeout::upload_timeout());
+
+    let request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let pending = tokio::spawn(app.oneshot(request));
+    // Advance past the handler sleep but well before the 300 s deadline.
+    tokio::time::advance(Duration::from_secs(201)).await;
+
+    let response = pending
+        .await
+        .expect("join handle")
+        .expect("response result");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// `custom_timeout(Duration)` enforces exactly the duration passed in.
+#[tokio::test(start_paused = true)]
+async fn test_timeout_custom_enforces_specified_duration() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                "ok"
+            }),
+        )
+        .layer(timeout::custom_timeout(Duration::from_secs(2)));
+
+    let request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let pending = tokio::spawn(app.oneshot(request));
+    tokio::time::advance(Duration::from_secs(3)).await;
+
+    let response = pending
+        .await
+        .expect("join handle")
+        .expect("response result");
+
+    assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+}
+
+// ============================================================================
+// Compression — additional preset coverage (issue #275)
+// ============================================================================
+
+/// `fast_compression()` honors `Accept-Encoding: gzip` and emits gzipped
+/// content (the speed/ratio knob lives below the wire encoding, so the
+/// behavioral signature is the same as `default_compression`).
+#[tokio::test]
+async fn test_compression_fast_honors_gzip() {
+    let app = Router::new()
+        .route("/", get(|| async { vec![b'A'; 4096] }))
+        .layer(compression::fast_compression());
+
+    let request = Request::builder()
+        .uri("/")
+        .header(header::ACCEPT_ENCODING, "gzip")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let encoding = response
+        .headers()
+        .get(header::CONTENT_ENCODING)
+        .expect("should set Content-Encoding")
+        .to_str()
+        .expect("ASCII");
+    assert_eq!(encoding, "gzip");
+}
+
+/// `best_compression()` honors `Accept-Encoding: gzip` and emits gzipped
+/// content. This locks in the contract that the "best" preset still
+/// negotiates the same encodings — only the compression level differs.
+#[tokio::test]
+async fn test_compression_best_honors_gzip() {
+    let app = Router::new()
+        .route("/", get(|| async { vec![b'A'; 4096] }))
+        .layer(compression::best_compression());
+
+    let request = Request::builder()
+        .uri("/")
+        .header(header::ACCEPT_ENCODING, "gzip")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = app.oneshot(request).await.expect("response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let encoding = response
+        .headers()
+        .get(header::CONTENT_ENCODING)
+        .expect("should set Content-Encoding")
+        .to_str()
+        .expect("ASCII");
+    assert_eq!(encoding, "gzip");
+}

--- a/crates/octarine/tests/pii_redaction_integration.rs
+++ b/crates/octarine/tests/pii_redaction_integration.rs
@@ -658,3 +658,122 @@ fn test_mixed_financial_pii_detected_together() {
     assert!(pii_types.contains(&PiiType::Iban));
     assert!(pii_types.contains(&PiiType::CryptoAddress));
 }
+
+// ==========================================
+// EDGE CASES — Empty, oversize, international formats
+//
+// Covers issue #275 acceptance criteria for missing scenarios in the
+// PII redaction integration suite. Each test asserts on redaction
+// output, not just absence of crash.
+// ==========================================
+
+/// Empty input: redaction must produce an empty string (no panic, no
+/// inserted markers) and `scan_for_pii` must report no findings.
+#[test]
+fn test_redact_empty_string() {
+    assert_eq!(redact_pii(""), "");
+    assert!(
+        scan_for_pii("").is_empty(),
+        "scan of empty string must report no PII",
+    );
+}
+
+/// Embedded SSN in a string under each detector's MAX_INPUT_LENGTH
+/// (10 KB) is still redacted — the scanner does not skip merely because
+/// the input is large. This is the "happy path" sibling of the
+/// over-limit test below.
+#[test]
+fn test_redact_large_input_under_limit_still_redacts_ssn() {
+    let padding = "x".repeat(4_000);
+    // Total length ~= 8 KB — well under the per-detector 10 KB guard.
+    let text = format!("{padding} SSN: 900-00-0001 {padding}");
+    assert!(
+        text.len() < 10_000,
+        "fixture must stay under MAX_INPUT_LENGTH; got {}",
+        text.len(),
+    );
+
+    let redacted = redact_pii(&text);
+    assert!(
+        redacted.contains("[SSN]"),
+        "SSN inside an under-limit string must still be redacted",
+    );
+    assert!(
+        !redacted.contains("900-00-0001"),
+        "raw SSN must not survive redaction",
+    );
+}
+
+/// Embedded SSN in a string above each detector's MAX_INPUT_LENGTH
+/// (10 KB) documents the current short-circuit behavior: detectors
+/// return no matches once the input exceeds their guard, so PII passes
+/// through unredacted. This test locks that contract in: any future
+/// change that starts truncating the input or chunking the scan must
+/// update both this test and the `MAX_INPUT_LENGTH` comments in
+/// `primitives/identifiers/*/detection.rs`.
+#[test]
+fn test_redact_large_input_above_limit_skips_pii() {
+    let padding = "x".repeat(11_000);
+    // Total length ~= 22 KB — above the per-detector 10 KB guard.
+    let text = format!("{padding} SSN: 900-00-0001 {padding}");
+    assert!(
+        text.len() > 10_000,
+        "fixture must exceed MAX_INPUT_LENGTH; got {}",
+        text.len(),
+    );
+
+    let redacted = redact_pii(&text);
+    // Output is the same length as input — nothing was substituted.
+    assert_eq!(
+        redacted.len(),
+        text.len(),
+        "above-limit input passes through with no substitutions",
+    );
+    assert!(
+        !redacted.contains("[SSN]"),
+        "SSN detector short-circuits at MAX_INPUT_LENGTH (10 KB) — \
+         no [SSN] marker should appear",
+    );
+    assert!(
+        redacted.contains("900-00-0001"),
+        "raw SSN survives because the detector skipped this oversize input",
+    );
+}
+
+/// IBAN in canonical UK format (with spaces) is detected and redacted.
+/// IBAN routes through the bank-account redactor (see
+/// `observe/pii/redactor/mod.rs:152`), which emits `[BANK_ACCOUNT]`
+/// rather than a separate `[IBAN]` token.
+#[test]
+fn test_redact_iban_uk_format_with_spaces() {
+    let text = "Account: GB82 WEST 1234 5698 7654 32";
+    let redacted = redact_pii(text);
+    assert_eq!(
+        redacted, "Account: [BANK_ACCOUNT]",
+        "UK IBAN with spaces must redact to [BANK_ACCOUNT]",
+    );
+}
+
+/// International phone in UK format (`+44 20 7946 0958`) — the Ofcom
+/// example reserved range — is detected and redacted to `[PHONE]`.
+#[test]
+fn test_redact_phone_uk_format() {
+    let text = "Call: +44 20 7946 0958";
+    let redacted = redact_pii(text);
+    assert_eq!(
+        redacted, "Call: [PHONE]",
+        "UK phone with spaces must redact to [PHONE]",
+    );
+}
+
+/// International phone in Japanese format (`+81-3-1234-5678`) is
+/// detected and redacted to `[PHONE]`.
+#[test]
+fn test_redact_phone_japan_format() {
+    let text = "Call: +81-3-1234-5678";
+    let redacted = redact_pii(text);
+    assert_eq!(
+        redacted, "Call: [PHONE]",
+        "Japan phone with hyphens must redact to [PHONE]",
+    );
+}


### PR DESCRIPTION
## Summary

Fills behavioral assertion gaps across non-security Layer 3 (decomposed from
umbrella issue #181). The common theme: tests existed but only proved
constructors didn't panic — closing this gap surfaces regressions when
behavior drifts.

- **observe/pii/scanner/health** — 7 `#[serial]` tests for healthy /
  degraded thresholds and health-score bounds. The file had no tests
  previously. Exercises `SCANNER_STATS` via a new test-only
  `reset_stats()` helper in `cache.rs`.
- **runtime/async/builder** — 6 tests asserting `with_name_prefix`
  propagates into channel names across all four channel constructors,
  and locking in the documented quirk that `channel_with_config` does
  NOT apply the builder prefix.
- **io/delete** — 2 async error-path tests for nonexistent file and
  directory rejection, asserting both the error wording and no-residue
  guarantees.
- **tests/pii_redaction_integration** — 6 tests for empty input, large
  input under and above the 10 KB `MAX_INPUT_LENGTH` guard (documents
  the short-circuit behavior), UK IBAN with spaces (redacts to
  `[BANK_ACCOUNT]`), and UK / Japan international phone formats.
- **tests/http/presets** — 9 behavioral tests filling preset audit gaps:
  multi-origin CORS production, `read_only` with explicit allow-list,
  `upload_body` / `ingestion_body` limits above their smaller siblings,
  `default_timeout` / `upload_timeout` / `custom_timeout` firing via
  `tokio::time::pause()`, and `fast_compression` / `best_compression`
  honoring gzip.

## Notes for reviewers

The original issue claimed "~26 tests with no behavioral assertion" in
`http/presets`. After audit, most preset functions already had behavioral
integration tests in `tests/http/presets.rs` — the unit tests in
`src/http/presets/*.rs` are smoke-only by design (each preset's
clippy comment explicitly documents this, since tower-http types expose
no public accessors). The audit found 9 actual gaps, not 26.

For the >10 KB PII case: the issue body asked to "verify scanner does
not truncate or skip", but the current detectors short-circuit at
`MAX_INPUT_LENGTH` (10 KB) — the new test documents that as the actual
behavior so future drift will be caught.

## Test plan

- [x] `just test-mod observe::pii::scanner::health` — 8 passed
- [x] `just test-mod runtime::r#async::builder` — 14 passed (8 existing + 6 new)
- [x] `just test-mod io::delete` — 16 passed (14 existing + 2 new)
- [x] `cargo test --test pii_redaction_integration` — 61 passed (55 existing + 6 new)
- [x] `cargo test --test http_integration` — 77 passed (68 existing + 9 new)
- [x] `just preflight` — fmt + clippy + arch-check + full suite all green

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)