### PR TITLE
test(auth,observe): use paused time and real concurrency in flaky tests

### DIFF
--- a/crates/octarine/src/auth/timing.rs
+++ b/crates/octarine/src/auth/timing.rs
@@ -238,8 +238,10 @@ mod tests {
         let elapsed = start.elapsed();
 
         assert_eq!(result, 42);
-        // Allow 20% margin for OS scheduler jitter
-        assert!(elapsed >= Duration::from_millis(40));
+        // std::thread::sleep is at-least, Instant is monotonic, so >=
+        // the configured floor is precise and CI-stable (no upper bound
+        // to flake under coverage load).
+        assert!(elapsed >= config.min_duration);
     }
 
     #[test]
@@ -249,47 +251,46 @@ mod tests {
             .max_duration(Duration::from_millis(100))
             .build();
 
+        let operation_duration = Duration::from_millis(20);
         let start = Instant::now();
         let result = constant_time_response_sync(&config, || {
-            std::thread::sleep(Duration::from_millis(20));
+            std::thread::sleep(operation_duration);
             42
         });
         let elapsed = start.elapsed();
 
         assert_eq!(result, 42);
-        // Allow margins for OS scheduler jitter and CI load
-        assert!(elapsed >= Duration::from_millis(16));
-        assert!(elapsed < Duration::from_millis(200));
+        // When operation > min_duration, no padding is added; the
+        // operation's own sleep is the precise floor.
+        assert!(elapsed >= operation_duration);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_constant_time_response_async_fast() {
         let config = ConstantTimeConfig::builder()
             .min_duration(Duration::from_millis(50))
             .build();
 
-        let start = Instant::now();
+        let start = tokio::time::Instant::now();
         let result = constant_time_response(&config, async { 42 }).await;
         let elapsed = start.elapsed();
 
         assert_eq!(result, 42);
-        // Allow 20% margin for OS scheduler jitter
-        assert!(elapsed >= Duration::from_millis(40));
+        // Paused time advances exactly when tokio::time::sleep fires,
+        // so elapsed is precisely the configured floor.
+        assert_eq!(elapsed, config.min_duration);
     }
 
     #[test]
     fn test_constant_time_response_sync_slow_warning() {
-        // Configure a very short max_duration so the operation exceeds it
+        // max_duration = ZERO means any non-zero elapsed time exceeds
+        // it, so the warn path triggers without a wall-clock sleep.
         let config = ConstantTimeConfig::builder()
-            .min_duration(Duration::from_millis(1))
-            .max_duration(Duration::from_millis(5))
+            .min_duration(Duration::from_nanos(1))
+            .max_duration(Duration::ZERO)
             .build();
 
-        // Operation that takes longer than max_duration triggers the warn path
-        let result = constant_time_response_sync(&config, || {
-            std::thread::sleep(Duration::from_millis(20));
-            99
-        });
+        let result = constant_time_response_sync(&config, || 99);
 
         // The warn path should not prevent the result from being returned
         assert_eq!(result, 99);

--- a/crates/octarine/tests/observe/writer_memory.rs
+++ b/crates/octarine/tests/observe/writer_memory.rs
@@ -435,29 +435,53 @@ async fn test_batch_write_respects_capacity() {
 // Thread Safety
 // ============================================================================
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_concurrent_writes() {
-    let writer = Arc::new(MemoryWriter::new());
-    let mut handles = vec![];
+    use std::collections::HashSet;
+    use tokio::sync::Barrier;
 
-    // Spawn multiple tasks writing concurrently
-    for i in 0..10 {
+    let writer = Arc::new(MemoryWriter::new());
+    let task_count = 10usize;
+    let writes_per_task = 10usize;
+    // Barrier so all tasks start writing at the same instant — without
+    // this, early-spawned tasks could finish before later ones start,
+    // hiding races behind cooperative scheduling.
+    let barrier = Arc::new(Barrier::new(task_count));
+    let mut handles = Vec::with_capacity(task_count);
+
+    for i in 0..task_count {
         let w = Arc::clone(&writer);
+        let b = Arc::clone(&barrier);
         handles.push(tokio::spawn(async move {
-            for j in 0..10 {
-                let event = Event::new(EventType::Info, format!("Task {} Event {}", i, j));
+            b.wait().await;
+            for j in 0..writes_per_task {
+                let event = Event::new(EventType::Info, format!("Task {i} Event {j}"));
                 w.write(&event).await.expect("write should succeed");
             }
         }));
     }
 
-    // Wait for all writes
     for handle in handles {
         handle.await.expect("task should complete");
     }
 
-    // All events should be written
-    assert_eq!(writer.len(), 100);
+    // Total count: catches dropped writes.
+    assert_eq!(writer.len(), task_count * writes_per_task);
+
+    // Uniqueness: every (task, event) pair must appear exactly once —
+    // catches lost or duplicated writes a count check would miss.
+    let stored = writer.all_events();
+    let messages: HashSet<String> = stored.iter().map(|e| e.message.clone()).collect();
+    assert_eq!(messages.len(), task_count * writes_per_task);
+    for i in 0..task_count {
+        for j in 0..writes_per_task {
+            let expected = format!("Task {i} Event {j}");
+            assert!(
+                messages.contains(&expected),
+                "missing event from concurrent write: {expected}"
+            );
+        }
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `auth/timing.rs` (4 tests): replace hardcoded margins and wall-clock sleeps. Sync tests now use precise `>=` floors (`std::thread::sleep` is at-least, `Instant` is monotonic — no upper bound to flake). `async_fast` switches to `#[tokio::test(start_paused = true)]` per the pattern introduced in #282. `slow_warning` uses `Duration::ZERO` for `max_duration` so the warn path triggers without a 20 ms sleep.
- `tests/observe/writer_memory.rs::test_concurrent_writes`: switch to `flavor = "multi_thread", worker_threads = 4`. The default `current_thread` runtime serializes spawned tasks at `.await` points; `MemoryWriter::write` has no internal `.await` (it uses `std::sync::RwLock`), so the previous test never exercised real contention. Adds a `tokio::sync::Barrier` for synchronized start and a `HashSet` uniqueness check across all 100 messages so a dropped/duplicated write actually fails the test.

## Test plan

- [x] `just test-filter test_constant_time_response` — all 4 tests pass in 0.26 s
- [x] `just test-filter test_concurrent_writes` — passes on multi-thread runtime
- [x] 20× flake-loop on all 5 tests: 20 pass / 0 fail
- [x] `just preflight` — fmt-check + clippy + arch-check + 6466 tests, all green

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)