### PR TITLE
refactor(data/paths): split PathBuilder god-module into per-concern impl blocks

### DIFF
--- a/.claude/memory/feedback_just_recipes.md
+++ b/.claude/memory/feedback_just_recipes.md
@@ -1,11 +1,11 @@
 ---
 name: Use just recipes, not raw commands
-description: All verification, testing, and linting should reference just recipes — never raw cargo/bash commands in plans or docs
+description: All verification, testing, linting, AND ad-hoc dev commands must use just recipes — never raw cargo/bash commands, even for one-off iteration
 type: feedback
+originSessionId: 0641e80c-85a8-41f7-9026-371e1fa16da1
 ---
+Always use `just` recipes — in plans, verification sections, documentation, AND for ad-hoc commands during development iteration. Never invoke `cargo test`, `cargo clippy`, `cargo build`, `cargo fmt`, or `bash scripts/*` directly, even when tempted to "just check this one thing quickly."
 
-Always reference `just` recipes in plans, verification sections, and documentation — never raw `cargo test`, `cargo clippy`, or `bash scripts/` commands.
+**Why:** `just` recipes are the single source of truth for how to run things. Agents, hooks, CI, and humans should all use the same recipes. Raw commands are implementation details that can drift, miss feature flags, or use wrong job counts. Reinforced 2026-04-29: agent reached for `cargo build` and `cargo test` mid-implementation when `just test-octarine` / `just test-mod` would have done the same job; user pushed back firmly.
 
-**Why:** `just` recipes are the single source of truth for how to run things. Agents, hooks, CI, and humans should all use the same recipes. Raw commands are implementation details that can drift.
-
-**How to apply:** In plan verification sections, write `just test-octarine` not `cargo test -p octarine --lib`. Write `just arch-check` not `bash scripts/arch-check.sh`. Write `just clippy` not `cargo clippy --workspace -- -D warnings`.
+**How to apply:** In plan verification sections AND during execution: write `just test-octarine` not `cargo test -p octarine --lib`. Write `just test-mod "data::paths::builder"` not `cargo test --lib data::paths::builder`. Write `just arch-check` not `bash scripts/arch-check.sh`. Write `just clippy` not `cargo clippy --workspace -- -D warnings`. If a recipe doesn't exist for the exact thing you want, prefer the closest existing recipe over a raw cargo invocation.

--- a/crates/octarine/src/data/paths/builder/mod.rs
+++ b/crates/octarine/src/data/paths/builder/mod.rs
@@ -23,6 +23,14 @@
 //! [`PathBuilder`] provides a unified API that delegates to specialized builders.
 //! Use it when you need multiple types of operations or prefer a single entry point.
 //!
+//! Methods on `PathBuilder` are split across files in the `path_builder/`
+//! subdirectory by concern (characteristic, filetype, security, filename,
+//! construction, format, home, context, building, lenient, boundary).
+//! Constructors and the methods that emit metrics directly (`detect`,
+//! `is_safe`, `validate_detailed`, `validate_path`, `sanitize`) stay in
+//! this file so the `define_metrics!`-generated `metric_names` module
+//! remains in scope.
+//!
 //! # Examples
 //!
 //! ## Using Specialized Builders
@@ -69,6 +77,9 @@ mod format;
 mod home;
 mod lenient;
 
+// PathBuilder method clusters, organized by concern
+mod path_builder;
+
 // Re-export all specialized builders
 pub use boundary::BoundaryBuilder;
 pub use characteristic::CharacteristicBuilder;
@@ -90,11 +101,8 @@ use crate::observe::Problem;
 use crate::observe::metrics::{increment_by, record};
 use crate::primitives::data::paths::PathBuilder as PrimitivePathBuilder;
 
