### PR TITLE
fix(pii-sync): scan_network detects PiiType::Hostname and Port

### DIFF
--- a/crates/octarine/src/identifiers/builder/network.rs
+++ b/crates/octarine/src/identifiers/builder/network.rs
@@ -216,6 +216,21 @@ impl NetworkBuilder {
         self.inner.find_urls_in_text(text)
     }
 
+    /// Find all hostname-like tokens in text
+    ///
+    /// Conservative filter skips plain English words (requires hyphen, digit,
+    /// or `:port` suffix). Confidence: Low.
+    #[must_use]
+    pub fn find_hostnames_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        self.inner.find_hostnames_in_text(text)
+    }
+
+    /// Find all port tokens (`:N`) in text
+    #[must_use]
+    pub fn find_ports_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        self.inner.find_ports_in_text(text)
+    }
+
     /// Find all API keys in text
     #[must_use]
     pub fn find_api_keys_in_text(&self, text: &str) -> Vec<IdentifierMatch> {

--- a/crates/octarine/src/identifiers/shortcuts/network.rs
+++ b/crates/octarine/src/identifiers/shortcuts/network.rs
@@ -85,6 +85,20 @@ pub fn is_hostname(value: &str) -> bool {
     NetworkBuilder::new().is_hostname(value)
 }
 
+/// Find all hostname-like tokens in text
+///
+/// Conservative filter skips plain English words.
+#[must_use]
+pub fn find_hostnames(text: &str) -> Vec<IdentifierMatch> {
+    NetworkBuilder::new().find_hostnames_in_text(text)
+}
+
+/// Find all port tokens (`:N`) in text
+#[must_use]
+pub fn find_ports(text: &str) -> Vec<IdentifierMatch> {
+    NetworkBuilder::new().find_ports_in_text(text)
+}
+
 // ============================================================
 // UUID SHORTCUTS
 // ============================================================

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -210,7 +210,7 @@ pub(super) fn scan_organizational(text: &str, pii_types: &mut Vec<PiiType>) {
     }
 }
 
-/// Scan for network identifiers (IP, MAC, UUID, URL)
+/// Scan for network identifiers (IP, MAC, UUID, URL, domain, hostname, port)
 pub(super) fn scan_network(text: &str, pii_types: &mut Vec<PiiType>) {
     let network = NetworkIdentifierBuilder::new();
 
@@ -230,6 +230,16 @@ pub(super) fn scan_network(text: &str, pii_types: &mut Vec<PiiType>) {
         if !network.find_domains_in_text(text).is_empty() {
             pii_types.push(PiiType::Domain);
         }
+    }
+
+    // Hostname and Port are checked unconditionally: their regex patterns are
+    // not part of `is_network_present`'s aggregate, so the guard above would
+    // skip text containing only a hostname or port.
+    if !network.find_hostnames_in_text(text).is_empty() {
+        pii_types.push(PiiType::Hostname);
+    }
+    if !network.find_ports_in_text(text).is_empty() {
+        pii_types.push(PiiType::Port);
     }
 }
 
@@ -404,7 +414,10 @@ pub(super) fn is_pii_present_with_config_impl(text: &str, config: &PiiScannerCon
     // Network domain
     if config.scan_network {
         let network = NetworkIdentifierBuilder::new();
-        if network.is_network_present(text) {
+        if network.is_network_present(text)
+            || !network.find_hostnames_in_text(text).is_empty()
+            || !network.find_ports_in_text(text).is_empty()
+        {
             return true;
         }
     }

--- a/crates/octarine/src/primitives/identifiers/network/builder/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/network/builder/detection.rs
@@ -236,6 +236,21 @@ impl NetworkIdentifierBuilder {
         detection::find_domains_in_text(text)
     }
 
+    /// Find all hostname-like tokens in text
+    ///
+    /// Conservative filter skips plain English words (requires hyphen, digit,
+    /// or `:port` suffix). Confidence: Low.
+    #[must_use]
+    pub fn find_hostnames_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_hostnames_in_text(text)
+    }
+
+    /// Find all port tokens (`:N`) in text
+    #[must_use]
+    pub fn find_ports_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_ports_in_text(text)
+    }
+
     /// Find all URLs in text
     #[must_use]
     pub fn find_urls_in_text(&self, text: &str) -> Vec<IdentifierMatch> {

--- a/crates/octarine/src/primitives/identifiers/network/detection/domain.rs
+++ b/crates/octarine/src/primitives/identifiers/network/detection/domain.rs
@@ -76,6 +76,62 @@ pub fn find_domains_in_text(text: &str) -> Vec<IdentifierMatch> {
     deduplicate_matches(matches)
 }
 
+/// Conservative filter: HOSTNAME regex matches any single word, so require
+/// a hyphen, an ASCII digit, or a `:port` suffix to avoid flagging plain
+/// English. Trade-off: bare `localhost` is filtered; `localhost:8080` passes.
+fn is_likely_real_hostname(matched: &str) -> bool {
+    matched.contains('-') || matched.chars().any(|c| c.is_ascii_digit()) || matched.contains(':')
+}
+
+/// Find all hostname-like tokens in text
+///
+/// Filters plain English words via a conservative rule. Detection-only;
+/// validation is out of scope.
+#[must_use]
+pub fn find_hostnames_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+    for capture in patterns::network::HOSTNAME.captures_iter(text) {
+        let full_match = get_full_match(&capture);
+        let matched_text = full_match.as_str();
+        if !is_likely_real_hostname(matched_text) {
+            continue;
+        }
+        matches.push(IdentifierMatch::new(
+            full_match.start(),
+            full_match.end(),
+            matched_text.to_string(),
+            IdentifierType::Hostname,
+            DetectionConfidence::Low,
+        ));
+    }
+    deduplicate_matches(matches)
+}
+
+/// Find all port tokens (`:N`) in text
+#[must_use]
+pub fn find_ports_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+    for capture in patterns::network::PORT.captures_iter(text) {
+        let full_match = get_full_match(&capture);
+        matches.push(IdentifierMatch::new(
+            full_match.start(),
+            full_match.end(),
+            full_match.as_str().to_string(),
+            IdentifierType::Port,
+            DetectionConfidence::Medium,
+        ));
+    }
+    deduplicate_matches(matches)
+}
+
 // ============================================================================
 // Test Data Detection
 // ============================================================================
