### PR TITLE
test(security): cover error paths and edge cases in Layer 3 builders

### DIFF
--- a/crates/octarine/src/security/commands/builder.rs
+++ b/crates/octarine/src/security/commands/builder.rs
@@ -393,4 +393,54 @@ mod tests {
             .expect("should escape");
         assert!(!escaped.is_empty());
     }
+
+    #[test]
+    fn test_validate_args_multi_arg_error() {
+        // The error path of validate_args (issue #274 / umbrella #181):
+        // a list with one bad item should propagate the failure.
+        let security = CommandSecurityBuilder::new();
+
+        let bad = ["safe-arg", "$(rm -rf /)", "also-safe"];
+        let err = security
+            .validate_args(bad)
+            .expect_err("middle arg has command substitution; expected Err");
+        // Error message should reference the offending argument index ("Argument 1").
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("Argument 1"),
+            "expected indexed error, got: {}",
+            msg
+        );
+
+        // All-safe inputs pass.
+        assert!(security.validate_args(["a", "b", "c"]).is_ok());
+        // Empty iterator is vacuously ok.
+        let empty: [&str; 0] = [];
+        assert!(security.validate_args(empty).is_ok());
+    }
+
+    #[test]
+    fn test_validate_env_dangerous_name() {
+        let security = CommandSecurityBuilder::new();
+
+        // Shell metacharacter in name is dangerous (per is_dangerous_env_name).
+        assert!(security.validate_env("BAD$NAME", "ok").is_err());
+        // `=` in the name is dangerous.
+        assert!(security.validate_env("KEY=other", "ok").is_err());
+        // Empty name is dangerous.
+        assert!(security.validate_env("", "value").is_err());
+    }
+
+    #[test]
+    fn test_validate_env_dangerous_value() {
+        let security = CommandSecurityBuilder::new();
+
+        // Shell expansion in value is dangerous.
+        assert!(security.validate_env("PATH", "$(whoami)").is_err());
+        // Null byte in value is dangerous.
+        assert!(security.validate_env("PATH", "ok\0bad").is_err());
+
+        // Positive case: plain value passes.
+        assert!(security.validate_env("PATH", "/usr/bin").is_ok());
+    }
 }

--- a/crates/octarine/src/security/formats/shortcuts.rs
+++ b/crates/octarine/src/security/formats/shortcuts.rs
@@ -161,4 +161,63 @@ mod tests {
         assert!(validate_yaml_safe("key: value").is_ok());
         assert!(validate_yaml_safe("!!python/object").is_err());
     }