-use crate::data::paths::types::{
-    FileCategory, PathDetectionResult, PathType, PathValidationResult, Platform,
-};
-use crate::primitives::data::paths::Platform as PrimitivePlatform;
-use crate::security::paths::{PathSanitizationStrategy, SecurityThreat};
+use crate::data::paths::types::{PathDetectionResult, PathValidationResult, Platform};
+use crate::security::paths::PathSanitizationStrategy;
 
 crate::define_metrics! {
     detect_ms => "data.paths.detect_ms",
@@ -192,123 +200,11 @@ impl PathBuilder {
     }
 
     // ========================================================================
-    // PATH TYPE DETECTION (delegates to CharacteristicBuilder)
-    // ========================================================================
-
-    /// Detect the type of a path
-    #[must_use]
-    pub fn detect_path_type(&self, path: &str) -> PathType {
-        CharacteristicBuilder::new().detect_path_type(path)
-    }
-
-    /// Detect the platform of a path
-    #[must_use]
-    pub fn detect_platform(&self, path: &str) -> Platform {
-        CharacteristicBuilder::new().detect_platform(path)
-    }
-
-    /// Check if path is absolute
-    #[must_use]
-    pub fn is_absolute(&self, path: &str) -> bool {
-        CharacteristicBuilder::new().is_absolute(path)
-    }
-
-    /// Check if path is relative
-    #[must_use]
-    pub fn is_relative(&self, path: &str) -> bool {
-        CharacteristicBuilder::new().is_relative(path)
-    }
-
-    /// Check if path is portable
-    #[must_use]
-    pub fn is_portable(&self, path: &str) -> bool {
-        CharacteristicBuilder::new().is_portable(path)
-    }
-
-    /// Check if path is Unix-style
-    #[must_use]
-    pub fn is_unix_style(&self, path: &str) -> bool {
-        CharacteristicBuilder::new().is_unix_path(path)
-    }
-
-    /// Check if path is Windows-style
-    #[must_use]
-    pub fn is_windows_style(&self, path: &str) -> bool {
-        CharacteristicBuilder::new().is_windows_path(path)
-    }
-
-    // ========================================================================
-    // FILE TYPE DETECTION (delegates to FiletypeBuilder)
-    // ========================================================================
-
-    /// Detect the file category
-    #[must_use]
-    pub fn detect_file_category(&self, path: &str) -> FileCategory {
-        FiletypeBuilder::new().detect(path)
-    }
-
-    /// Check if file is an image
-    #[must_use]
-    pub fn is_image(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_image(path)
-    }
-
-    /// Check if file is audio
-    #[must_use]
-    pub fn is_audio(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_audio(path)
-    }
-
-    /// Check if file is video
-    #[must_use]
-    pub fn is_video(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_video(path)
-    }
-
-    /// Check if file is media
-    #[must_use]
-    pub fn is_media(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_media(path)
-    }
-
-    /// Check if file is a document
-    #[must_use]
-    pub fn is_document(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_document(path)
-    }
-
-    /// Check if file is source code
-    #[must_use]
-    pub fn is_code(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_code(path)
-    }
-
-    /// Check if file is a config file
-    #[must_use]
-    pub fn is_config(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_config(path)
-    }
-
-    /// Check if file is an executable
-    #[must_use]
-    pub fn is_executable(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_executable(path)
-    }
-
-    /// Check if file is an archive
-    #[must_use]
-    pub fn is_archive(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_archive(path)
-    }
-
-    /// Check if file is security-sensitive
-    #[must_use]
-    pub fn is_security_sensitive(&self, path: &str) -> bool {
-        FiletypeBuilder::new().is_security_sensitive(path)
-    }
-
-    // ========================================================================
-    // SECURITY DETECTION (delegates to SecurityBuilder)
+    // METRIC-EMITTING METHODS
+    //
+    // These stay in this file because they reference the file-local
+    // `metric_names` module generated by `define_metrics!` above. Pure
+    // delegators live in submodules under `path_builder/`.
     // ========================================================================
 
     /// Perform comprehensive path detection
@@ -333,70 +229,6 @@ impl PathBuilder {
 
         result.into()
     }
-
-    /// Detect all security threats
-    #[must_use]
-    pub fn detect_threats(&self, path: &str) -> Vec<SecurityThreat> {
-        SecurityBuilder::new().detect_threats(path)
-    }
-
-    /// Check if path has any security threat
-    #[must_use]
-    pub fn is_threat_present(&self, path: &str) -> bool {
-        SecurityBuilder::new().is_threat_present(path)
-    }
-
-    /// Check if path has traversal
-    #[must_use]
-    pub fn is_traversal_present(&self, path: &str) -> bool {
-        SecurityBuilder::new().is_traversal_present(path)
-    }
-
-    /// Check if path has encoded traversal
-    #[must_use]
-    pub fn is_encoded_traversal_present(&self, path: &str) -> bool {
-        SecurityBuilder::new().is_encoded_traversal_present(path)
-    }
-
-    /// Check if path has command injection
-    #[must_use]
-    pub fn is_command_injection_present(&self, path: &str) -> bool {
-        SecurityBuilder::new().is_command_injection_present(path)
-    }
-
-    /// Check if path has variable expansion
-    #[must_use]
-    pub fn is_variable_expansion_present(&self, path: &str) -> bool {
-        SecurityBuilder::new().is_variable_expansion_present(path)
-    }
-
-    /// Check if path has shell metacharacters
-    #[must_use]
-    pub fn is_shell_metacharacters_present(&self, path: &str) -> bool {
-        SecurityBuilder::new().is_shell_metacharacters_present(path)
-    }
-
-    /// Check if path has null bytes
-    #[must_use]
-    pub fn is_null_bytes_present(&self, path: &str) -> bool {
-        SecurityBuilder::new().is_null_bytes_present(path)
-    }
-
-    /// Check if path has control characters
-    #[must_use]
-    pub fn is_control_characters_present(&self, path: &str) -> bool {
-        SecurityBuilder::new().is_control_characters_present(path)
-    }
-
-    /// Check if path has double encoding
-    #[must_use]
-    pub fn is_double_encoding_present(&self, path: &str) -> bool {
-        SecurityBuilder::new().is_double_encoding_present(path)
-    }
-
-    // ========================================================================
-    // VALIDATION
-    // ========================================================================
 
     /// Check if path is safe
     #[must_use]
@@ -452,10 +284,6 @@ impl PathBuilder {
         SecurityBuilder::new().validate_path(path)
     }
 
-    // ========================================================================
-    // SANITIZATION
-    // ========================================================================
-
     /// Sanitize a path by removing threats
     ///
     /// Cleans the path by removing traversal patterns and dangerous characters.
@@ -489,375 +317,13 @@ impl PathBuilder {
     ) -> Result<String, Problem> {
         SecurityBuilder::new().sanitize_with(path, strategy)
     }
-
-    // ========================================================================
-    // FILENAME OPERATIONS (delegates to FilenameBuilder)
-    // ========================================================================
-
-    /// Validate a filename
-    ///
-    /// # Errors
-    ///
-    /// Returns `Problem::Validation` if the filename:
-    /// - Is invalid (empty, too long, or contains invalid characters)
-    /// - Is unsafe (contains traversal or dangerous patterns)
-    pub fn validate_filename(&self, filename: &str) -> Result<(), Problem> {
-        let fb = FilenameBuilder::new();
-        if !fb.is_valid(filename) {
-            return Err(Problem::validation(format!(
-                "Invalid filename: {}",
-                filename
-            )));
-        }
-        if !fb.is_safe(filename) {
-            return Err(Problem::validation(format!(
-                "Unsafe filename: {}",
-                filename
-            )));
-        }
-        Ok(())
-    }
-
-    /// Validate a filename for uploads
-    ///
-    /// # Errors
-    ///
-    /// Returns `Problem::Validation` if the filename is not safe for uploads
-    /// (contains dangerous extensions, hidden prefixes, or security threats).
-    pub fn validate_upload_filename(&self, filename: &str) -> Result<(), Problem> {
-        let fb = FilenameBuilder::new();
-        if !fb.is_upload_safe(filename) {
-            return Err(Problem::validation(format!(
-                "Unsafe upload filename: {}",
-                filename
-            )));
-        }
-        Ok(())
-    }
-
-    /// Sanitize a filename
-    ///
-    /// Removes dangerous characters and patterns from a filename.
-    /// For lenient cleaning that always returns a value, use [`Self::to_safe_filename`].
-    ///
-    /// # Errors
-    ///
-    /// Returns `Problem::Validation` if the filename cannot be safely sanitized
-    /// or would become empty/invalid after removing dangerous content.
-    pub fn sanitize_filename(&self, filename: &str) -> Result<String, Problem> {
-        FilenameBuilder::new().sanitize(filename)
-    }
-
-    /// Get a safe filename
-    #[must_use]
-    pub fn to_safe_filename(&self, filename: &str) -> String {
-        FilenameBuilder::new().to_safe_filename(filename)
-    }
-
-    /// Get filename from path
-    #[must_use]
-    pub fn filename<'a>(&self, path: &'a str) -> &'a str {
-        PrimitivePathBuilder::new().filename(path)
-    }
-
-    /// Get file extension
-    #[must_use]
-    pub fn find_extension<'a>(&self, path: &'a str) -> Option<&'a str> {
-        PrimitivePathBuilder::new().find_extension(path)
-    }
-
-    /// Get filename stem
-    #[must_use]
-    pub fn stem<'a>(&self, path: &'a str) -> &'a str {
-        PrimitivePathBuilder::new().stem(path)
-    }
-
-    // ========================================================================
-    // PATH CONSTRUCTION
-    // ========================================================================
-
-    /// Join two path segments
-    ///
-    /// Uses the platform set via `for_platform()` or `Platform::Auto` by default.
-    #[must_use]
-    pub fn join(&self, base: &str, path: &str) -> String {
-        let prim_platform: PrimitivePlatform = self.platform.into();
-        PrimitivePathBuilder::for_platform(prim_platform).join(base, path)
-    }
-
-    /// Join paths with Unix separators
-    #[must_use]
-    pub fn join_unix(&self, base: &str, path: &str) -> String {
-        PrimitivePathBuilder::new().join_unix(base, path)
-    }
-
-    /// Join paths with Windows separators
-    #[must_use]
-    pub fn join_windows(&self, base: &str, path: &str) -> String {
-        PrimitivePathBuilder::new().join_windows(base, path)
-    }
-
-    /// Get parent directory
-    #[must_use]
-    pub fn find_parent<'a>(&self, path: &'a str) -> Option<&'a str> {
-        PrimitivePathBuilder::new().find_parent(path)
-    }
-
-    /// Split path into components
-    #[must_use]
-    pub fn split<'a>(&self, path: &'a str) -> Vec<&'a str> {
-        PrimitivePathBuilder::new().split(path)
-    }
-
-    /// Clean path by resolving . and .. components
-    #[must_use]
-    pub fn clean_path_components(&self, path: &str) -> String {
-        PrimitivePathBuilder::new().clean_path(path)
-    }
-
-    /// Convert a relative path to absolute by resolving against a base
-    #[must_use]
-    pub fn to_absolute_path(&self, base: &str, path: &str) -> String {
-        PrimitivePathBuilder::new().to_absolute_path(base, path)
-    }
-
-    /// Convert an absolute path to a relative path from one location to another
-    #[must_use]
-    pub fn to_relative_path(&self, from: &str, to: &str) -> String {
-        PrimitivePathBuilder::new().to_relative_path(from, to)
-    }
-
-    // ========================================================================
-    // FORMAT CONVERSION (delegates to FormatBuilder)
-    // ========================================================================
-
-    /// Detect the format of a path
-    #[must_use]
-    pub fn detect_format(&self, path: &str) -> PathFormat {
-        FormatBuilder::new().detect(path)
-    }
-
-    /// Convert path to a specific format
-    #[must_use]
-    pub fn convert_format(&self, path: &str, target: PathFormat) -> String {
-        FormatBuilder::new().convert(path, target).into_owned()
-    }
-
-    /// Convert to Unix format
-    #[must_use]
-    pub fn to_unix(&self, path: &str) -> String {
-        FormatBuilder::new().convert_to_unix(path).into_owned()
-    }
-
-    /// Convert to Windows format
-    #[must_use]
-    pub fn to_windows(&self, path: &str) -> String {
-        FormatBuilder::new().convert_to_windows(path).into_owned()
-    }
-
-    /// Normalize path
-    #[must_use]
-    pub fn normalize(&self, path: &str) -> String {
-        PrimitivePathBuilder::new().normalize_unix(path)
-    }
-
-    /// Convert to WSL path
-    #[must_use]
-    pub fn to_wsl(&self, path: &str) -> Option<String> {
-        FormatBuilder::new().convert_to_wsl(path)
-    }
-
-    /// Convert WSL to Windows path
-    #[must_use]
-    pub fn wsl_to_windows(&self, path: &str) -> Option<String> {
-        FormatBuilder::new().wsl_to_windows(path)
-    }
-
-    // ========================================================================
-    // HOME DIRECTORY (delegates to HomeBuilder)
-    // ========================================================================
-
-    /// Check for home reference
-    #[must_use]
-    pub fn is_home_reference_present(&self, path: &str) -> bool {
-        HomeBuilder::new().is_reference_present(path)
-    }
-
-    /// Expand home directory
-    pub fn expand_home(&self, path: &str) -> Result<String, Problem> {
-        HomeBuilder::new().expand(path)
-    }
-
-    /// Collapse home directory
-    #[must_use]
-    pub fn collapse_home(&self, path: &str) -> String {
-        HomeBuilder::new().collapse(path)
-    }
-
-    // ========================================================================
-    // CONTEXT-SPECIFIC (delegates to PathContextBuilder)
-    // ========================================================================
-
-    /// Check if env path
-    #[must_use]
-    pub fn is_env_path(&self, path: &str) -> bool {
-        PathContextBuilder::new().is_env_path(path)
-    }
-
-    /// Sanitize env path
-    pub fn sanitize_env_path(&self, path: &str) -> Result<String, Problem> {
-        PathContextBuilder::new().sanitize_env(path)
-    }
-
-    /// Check if SSH path
-    #[must_use]
-    pub fn is_ssh_path(&self, path: &str) -> bool {
-        PathContextBuilder::new().is_ssh_path(path)
-    }
-
-    /// Sanitize SSH path
-    pub fn sanitize_ssh_path(&self, path: &str) -> Result<String, Problem> {
-        PathContextBuilder::new().sanitize_ssh(path)
-    }
-
-    /// Check if credential path
-    #[must_use]
-    pub fn is_credential_path(&self, path: &str) -> bool {
-        PathContextBuilder::new().is_credential_path(path)
-    }
-
-    /// Sanitize credential path
-    pub fn sanitize_credential_path(&self, path: &str) -> Result<String, Problem> {
-        PathContextBuilder::new().sanitize_credential(path)
-    }
-
-    /// Sanitize certificate path
-    pub fn sanitize_certificate_path(&self, path: &str) -> Result<String, Problem> {
-        PathContextBuilder::new().sanitize_certificate(path)
-    }
-
-    /// Sanitize keystore path
-    pub fn sanitize_keystore_path(&self, path: &str) -> Result<String, Problem> {
-        PathContextBuilder::new().sanitize_keystore(path)
-    }
-
-    /// Sanitize secret path
-    pub fn sanitize_secret_path(&self, path: &str) -> Result<String, Problem> {
-        PathContextBuilder::new().sanitize_secret(path)
-    }
-
-    /// Sanitize backup path
-    pub fn sanitize_backup_path(&self, path: &str) -> Result<String, Problem> {
-        PathContextBuilder::new().sanitize_backup(path)
-    }
-
-    /// Check if op reference
-    #[must_use]
-    pub fn is_op_reference(&self, path: &str) -> bool {
-        PathContextBuilder::new().is_op_reference(path)
-    }
-
-    /// Sanitize op reference
-    pub fn sanitize_op_reference(&self, path: &str) -> Result<String, Problem> {
-        PathContextBuilder::new().sanitize_op(path)
-    }
-
-    // ========================================================================
-    // PATH BUILDING (delegates to ConstructionBuilder)
-    // ========================================================================
-
-    /// Build path from components
-    pub fn build_path(&self, base: &str, components: &[&str]) -> Result<String, Problem> {
-        ConstructionBuilder::new().build(base, components)
-    }
-
-    /// Build absolute path
-    pub fn build_absolute_path(&self, base: &str, components: &[&str]) -> Result<String, Problem> {
-        ConstructionBuilder::new().build_absolute(base, components)
-    }
-
-    /// Build file path
-    pub fn build_file_path(&self, directory: &str, filename: &str) -> Result<String, Problem> {
-        ConstructionBuilder::new().build_file(directory, filename)
-    }
-
-    /// Build temp path
-    #[must_use]
-    pub fn build_temp_path(&self, filename: &str) -> String {
-        ConstructionBuilder::new().temp(filename)
-    }
-
-    /// Build config path
-    #[must_use]
-    pub fn build_config_path(&self, directory: &str, environment: Option<&str>) -> String {
-        ConstructionBuilder::new().config(directory, environment)
-    }
-
-    /// Join components
-    pub fn join_components(&self, components: &[&str]) -> Result<String, Problem> {
-        ConstructionBuilder::new().join(components)
-    }
-
-    // ========================================================================
-    // LENIENT SANITIZATION (delegates to LenientBuilder)
-    // ========================================================================
-
-    /// Clean path (lenient)
-    #[must_use]
-    pub fn clean_path(&self, path: &str) -> String {
-        LenientBuilder::new().clean_path(path)
-    }
-
-    /// Clean user path (lenient)
-    #[must_use]
-    pub fn clean_user_path(&self, path: &str) -> String {
-        LenientBuilder::new().clean_user_path(path)
-    }
-
-    /// Clean filename (lenient)
-    #[must_use]
-    pub fn clean_filename(&self, filename: &str) -> String {
-        LenientBuilder::new().clean_filename(filename)
-    }
-
-    /// Clean separators (lenient)
-    #[must_use]
-    pub fn clean_separators(&self, path: &str) -> String {
-        LenientBuilder::new().clean_separators(path)
-    }
-
-    // ========================================================================
-    // BOUNDARY OPERATIONS
-    // ========================================================================
-
-    /// Check if within boundary
-    #[must_use]
-    pub fn is_within_boundary(&self, path: &str) -> bool {
-        if let Some(ref boundary) = self.boundary {
-            BoundaryBuilder::new(boundary).is_within(path)
-        } else {
-            true
-        }
-    }
-
-    /// Resolve path in boundary
-    pub fn resolve_in_boundary(&self, path: &str) -> Result<String, Problem> {
-        if let Some(ref boundary) = self.boundary {
-            let bb = BoundaryBuilder::new(boundary);
-            if !bb.is_within(path) {
-                return Err(Problem::validation("Path escapes boundary"));
-            }
-            Ok(bb.resolve(path))
-        } else {
-            Ok(path.to_string())
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
+    use crate::data::paths::types::PathType;
 
     #[test]
     fn test_builder_creation() {

--- a/crates/octarine/src/data/paths/builder/path_builder/boundary.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/boundary.rs
@@ -1,0 +1,33 @@
+//! Boundary delegators for [`PathBuilder`] that go beyond the simple
+//! `boundary()` configuration setter (which lives in `builder/mod.rs`).
+//!
+//! Methods here read `self.boundary` and route through
+//! [`BoundaryBuilder`].
+
+use super::super::{BoundaryBuilder, PathBuilder};
+use crate::observe::Problem;
+
+impl PathBuilder {
+    /// Check if within boundary
+    #[must_use]
+    pub fn is_within_boundary(&self, path: &str) -> bool {
+        if let Some(ref boundary) = self.boundary {
+            BoundaryBuilder::new(boundary).is_within(path)
+        } else {
+            true
+        }
+    }
+
+    /// Resolve path in boundary
+    pub fn resolve_in_boundary(&self, path: &str) -> Result<String, Problem> {
+        if let Some(ref boundary) = self.boundary {
+            let bb = BoundaryBuilder::new(boundary);
+            if !bb.is_within(path) {
+                return Err(Problem::validation("Path escapes boundary"));
+            }
+            Ok(bb.resolve(path))
+        } else {
+            Ok(path.to_string())
+        }
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/building.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/building.rs
@@ -1,0 +1,41 @@
+//! Path-building delegators for [`PathBuilder`].
+//!
+//! Methods that delegate to [`ConstructionBuilder`] for assembling paths
+//! from components and producing temp/config paths.
+
+use super::super::{ConstructionBuilder, PathBuilder};
+use crate::observe::Problem;
+
+impl PathBuilder {
+    /// Build path from components
+    pub fn build_path(&self, base: &str, components: &[&str]) -> Result<String, Problem> {
+        ConstructionBuilder::new().build(base, components)
+    }
+
+    /// Build absolute path
+    pub fn build_absolute_path(&self, base: &str, components: &[&str]) -> Result<String, Problem> {
+        ConstructionBuilder::new().build_absolute(base, components)
+    }
+
+    /// Build file path
+    pub fn build_file_path(&self, directory: &str, filename: &str) -> Result<String, Problem> {
+        ConstructionBuilder::new().build_file(directory, filename)
+    }
+
+    /// Build temp path
+    #[must_use]
+    pub fn build_temp_path(&self, filename: &str) -> String {
+        ConstructionBuilder::new().temp(filename)
+    }
+
+    /// Build config path
+    #[must_use]
+    pub fn build_config_path(&self, directory: &str, environment: Option<&str>) -> String {
+        ConstructionBuilder::new().config(directory, environment)
+    }
+
+    /// Join components
+    pub fn join_components(&self, components: &[&str]) -> Result<String, Problem> {
+        ConstructionBuilder::new().join(components)
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/characteristic.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/characteristic.rs
@@ -1,0 +1,51 @@
+//! Path type and platform characteristic delegators for [`PathBuilder`].
+//!
+//! Methods that delegate to [`CharacteristicBuilder`].
+
+use super::super::CharacteristicBuilder;
+use super::super::PathBuilder;
+use crate::data::paths::types::{PathType, Platform};
+
+impl PathBuilder {
+    /// Detect the type of a path
+    #[must_use]
+    pub fn detect_path_type(&self, path: &str) -> PathType {
+        CharacteristicBuilder::new().detect_path_type(path)
+    }
+
+    /// Detect the platform of a path
+    #[must_use]
+    pub fn detect_platform(&self, path: &str) -> Platform {
+        CharacteristicBuilder::new().detect_platform(path)
+    }
+
+    /// Check if path is absolute
+    #[must_use]
+    pub fn is_absolute(&self, path: &str) -> bool {
+        CharacteristicBuilder::new().is_absolute(path)
+    }
+
+    /// Check if path is relative
+    #[must_use]
+    pub fn is_relative(&self, path: &str) -> bool {
+        CharacteristicBuilder::new().is_relative(path)
+    }
+
+    /// Check if path is portable
+    #[must_use]
+    pub fn is_portable(&self, path: &str) -> bool {
+        CharacteristicBuilder::new().is_portable(path)
+    }
+
+    /// Check if path is Unix-style
+    #[must_use]
+    pub fn is_unix_style(&self, path: &str) -> bool {
+        CharacteristicBuilder::new().is_unix_path(path)
+    }
+
+    /// Check if path is Windows-style
+    #[must_use]
+    pub fn is_windows_style(&self, path: &str) -> bool {
+        CharacteristicBuilder::new().is_windows_path(path)
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/construction.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/construction.rs
@@ -1,0 +1,61 @@
+//! Path construction delegators for [`PathBuilder`].
+//!
+//! Low-level path manipulation methods that delegate to the primitive
+//! [`PrimitivePathBuilder`] for joining, splitting, and resolving paths.
+
+use super::super::PathBuilder;
+use crate::primitives::data::paths::PathBuilder as PrimitivePathBuilder;
+use crate::primitives::data::paths::Platform as PrimitivePlatform;
+
+impl PathBuilder {
+    /// Join two path segments
+    ///
+    /// Uses the platform set via `for_platform()` or `Platform::Auto` by default.
+    #[must_use]
+    pub fn join(&self, base: &str, path: &str) -> String {
+        let prim_platform: PrimitivePlatform = self.platform.into();
+        PrimitivePathBuilder::for_platform(prim_platform).join(base, path)
+    }
+
+    /// Join paths with Unix separators
+    #[must_use]
+    pub fn join_unix(&self, base: &str, path: &str) -> String {
+        PrimitivePathBuilder::new().join_unix(base, path)
+    }
+
+    /// Join paths with Windows separators
+    #[must_use]
+    pub fn join_windows(&self, base: &str, path: &str) -> String {
+        PrimitivePathBuilder::new().join_windows(base, path)
+    }
+
+    /// Get parent directory
+    #[must_use]
+    pub fn find_parent<'a>(&self, path: &'a str) -> Option<&'a str> {
+        PrimitivePathBuilder::new().find_parent(path)
+    }
+
+    /// Split path into components
+    #[must_use]
+    pub fn split<'a>(&self, path: &'a str) -> Vec<&'a str> {
+        PrimitivePathBuilder::new().split(path)
+    }
+
+    /// Clean path by resolving . and .. components
+    #[must_use]
+    pub fn clean_path_components(&self, path: &str) -> String {
+        PrimitivePathBuilder::new().clean_path(path)
+    }
+
+    /// Convert a relative path to absolute by resolving against a base
+    #[must_use]
+    pub fn to_absolute_path(&self, base: &str, path: &str) -> String {
+        PrimitivePathBuilder::new().to_absolute_path(base, path)
+    }
+
+    /// Convert an absolute path to a relative path from one location to another
+    #[must_use]
+    pub fn to_relative_path(&self, from: &str, to: &str) -> String {
+        PrimitivePathBuilder::new().to_relative_path(from, to)
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/context.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/context.rs
@@ -1,0 +1,74 @@
+//! Context-specific path sanitization delegators for [`PathBuilder`].
+//!
+//! Methods that delegate to [`PathContextBuilder`] for env, SSH,
+//! credential, certificate, keystore, secret, backup, and op-reference
+//! path handling.
+
+use super::super::{PathBuilder, PathContextBuilder};
+use crate::observe::Problem;
+
+impl PathBuilder {
+    /// Check if env path
+    #[must_use]
+    pub fn is_env_path(&self, path: &str) -> bool {
+        PathContextBuilder::new().is_env_path(path)
+    }
+
+    /// Sanitize env path
+    pub fn sanitize_env_path(&self, path: &str) -> Result<String, Problem> {
+        PathContextBuilder::new().sanitize_env(path)
+    }
+
+    /// Check if SSH path
+    #[must_use]
+    pub fn is_ssh_path(&self, path: &str) -> bool {
+        PathContextBuilder::new().is_ssh_path(path)
+    }
+
+    /// Sanitize SSH path
+    pub fn sanitize_ssh_path(&self, path: &str) -> Result<String, Problem> {
+        PathContextBuilder::new().sanitize_ssh(path)
+    }
+
+    /// Check if credential path
+    #[must_use]
+    pub fn is_credential_path(&self, path: &str) -> bool {
+        PathContextBuilder::new().is_credential_path(path)
+    }
+
+    /// Sanitize credential path
+    pub fn sanitize_credential_path(&self, path: &str) -> Result<String, Problem> {
+        PathContextBuilder::new().sanitize_credential(path)
+    }
+
+    /// Sanitize certificate path
+    pub fn sanitize_certificate_path(&self, path: &str) -> Result<String, Problem> {
+        PathContextBuilder::new().sanitize_certificate(path)
+    }
+
+    /// Sanitize keystore path
+    pub fn sanitize_keystore_path(&self, path: &str) -> Result<String, Problem> {
+        PathContextBuilder::new().sanitize_keystore(path)
+    }
+
+    /// Sanitize secret path
+    pub fn sanitize_secret_path(&self, path: &str) -> Result<String, Problem> {
+        PathContextBuilder::new().sanitize_secret(path)
+    }
+
+    /// Sanitize backup path
+    pub fn sanitize_backup_path(&self, path: &str) -> Result<String, Problem> {
+        PathContextBuilder::new().sanitize_backup(path)
+    }
+
+    /// Check if op reference
+    #[must_use]
+    pub fn is_op_reference(&self, path: &str) -> bool {
+        PathContextBuilder::new().is_op_reference(path)
+    }
+
+    /// Sanitize op reference
+    pub fn sanitize_op_reference(&self, path: &str) -> Result<String, Problem> {
+        PathContextBuilder::new().sanitize_op(path)
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/filename.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/filename.rs
@@ -1,0 +1,89 @@
+//! Filename operation delegators for [`PathBuilder`].
+//!
+//! Methods that delegate to [`FilenameBuilder`] for validation,
+//! sanitization, and accessor operations on file names.
+
+use super::super::FilenameBuilder;
+use super::super::PathBuilder;
+use crate::observe::Problem;
+use crate::primitives::data::paths::PathBuilder as PrimitivePathBuilder;
+
+impl PathBuilder {
+    /// Validate a filename
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem::Validation` if the filename:
+    /// - Is invalid (empty, too long, or contains invalid characters)
+    /// - Is unsafe (contains traversal or dangerous patterns)
+    pub fn validate_filename(&self, filename: &str) -> Result<(), Problem> {
+        let fb = FilenameBuilder::new();
+        if !fb.is_valid(filename) {
+            return Err(Problem::validation(format!(
+                "Invalid filename: {}",
+                filename
+            )));
+        }
+        if !fb.is_safe(filename) {
+            return Err(Problem::validation(format!(
+                "Unsafe filename: {}",
+                filename
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validate a filename for uploads
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem::Validation` if the filename is not safe for uploads
+    /// (contains dangerous extensions, hidden prefixes, or security threats).
+    pub fn validate_upload_filename(&self, filename: &str) -> Result<(), Problem> {
+        let fb = FilenameBuilder::new();
+        if !fb.is_upload_safe(filename) {
+            return Err(Problem::validation(format!(
+                "Unsafe upload filename: {}",
+                filename
+            )));
+        }
+        Ok(())
+    }
+
+    /// Sanitize a filename
+    ///
+    /// Removes dangerous characters and patterns from a filename.
+    /// For lenient cleaning that always returns a value, use [`Self::to_safe_filename`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem::Validation` if the filename cannot be safely sanitized
+    /// or would become empty/invalid after removing dangerous content.
+    pub fn sanitize_filename(&self, filename: &str) -> Result<String, Problem> {
+        FilenameBuilder::new().sanitize(filename)
+    }
+
+    /// Get a safe filename
+    #[must_use]
+    pub fn to_safe_filename(&self, filename: &str) -> String {
+        FilenameBuilder::new().to_safe_filename(filename)
+    }
+
+    /// Get filename from path
+    #[must_use]
+    pub fn filename<'a>(&self, path: &'a str) -> &'a str {
+        PrimitivePathBuilder::new().filename(path)
+    }
+
+    /// Get file extension
+    #[must_use]
+    pub fn find_extension<'a>(&self, path: &'a str) -> Option<&'a str> {
+        PrimitivePathBuilder::new().find_extension(path)
+    }
+
+    /// Get filename stem
+    #[must_use]
+    pub fn stem<'a>(&self, path: &'a str) -> &'a str {
+        PrimitivePathBuilder::new().stem(path)
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/filetype.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/filetype.rs
@@ -1,0 +1,75 @@
+//! File category and type delegators for [`PathBuilder`].
+//!
+//! Methods that delegate to [`FiletypeBuilder`].
+
+use super::super::FiletypeBuilder;
+use super::super::PathBuilder;
+use crate::data::paths::types::FileCategory;
+
+impl PathBuilder {
+    /// Detect the file category
+    #[must_use]
+    pub fn detect_file_category(&self, path: &str) -> FileCategory {
+        FiletypeBuilder::new().detect(path)
+    }
+
+    /// Check if file is an image
+    #[must_use]
+    pub fn is_image(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_image(path)
+    }
+
+    /// Check if file is audio
+    #[must_use]
+    pub fn is_audio(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_audio(path)
+    }
+
+    /// Check if file is video
+    #[must_use]
+    pub fn is_video(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_video(path)
+    }
+
+    /// Check if file is media
+    #[must_use]
+    pub fn is_media(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_media(path)
+    }
+
+    /// Check if file is a document
+    #[must_use]
+    pub fn is_document(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_document(path)
+    }
+
+    /// Check if file is source code
+    #[must_use]
+    pub fn is_code(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_code(path)
+    }
+
+    /// Check if file is a config file
+    #[must_use]
+    pub fn is_config(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_config(path)
+    }
+
+    /// Check if file is an executable
+    #[must_use]
+    pub fn is_executable(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_executable(path)
+    }
+
+    /// Check if file is an archive
+    #[must_use]
+    pub fn is_archive(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_archive(path)
+    }
+
+    /// Check if file is security-sensitive
+    #[must_use]
+    pub fn is_security_sensitive(&self, path: &str) -> bool {
+        FiletypeBuilder::new().is_security_sensitive(path)
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/format.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/format.rs
@@ -1,0 +1,51 @@
+//! Path format conversion delegators for [`PathBuilder`].
+//!
+//! Methods that delegate to [`FormatBuilder`] for detection of path
+//! format and conversion between Unix, Windows, and WSL representations.
+
+use super::super::{FormatBuilder, PathBuilder, PathFormat};
+use crate::primitives::data::paths::PathBuilder as PrimitivePathBuilder;
+
+impl PathBuilder {
+    /// Detect the format of a path
+    #[must_use]
+    pub fn detect_format(&self, path: &str) -> PathFormat {
+        FormatBuilder::new().detect(path)
+    }
+
+    /// Convert path to a specific format
+    #[must_use]
+    pub fn convert_format(&self, path: &str, target: PathFormat) -> String {
+        FormatBuilder::new().convert(path, target).into_owned()
+    }
+
+    /// Convert to Unix format
+    #[must_use]
+    pub fn to_unix(&self, path: &str) -> String {
+        FormatBuilder::new().convert_to_unix(path).into_owned()
+    }
+
+    /// Convert to Windows format
+    #[must_use]
+    pub fn to_windows(&self, path: &str) -> String {
+        FormatBuilder::new().convert_to_windows(path).into_owned()
+    }
+
+    /// Normalize path
+    #[must_use]
+    pub fn normalize(&self, path: &str) -> String {
+        PrimitivePathBuilder::new().normalize_unix(path)
+    }
+
+    /// Convert to WSL path
+    #[must_use]
+    pub fn to_wsl(&self, path: &str) -> Option<String> {
+        FormatBuilder::new().convert_to_wsl(path)
+    }
+
+    /// Convert WSL to Windows path
+    #[must_use]
+    pub fn wsl_to_windows(&self, path: &str) -> Option<String> {
+        FormatBuilder::new().wsl_to_windows(path)
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/home.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/home.rs
@@ -1,0 +1,26 @@
+//! Home directory delegators for [`PathBuilder`].
+//!
+//! Methods that delegate to [`HomeBuilder`] for `~` expansion and
+//! collapse.
+
+use super::super::{HomeBuilder, PathBuilder};
+use crate::observe::Problem;
+
+impl PathBuilder {
+    /// Check for home reference
+    #[must_use]
+    pub fn is_home_reference_present(&self, path: &str) -> bool {
+        HomeBuilder::new().is_reference_present(path)
+    }
+
+    /// Expand home directory
+    pub fn expand_home(&self, path: &str) -> Result<String, Problem> {
+        HomeBuilder::new().expand(path)
+    }
+
+    /// Collapse home directory
+    #[must_use]
+    pub fn collapse_home(&self, path: &str) -> String {
+        HomeBuilder::new().collapse(path)
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/lenient.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/lenient.rs
@@ -1,0 +1,32 @@
+//! Lenient sanitization delegators for [`PathBuilder`].
+//!
+//! Methods that delegate to [`LenientBuilder`] — these always return a
+//! value (never error), suitable for best-effort cleaning.
+
+use super::super::{LenientBuilder, PathBuilder};
+
+impl PathBuilder {
+    /// Clean path (lenient)
+    #[must_use]
+    pub fn clean_path(&self, path: &str) -> String {
+        LenientBuilder::new().clean_path(path)
+    }
+
+    /// Clean user path (lenient)
+    #[must_use]
+    pub fn clean_user_path(&self, path: &str) -> String {
+        LenientBuilder::new().clean_user_path(path)
+    }
+
+    /// Clean filename (lenient)
+    #[must_use]
+    pub fn clean_filename(&self, filename: &str) -> String {
+        LenientBuilder::new().clean_filename(filename)
+    }
+
+    /// Clean separators (lenient)
+    #[must_use]
+    pub fn clean_separators(&self, path: &str) -> String {
+        LenientBuilder::new().clean_separators(path)
+    }
+}

--- a/crates/octarine/src/data/paths/builder/path_builder/mod.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/mod.rs
@@ -1,0 +1,22 @@
+//! `PathBuilder` extension impl blocks, organized by concern.
+//!
+//! `PathBuilder` is defined in the parent module (`builder/mod.rs`).
+//! Each file here adds an `impl PathBuilder { ... }` block scoped to a
+//! specific concern (file type detection, format conversion, etc.). This
+//! mirrors the split-impl pattern used in `observe/builder/` and
+//! `observe/context/builder/`.
+//!
+//! Methods that emit metrics directly stay in `builder/mod.rs` so the
+//! `define_metrics!`-generated `metric_names` module remains in scope.
+
+mod boundary;
+mod building;
+mod characteristic;
+mod construction;
+mod context;
+mod filename;
+mod filetype;
+mod format;
+mod home;
+mod lenient;
+mod security;

--- a/crates/octarine/src/data/paths/builder/path_builder/security.rs
+++ b/crates/octarine/src/data/paths/builder/path_builder/security.rs
@@ -1,0 +1,70 @@
+//! Security threat detection delegators for [`PathBuilder`].
+//!
+//! Methods that delegate to [`SecurityBuilder`] (defined in
+//! `crate::security::paths`). The metric-emitting `detect()` method stays
+//! in `builder/mod.rs` to keep `define_metrics!`-generated names in scope.
+
+use super::super::PathBuilder;
+use crate::security::paths::{SecurityBuilder, SecurityThreat};
+
+impl PathBuilder {
+    /// Detect all security threats
+    #[must_use]
+    pub fn detect_threats(&self, path: &str) -> Vec<SecurityThreat> {
+        SecurityBuilder::new().detect_threats(path)
+    }
+
+    /// Check if path has any security threat
+    #[must_use]
+    pub fn is_threat_present(&self, path: &str) -> bool {
+        SecurityBuilder::new().is_threat_present(path)
+    }
+
+    /// Check if path has traversal
+    #[must_use]
+    pub fn is_traversal_present(&self, path: &str) -> bool {
+        SecurityBuilder::new().is_traversal_present(path)
+    }
+
+    /// Check if path has encoded traversal
+    #[must_use]
+    pub fn is_encoded_traversal_present(&self, path: &str) -> bool {
+        SecurityBuilder::new().is_encoded_traversal_present(path)
+    }
+
+    /// Check if path has command injection
+    #[must_use]
+    pub fn is_command_injection_present(&self, path: &str) -> bool {
+        SecurityBuilder::new().is_command_injection_present(path)
+    }
+
+    /// Check if path has variable expansion
+    #[must_use]
+    pub fn is_variable_expansion_present(&self, path: &str) -> bool {
+        SecurityBuilder::new().is_variable_expansion_present(path)
+    }
+
+    /// Check if path has shell metacharacters
+    #[must_use]
+    pub fn is_shell_metacharacters_present(&self, path: &str) -> bool {
+        SecurityBuilder::new().is_shell_metacharacters_present(path)
+    }
+
+    /// Check if path has null bytes
+    #[must_use]
+    pub fn is_null_bytes_present(&self, path: &str) -> bool {
+        SecurityBuilder::new().is_null_bytes_present(path)
+    }
+
+    /// Check if path has control characters
+    #[must_use]
+    pub fn is_control_characters_present(&self, path: &str) -> bool {
+        SecurityBuilder::new().is_control_characters_present(path)
+    }
+
+    /// Check if path has double encoding
+    #[must_use]
+    pub fn is_double_encoding_present(&self, path: &str) -> bool {
+        SecurityBuilder::new().is_double_encoding_present(path)
+    }
+}


### PR DESCRIPTION
## Summary

The unified `PathBuilder` facade in `crates/octarine/src/data/paths/builder/mod.rs` was 920 LOC with 89 `pub fn` delegators packed into a single file — ~9× the size of any other Layer 3 builder. Audit (`audit-architecture` finding `architecture-003`) flagged it as a god-module.

This refactor splits the delegators into a new `path_builder/` subdirectory, with one file per concern, each containing an `impl PathBuilder { ... }` extension block. The struct, constructors, and the five methods that emit metrics directly (`detect`, `is_safe`, `validate_detailed`, `validate_path`, `sanitize`) stay in `mod.rs` so the `define_metrics!`-generated `metric_names` module remains in scope.

- `mod.rs` drops from **920 → 386 LOC**
- 11 new files under `path_builder/` (boundary, building, characteristic, construction, context, filename, filetype, format, home, lenient, security), each well under 100 LOC
- **Public API is byte-identical** — all 89 methods remain on `PathBuilder` via merged impl blocks; no caller-site changes across the 151 use sites
- Pattern mirrors precedent in `observe/builder/` (7 files) and `observe/context/builder/` (5 files)

The bundled `chore(memory)` commit strengthens an internal feedback memory; not part of the refactor itself.

## Test plan

- [x] `just preflight` — fmt + clippy + arch-check + tests all pass (6481 unit + 241 doctests)
- [x] `just test-mod "data::paths::builder"` — 134 passed, 0 failed (including the existing 6-test PathBuilder integration suite)
- [x] Public API surface unchanged — confirmed by clean compile across all 151 caller sites
- [x] Metric emissions unchanged — `data.paths.{detect_ms,validate_ms,validated}` still fire from the methods that stayed in `mod.rs`

Closes #174