### PR TITLE
refactor(visibility): re-export primitives types from L3 shortcuts

### DIFF
--- a/crates/octarine/src/crypto/validation/mod.rs
+++ b/crates/octarine/src/crypto/validation/mod.rs
@@ -102,6 +102,9 @@ pub use types::{ValidatedCertificate, ValidatedKey, ValidatedSshKey};
 // Re-export policy from security primitives
 pub use crate::primitives::security::crypto::{CryptoAuditResult, CryptoPolicy, CryptoThreat};
 
+// Re-export key/algorithm types from identifiers primitives
+pub use crate::primitives::identifiers::crypto::{KeyType, SignatureAlgorithm};
+
 // Re-export shortcuts
 pub use shortcuts::{
     is_safe_signature_algorithm, is_secure_hash, is_strong_key, is_strong_key_strict,

--- a/crates/octarine/src/crypto/validation/shortcuts.rs
+++ b/crates/octarine/src/crypto/validation/shortcuts.rs
@@ -2,16 +2,15 @@
 //!
 //! Convenience functions for common crypto validation operations.
 
-use crate::primitives::identifiers::crypto::{KeyType, SignatureAlgorithm};
-use crate::primitives::security::crypto::CryptoPolicy;
+use super::{CryptoPolicy, KeyType, SignatureAlgorithm};
 use crate::primitives::types::Problem;
 
+#[cfg(feature = "crypto-validation")]
+use super::CryptoAuditResult;
 #[cfg(feature = "crypto-validation")]
 use super::builder::CryptoValidationBuilder;
 #[cfg(feature = "crypto-validation")]
 use super::types::{ValidatedCertificate, ValidatedSshKey, ValidationSummary};
-#[cfg(feature = "crypto-validation")]
-use crate::primitives::security::crypto::CryptoAuditResult;
 
 // ============================================================================
 // Certificate Validation Shortcuts

--- a/crates/octarine/src/primitives/identifiers/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/mod.rs
@@ -133,11 +133,9 @@ pub(crate) use token::TokenIdentifierBuilder;
 #[cfg(feature = "crypto-validation")]
 pub(crate) use crypto::CryptoIdentifierBuilder;
 
-// Re-export crypto types for crate-internal use (feature-gated)
+// Re-export crypto types — pub so L3 can re-export (feature-gated)
 #[cfg(feature = "crypto-validation")]
-pub(crate) use crypto::{
-    CertificateType, CryptoDetectionResult, KeyFormat, KeyType, SignatureAlgorithm,
-};
+pub use crypto::{CertificateType, CryptoDetectionResult, KeyFormat, KeyType, SignatureAlgorithm};
 
 // Re-export TextRedactionPolicy types — pub so L3 can re-export
 pub use biometric::redaction::TextRedactionPolicy as BiometricTextPolicy;

--- a/crates/octarine/src/security/queries/shortcuts.rs
+++ b/crates/octarine/src/security/queries/shortcuts.rs
@@ -3,8 +3,7 @@
 //! Convenience functions for common query security operations.
 //! These wrap the QueryBuilder for simple use cases.
 
-use super::QueryBuilder;
-use crate::primitives::security::queries::QueryThreat;
+use super::{GraphqlAnalysis, QueryBuilder, QueryThreat, QueryType};
 use crate::primitives::types::Problem;
 
 // ============================================================================
@@ -167,7 +166,7 @@ pub fn detect_graphql_threats(query: &str) -> Vec<QueryThreat> {
 /// Returns detailed analysis including depth, alias count, field count,
 /// and detected threats.
 #[must_use]
-pub fn analyze_graphql_query(query: &str) -> crate::primitives::security::queries::GraphqlAnalysis {
+pub fn analyze_graphql_query(query: &str) -> GraphqlAnalysis {
     QueryBuilder::new().analyze_graphql_query(query)
 }
 
@@ -179,10 +178,7 @@ pub fn analyze_graphql_query(query: &str) -> crate::primitives::security::querie
 ///
 /// Use this when you need to handle multiple query types dynamically.
 #[must_use]
-pub fn detect_threats(
-    input: &str,
-    query_type: crate::primitives::security::queries::QueryType,
-) -> Vec<QueryThreat> {
+pub fn detect_threats(input: &str, query_type: QueryType) -> Vec<QueryThreat> {
     QueryBuilder::new().detect_threats(input, query_type)
 }
 
@@ -190,10 +186,7 @@ pub fn detect_threats(
 ///
 /// Use this when you need to handle multiple query types dynamically.
 #[must_use]
-pub fn is_injection_present(
-    input: &str,
-    query_type: crate::primitives::security::queries::QueryType,
-) -> bool {
+pub fn is_injection_present(input: &str, query_type: QueryType) -> bool {
     QueryBuilder::new().is_injection_present(input, query_type)
 }
 
@@ -243,8 +236,6 @@ mod tests {
 
     #[test]
     fn test_generic_shortcuts() {
-        use crate::primitives::security::queries::QueryType;
-
         // Test is_injection_present with different query types
         assert!(is_injection_present("' OR 1=1 --", QueryType::Sql));
         assert!(is_injection_present("$gt", QueryType::NoSql));


### PR DESCRIPTION
## Summary

- Layer 3 shortcuts in `security/queries` and `crypto/validation` referenced `crate::primitives::...` types directly in their public function signatures, forcing external callers to reach into the primitives namespace.
- Each Layer 3 module now owns its public type surface via `pub use` re-exports — matching the existing pattern for `CryptoAuditResult`/`CryptoPolicy`/`CryptoThreat` and the biometric types.
- Promoted the crypto-types aggregator in `primitives/identifiers/mod.rs` from `pub(crate) use` to `pub use` so L3 can re-export. This does **not** widen the external API surface — `primitives` is `pub(crate)` at the crate root, so the visibility change is crate-internal only. Mirrors the biometric-types aggregator in the same file.

## Files changed

- `crates/octarine/src/security/queries/shortcuts.rs` — 3 signatures + imports + 1 test import switched to `super::`
- `crates/octarine/src/crypto/validation/mod.rs` — added `pub use crate::primitives::identifiers::crypto::{KeyType, SignatureAlgorithm};`
- `crates/octarine/src/crypto/validation/shortcuts.rs` — imports rewritten to `super::`
- `crates/octarine/src/primitives/identifiers/mod.rs` — `pub(crate) use` → `pub use` for crypto types

The only `crate::primitives::...` import remaining in either shortcuts file is `Problem` (canonical error type in `primitives::types`, used as such throughout Layer 3 — not part of the leak).

## Test plan

- [x] `just preflight` — fmt + clippy (no warnings, `-D warnings`) + arch-check + tests
- [x] All 6481+ tests pass
- [x] `arch-check` confirms no `type-visibility` violations remain
- [x] No behavior changes — pure path-cleanup refactor; existing tests cover all affected functions
- [x] `grep -n "crate::primitives" {security/queries,crypto/validation}/shortcuts.rs` — only `Problem` remains

Closes #171