+
+    #[test]
+    fn test_validate_json_safe_depth_failure() {
+        // JsonPolicy::strict() max_depth = 32; build a chain of 40 nested objects.
+        let mut deep = String::with_capacity(120);
+        for _ in 0..40 {
+            deep.push_str("{\"a\":");
+        }
+        deep.push('1');
+        for _ in 0..40 {
+            deep.push('}');
+        }
+        assert!(validate_json_safe(&deep).is_err());
+
+        // Sanity: shallow JSON passes strict.
+        assert!(validate_json_safe(r#"{"a":1}"#).is_ok());
+    }
+
+    #[test]
+    fn test_validate_json_safe_size_failure() {
+        // JsonPolicy::strict() max_size = 1MB; build a payload above that.
+        let big = format!("{{\"a\":\"{}\"}}", "x".repeat(1_100_000));
+        assert!(validate_json_safe(&big).is_err());
+    }
+
+    #[test]
+    fn test_detect_xml_threats_doctype() {
+        // Bare DOCTYPE (no entity) should produce a DtdPresent threat.
+        let threats = detect_xml_threats("<!DOCTYPE html><root/>");
+        assert!(
+            threats.contains(&FormatThreat::DtdPresent),
+            "expected DtdPresent in {:?}",
+            threats
+        );
+
+        // Clean XML produces no threats via the shortcut entry point.
+        assert!(detect_xml_threats("<root><child/></root>").is_empty());
+    }
+
+    #[test]
+    fn test_yaml_anchor_bomb_via_shortcut() {
+        // Anchor-bomb heuristic (primitives/security/formats/yaml/detection.rs):
+        // 1 anchor + > 10 aliases triggers the self-referential branch.
+        let mut yaml = String::from("a: &a value\nlist:\n");
+        for _ in 0..12 {
+            yaml.push_str("  - *a\n");
+        }
+
+        // is_yaml_unsafe combines unsafe-tag and anchor-bomb checks.
+        assert!(is_yaml_unsafe(&yaml));
+
+        // detect_yaml_threats with strict policy (max_aliases=0) flags AnchorBomb.
+        let threats = detect_yaml_threats(&yaml, &YamlPolicy::strict());
+        assert!(
+            threats.contains(&FormatThreat::YamlAnchorBomb),
+            "expected YamlAnchorBomb in {:?}",
+            threats
+        );
+    }
 }

--- a/crates/octarine/src/security/network/builder.rs
+++ b/crates/octarine/src/security/network/builder.rs
@@ -779,4 +779,89 @@ mod tests {
         assert!(builder.is_potential_ssrf("http://localhost/admin"));
         assert!(builder.validate_url_format("https://example.com").is_ok());
     }
+
+    #[test]
+    fn test_validate_hostname_length_error_path() {
+        let builder = NetworkSecurityBuilder::silent();
+
+        // Success: within RFC 1035 max (253).
+        assert!(
+            builder
+                .validate_hostname_length("ok.example.com", 253)
+                .is_ok()
+        );
+
+        // Error: 300 chars exceeds 253.
+        let too_long = "a".repeat(300);
+        assert!(builder.validate_hostname_length(&too_long, 253).is_err());
+
+        // Error: even smaller maxes are enforced (length-only check is policy-driven).
+        assert!(
+            builder
+                .validate_hostname_length("abcdef.example.com", 5)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_classify_host_variants() {
+        use super::super::types::HostType;
+        let builder = NetworkSecurityBuilder::silent();
+
+        assert_eq!(builder.classify_host("192.168.1.1"), HostType::Ipv4);
+        assert_eq!(builder.classify_host("::1"), HostType::Ipv6);
+        assert_eq!(builder.classify_host("[::1]"), HostType::Ipv6);
+        assert_eq!(builder.classify_host("example.com"), HostType::Domain);
+        assert_eq!(builder.classify_host(""), HostType::Unknown);
+    }
+
+    #[test]
+    fn test_ssrf_ipv4_range_boundaries() {
+        // RFC 1918 boundary coverage (issue #274 / umbrella #181).
+        let builder = NetworkSecurityBuilder::silent();
+
+        // 10.0.0.0/8 — full /8 is private.
+        assert!(builder.is_potential_ssrf("http://10.0.0.0/"));
+        assert!(builder.is_potential_ssrf("http://10.255.255.255/"));
+
+        // 172.16.0.0/12 — 172.16.x.x through 172.31.x.x.
+        assert!(builder.is_potential_ssrf("http://172.16.0.0/"));
+        assert!(builder.is_potential_ssrf("http://172.31.255.255/"));
+
+        // Just outside 172.16-31 should NOT trigger SSRF.
+        assert!(!builder.is_potential_ssrf("http://172.15.0.0/"));
+        assert!(!builder.is_potential_ssrf("http://172.32.0.0/"));
+
+        // 192.168.0.0/16 — full /16 is private.
+        assert!(builder.is_potential_ssrf("http://192.168.0.0/"));
+        assert!(builder.is_potential_ssrf("http://192.168.255.255/"));
+    }
+
+    #[test]
+    fn test_ssrf_ipv6_private_addresses() {
+        // IPv6 private-range coverage (issue #274 / umbrella #181).
+        let builder = NetworkSecurityBuilder::silent();
+
+        // Direct IPv6 classification — non-bracketed form parses cleanly.
+        // Unique-local (fc00::/7).
+        assert!(builder.is_private_ipv6("fd00::1"));
+        assert!(builder.is_private_ipv6("fc00::1"));
+        // Link-local (fe80::/10).
+        assert!(builder.is_private_ipv6("fe80::1"));
+        // Loopback.
+        assert!(builder.is_private_ipv6("::1"));
+        // Unspecified.
+        assert!(builder.is_private_ipv6("::"));
+        // Public IPv6 (documentation prefix) should not match.
+        assert!(!builder.is_private_ipv6("2001:db8::1"));
+
+        // SSRF via URL form: bracketed `[::1]` works because it's in the
+        // localhost lookup table. Other private IPv6 ranges are not yet
+        // detected in `is_potential_ssrf` (the URL-host extractor returns
+        // `[fd00::1]` with brackets, which `is_private_ipv6` cannot parse).
+        // The direct `is_private_ipv6` checks above are the canonical
+        // coverage; URL-form SSRF for arbitrary private IPv6 is tracked
+        // as a separate primitive-level gap.
+        assert!(builder.is_potential_ssrf("http://[::1]/"));
+    }
 }

--- a/crates/octarine/src/security/paths/builder.rs
+++ b/crates/octarine/src/security/paths/builder.rs
@@ -403,6 +403,12 @@ impl SecurityBuilder {
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
+    use crate::observe::metrics::{flush_for_testing, snapshot};
+    use std::sync::Mutex;
+
+    /// Serializes metrics-touching tests within this file so they don't race
+    /// each other on the shared global registry.
+    static METRICS_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_builder_creation() {
@@ -450,5 +456,89 @@ mod tests {
         assert!(!clean.contains(".."));
 
         assert!(security.sanitize("safe/path").is_ok());
+    }
+
+    #[test]
+    fn test_metrics_validate_ms_recorded() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = SecurityBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .histograms
+            .get("security.paths.validate_ms")
+            .map_or(0, |h| h.count);
+
+        let _ = builder.validate_path("safe/path");
+        flush_for_testing();
+
+        let after = snapshot()
+            .histograms
+            .get("security.paths.validate_ms")
+            .map_or(0, |h| h.count);
+        assert!(after > before, "validate_ms should record");
+    }
+
+    #[test]
+    fn test_metrics_threats_detected_counter() {
+        let _guard = METRICS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let builder = SecurityBuilder::new();
+        flush_for_testing();
+        let before = snapshot()
+            .counters
+            .get("security.paths.threats_detected")
+            .map_or(0, |c| c.value);
+
+        assert!(builder.is_traversal_present("../etc/passwd"));
+        flush_for_testing();
+
+        let after = snapshot()
+            .counters
+            .get("security.paths.threats_detected")
+            .map_or(0, |c| c.value);
+        assert!(after > before, "threats_detected should increment");
+    }
+
+    #[test]
+    fn test_silent_mode_emits_no_metrics() {
+        // Structural test: `silent()` returns a builder with emit_events=false,
+        // and every metric call site in this module is gated by `if self.emit_events`.
+        // A behavioral delta-assertion would race with concurrent tests across the
+        // workspace that hit these same global metric names via shortcuts/facade.
+        let builder = SecurityBuilder::silent();
+        assert!(!builder.emit_events);
+
+        // Sanity: invoking through the silent builder still works functionally.
+        assert!(builder.is_threat_present("../etc/passwd"));
+        assert!(builder.validate_path("safe/path").is_ok());
+        assert!(builder.sanitize("../etc/passwd").is_ok());
+    }
+
+    #[test]
+    fn test_paths_edge_cases() {
+        // Edge-case inputs flagged by the audit (umbrella #181 / issue #274):
+        // empty string, unicode, Windows separators on Linux, very long paths.
+        // The contract is "well-defined behavior, no panic" — exact ok/err
+        // depends on the primitive's policy, so we just exercise the path.
+        let security = SecurityBuilder::silent();
+
+        // Empty string — should be handled (validate_not_empty rejects).
+        let _ = security.validate_path("");
+        let _ = security.is_threat_present("");
+
+        // Unicode path: non-ASCII filename should not crash the validator.
+        // A bare unicode filename has no traversal/injection markers, so it
+        // is expected to pass the strict validator.
+        assert!(security.validate_path("café/file.txt").is_ok());
+
+        // Windows separators on a Linux host: backslashes are not directory
+        // separators here, so this is a single filename containing `\`. It
+        // contains no threats and should validate.
+        assert!(security.validate_path("foo\\bar.txt").is_ok());
+
+        // Long path: 4096 chars (typical PATH_MAX). Should not panic; either
+        // accepted or rejected for length, both are acceptable behaviors.
+        let long_path = "a/".repeat(2048);
+        let _ = security.validate_path(&long_path);
+        let _ = security.is_threat_present(&long_path);
     }
 }


### PR DESCRIPTION
## Summary

Adds 14 tests across four Layer 3 security builders to close the
test-gap checkboxes flagged in the audit umbrella (#181). All new
tests follow the existing `METRICS_LOCK + flush_for_testing + snapshot`
delta pattern and respect the `octarine-test-resilience` rules
(no fixed sleeps, no absolute metric assertions).

- `security/paths/builder.rs`: 4 tests — metrics deltas
  (`validate_ms`, `threats_detected`), silent-mode structural test,
  edge-case inputs (empty, unicode, Windows separators on Linux,
  long paths). The file previously had no metrics tests; this brings
  it in line with `network`, `formats`, and `queries`.
- `security/network/builder.rs`: 4 tests — `validate_hostname_length`
  error path, `classify_host` four-variant coverage, IPv4 SSRF range
  boundaries (10/8, 172.16-31/12, 192.168/16 plus just-outside cases
  at 172.15.0.0 and 172.32.0.0), IPv6 private-range coverage via
  `is_private_ipv6` (fc00::/7, fe80::/10, ::1, ::, plus a public
  negative).
- `security/formats/shortcuts.rs`: 4 tests — `validate_json_safe`
  depth and size failure paths against `JsonPolicy::strict()`,
  `detect_xml_threats` DOCTYPE branch (`FormatThreat::DtdPresent`),
  YAML anchor-bomb detection via `is_yaml_unsafe` and
  `detect_yaml_threats` shortcuts.
- `security/commands/builder.rs`: 3 tests — `validate_args`
  multi-arg error (asserts the indexed error message), `validate_env`
  dangerous-name cases (`$` in name, `=` in name, empty name),
  `validate_env` dangerous-value cases (command substitution, null
  byte) plus a positive case.

## Test plan

- `just test-mod "security::paths::builder"` — 25 tests pass
- `just test-mod "security::network::builder"` — 21 tests pass
- `just test-filter "security::formats"` — formats shortcut tests pass
- `just test-mod "security::commands::builder"` — 18 tests pass
- `just preflight` — full workspace tests + clippy + fmt + arch-check
  green (6481 unit tests, 0 failures)

## Note on out-of-scope finding

The IPv6 SSRF test calls `is_private_ipv6` directly. The URL-form
(`http://[fd00::1]/`) is not detected because
`extract_host_for_ssrf_check` returns the bracketed `[fd00::1]` and
`is_private_ipv6` cannot parse brackets. The Layer 3 IPv6 coverage
the audit asked for is satisfied here; the URL-form gap is a
primitive-level issue worth a separate ticket.

Closes #274