@@ -280,5 +336,58 @@ mod tests {
         // Regular hostnames - NOT test
         assert!(!is_test_hostname("production-db"));
         assert!(!is_test_hostname("web-server"));
+    }
+
+    #[test]
+    fn test_find_hostnames_in_text_filters_english_words() {
+        let matches = find_hostnames_in_text("Hello there, this is the server.");
+        assert!(
+            matches.is_empty(),
+            "expected zero hostnames in plain English, got {matches:?}"
+        );
+    }
+
+    #[test]
+    fn test_find_hostnames_in_text_detects_real_hostnames() {
+        let matches = find_hostnames_in_text("server1 my-db-prod cache:8080");
+        let values: Vec<&str> = matches.iter().map(|m| m.matched_text.as_str()).collect();
+        assert!(values.contains(&"server1"), "missing server1 in {values:?}");
+        assert!(
+            values.contains(&"my-db-prod"),
+            "missing my-db-prod in {values:?}"
+        );
+        assert!(
+            values.iter().any(|v| v.starts_with("cache")),
+            "missing cache:8080 in {values:?}"
+        );
+        assert!(
+            matches
+                .iter()
+                .all(|m| m.identifier_type == IdentifierType::Hostname)
+        );
+    }
+
+    #[test]
+    fn test_find_hostnames_in_text_localhost_alone_filtered() {
+        // Bare `localhost` (no digit/hyphen/colon) — filtered. Trade-off for
+        // the conservative rule. `localhost:8080` still passes.
+        assert!(find_hostnames_in_text("localhost").is_empty());
+        assert!(!find_hostnames_in_text("localhost:8080").is_empty());
+    }
+
+    #[test]
+    fn test_find_ports_in_text() {
+        let matches = find_ports_in_text("Connect to :8080 or :443 for HTTPS.");
+        assert_eq!(matches.len(), 2);
+        assert!(
+            matches
+                .iter()
+                .all(|m| m.identifier_type == IdentifierType::Port)
+        );
+    }
+
+    #[test]
+    fn test_find_ports_in_text_empty() {
+        assert!(find_ports_in_text("no ports here").is_empty());
     }
 }

--- a/crates/octarine/src/primitives/identifiers/network/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/network/detection/mod.rs
@@ -59,7 +59,8 @@ pub use common::{
 
 // Domain, hostname, port
 pub use domain::{
-    find_domains_in_text, is_domain, is_hostname, is_port, is_test_domain, is_test_hostname,
+    find_domains_in_text, find_hostnames_in_text, find_ports_in_text, is_domain, is_hostname,
+    is_port, is_test_domain, is_test_hostname,
 };
 
 // IP addresses

--- a/crates/octarine/tests/observe/pii_pipeline.rs
+++ b/crates/octarine/tests/observe/pii_pipeline.rs
@@ -399,3 +399,23 @@ fn test_multiple_emails_all_redacted() {
     // Both should be replaced with [EMAIL]
     assert_eq!(redacted.matches("[EMAIL]").count(), 2);
 }
+
+#[test]
+fn test_detects_hostname_in_scan() {
+    let text = "Deploy to db-prod-01 and verify cache:8080 is healthy.";
+    let types = scan_for_pii(text);
+    assert!(
+        types.contains(&PiiType::Hostname),
+        "expected PiiType::Hostname in {types:?}",
+    );
+}
+
+#[test]
+fn test_detects_port_in_scan() {
+    let text = "Service listens on :8080 and :443.";
+    let types = scan_for_pii(text);
+    assert!(
+        types.contains(&PiiType::Port),
+        "expected PiiType::Port in {types:?}",
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `find_hostnames_in_text` and `find_ports_in_text` through L1 → L3 (detection, primitive builder, public builder, shortcuts).
- Wires both into `scan_network` so `PiiType::Hostname` and `PiiType::Port` are actually produced. Closes the audit gap from `audit/octarine-pii-sync`.
- Extends `is_pii_present_with_config_impl` so text containing only a hostname or port is recognised — `patterns::network::all()` doesn't include the HOSTNAME/PORT regexes, so the new checks must run outside the existing `is_network_present` guard.
- Hostname scanning uses a **conservative filter** — matched text must contain a hyphen, an ASCII digit, or `:` (port suffix) — to avoid flagging plain English words like `Hello` or `Server`. Trade-off: bare `localhost` is filtered; `localhost:8080` still passes. Confidence: `Hostname=Low`, `Port=Medium`.

## Test plan

- [x] 5 new unit tests in `primitives/identifiers/network/detection/domain.rs` covering: English-word filter, real-hostname detection, `localhost` edge case, port detection, empty input.
- [x] 2 new integration tests in `tests/observe/pii_pipeline.rs` confirming `scan_for_pii` produces `PiiType::Hostname` and `PiiType::Port`.
- [x] `just preflight` (fmt + clippy `-D warnings` + arch-check + full workspace tests) — 6486 unit tests + 234 integration tests + doctests, all green.

## Pre-review findings

- 3x `missing-test-file` (false positives — octarine convention is inline `#[cfg(test)] mod tests`; `mod.rs` is re-exports only).

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)