### PR TITLE
feat(release): add `just release <type>` keyword bumps, skill, and docs

### DIFF
--- a/.claude/skills/octarine-release/SKILL.md
+++ b/.claude/skills/octarine-release/SKILL.md
@@ -1,0 +1,157 @@
+---
+description: Octarine release process — semantic versioning policy, bump-type rules, and `just release` usage. Use when cutting a release, picking a version bump (major/minor/patch/beta/rc), or auditing a change to decide whether it requires a breaking-version bump.
+---
+
+# Octarine Release
+
+The release pipeline lives in two places: the `just release` recipe in the
+project root `justfile` (orchestration) and `scripts/release/` (the
+semver state machine that drives bump keywords). This skill is the policy
+half — when to pick which bump type, what counts as a breaking change in a
+security library, and how the alpha → beta → rc → stable lifecycle is
+enforced. See `docs/releases/` for the operator-facing reference.
+
+## Pre-1.0 SemVer Policy
+
+Octarine is on `0.x` and not yet published to crates.io. While we're pre-1.0,
+we follow the [Cargo SemVer convention](https://doc.rust-lang.org/cargo/reference/semver.html)
+for `0.y.z`:
+
+| Version part | Meaning while 0.x | After 1.0 |
+|---|---|---|
+| `0.X.0` (minor) | Breaking change OR new feature | New backwards-compatible feature |
+| `0.X.Y` (patch) | Backwards-compatible change (bugfix, doc, internal) | Bugfix only |
+| `1.0.0` | First stable release | First major bump after stable |
+
+Every breaking change **must** be recorded in `CHANGELOG.md` under the
+release entry, with enough context that downstream callers can adjust.
+
+## Bump Types
+
+| Keyword | Formula | When to use |
+|---|---|---|
+| `patch` | `0.X.Y` → `0.X.(Y+1)`; from prerelease, **finalize** to `0.X.Y` | Bugfix, doc-only change, internal refactor with no public API delta |
+| `minor` | `0.X.Y` → `0.(X+1).0`; from prerelease, **finalize** to `0.X.Y` | New feature OR breaking change while 0.x |
+| `major` | `X.Y.Z` → `(X+1).0.0` (always advances) | Breaking change after 1.0; intentional "we're stable now" 0.x → 1.0 |
+| `beta` | stable → `X.Y.Z-beta.1`; alpha → `X.Y.Z-beta.1`; beta → `beta.(N+1)` | Feature-complete prerelease for downstream testing |
+| `rc` | `X.Y.Z-beta.N` → `X.Y.Z-rc.1`; rc → `rc.(N+1)` | Final validation candidate, no further changes expected |
+
+**Finalize semantics**: from `0.3.0-beta.3`, both `patch` and `minor` produce
+`0.3.0`. The beta becomes the stable release. This avoids skipping the
+stable line entirely (e.g. `0.3.0-beta.3 → 0.3.1` would mean "0.3.0 never
+shipped"). Use `major` or a literal version if you want different behavior.
+
+## Breaking Change Catalog
+
+Octarine's public API surface is **Layer 3**: the eight `pub` modules
+`identifiers/`, `data/`, `security/`, `runtime/`, `crypto/`, `auth/`, `http/`,
+`io/`. Layer 1 (`primitives/`) is `pub(crate)` and Layer 2 (`observe/`) is
+public but its breaking changes also count. See
+`docs/architecture/layer-architecture.md`.
+
+Breaking changes (require minor bump while 0.x, major bump after 1.0):
+
+- Removing or renaming any public function, struct, enum, trait, or module
+  in Layer 2 or Layer 3
+- Adding a required parameter to a public Builder method or shortcut
+- Adding a non-`#[non_exhaustive]` field or variant to a public struct/enum
+- Changing visibility from `pub` to `pub(crate)` (or removing a re-export)
+- Tightening validation defaults (e.g. rejecting a previously-accepted
+  pattern in a `validate_*` function) — even when "more secure"
+- Changing detection semantics so that `is_*` returns `false` for inputs
+  that previously returned `true`, or vice versa, in ways callers depend on
+- Removing a feature flag
+
+**Not breaking** (patch is fine):
+
+- Adding new public API (additive)
+- Adding fields/variants to a `#[non_exhaustive]` type
+- Internal refactors below `pub(crate)`
+- Behavior changes that fix incorrect output (genuine bugfix)
+- Adding a new feature flag (default-off)
+
+When in doubt, run `cargo semver-checks check-release --workspace
+--baseline-rev origin/main` — it catches the structural cases mechanically.
+
+## Beta vs RC Promotion
+
+The state machine enforces a strict forward-only lifecycle:
+
+```
+        beta ───────► rc ───────► (finalize via patch/minor)
+        ▲
+        │
+       alpha                    stable
+```
+
+Errors raised by `python3 -m scripts.release bump`:
+
+- `rc` from stable: requires a prior prerelease (use `beta` first)
+- `beta` from `rc`: regression (would walk backward in the lifecycle)
+- `rc` from `alpha`: must promote `alpha → beta` first
+
+Stable is reached by `patch` or `minor` from any prerelease, never by `rc`
+directly.
+
+## How to Release
+
+Happy path:
+
+```bash
+just release-preview <type>      # Read-only smoke test — proposed version,
+                                 # doc files to rewrite, commits since last tag
+
+just release <type>              # Run preflight-full, bump versions, sweep
+                                 # doc references, generate CHANGELOG, commit,
+                                 # tag
+
+# Review the new CHANGELOG entry — look for the "TODO: review" marker.
+# Amend the commit if curation is needed.
+
+git push && git push --tags
+gh release create vX.Y.Z [--prerelease] --generate-notes
+```
+
+See `docs/releases/checklist.md` for the full step-by-step.
+
+## Common Mistakes
+
+- **`rc` from stable**: nothing to promote. The state machine errors.
+  Cut a beta first.
+- **Forgetting `git push --tags`**: a bare `git push` ships the commit but
+  not the tag, so `gh release create` will fail.
+- **Manually editing `crates/octarine-derive/Cargo.toml`**: the derive crate
+  is intentionally on independent versioning. The release recipe never
+  touches it.
+- **Skipping `release-preview`**: the keyword bumps look obvious until they
+  aren't (e.g. `minor` from a prerelease finalizes — surprising the first
+  time). Preview to confirm.
+- **Mass-editing CHANGELOG entries after tag**: amending the release commit
+  works only before push. After push, follow up with a plain `chore(docs):`
+  commit.
+
+## Verification
+
+- `just release-preview <type>` — read-only; never mutates the tree
+- `just release-test` — pytest matrix for the version state machine
+- `cargo semver-checks check-release --workspace --baseline-rev origin/main`
+  — mechanical breaking-change detection on the public API
+- Throwaway-branch dry run (recommended before adopting a new bump type):
+  on a scratch branch, run `just release patch`, inspect the result, then
+  `git reset --hard <prev-tag> && git tag -d v<new>` to undo
+
+## When to Use
+
+- Cutting any release (literal version or keyword bump)
+- Deciding whether a PR needs a minor or patch bump while 0.x
+- Authoring a CHANGELOG entry (section schema lives in
+  `docs/releases/changelog-format.md`)
+- Reviewing a PR for SemVer compliance — does it tighten validation? add
+  a required parameter? remove a re-export?
+
+## When NOT to Use
+
+- Day-to-day commits (no release context)
+- `octarine-derive` versioning — that crate is independently versioned and
+  not in scope here
+- Publishing to crates.io — not yet automated; track separately

--- a/.claude/skills/octarine-release/metadata.yml
+++ b/.claude/skills/octarine-release/metadata.yml
@@ -1,0 +1,7 @@
+name: octarine-release
+version: "1.0"
+
+labels: []
+required_tools: []
+required_permissions: []
+required_mcps: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,10 @@ from `.claude/skills/` to prevent the most common implementation errors:
 - **`octarine-platform-compat`** — WHEN writing `cfg()` attributes,
   platform-specific code, file permissions, signal handling, or path
   operations targeting Windows, macOS, Linux, or ARM64.
+- **`octarine-release`** — WHEN cutting a release, picking a bump type
+  (major/minor/patch/beta/rc), or auditing a change for SemVer impact.
+  Encodes the pre-1.0 versioning policy and the breaking-change catalog
+  for Layer 3 public APIs.
 
 Seven project-specific audit agents are available in `.claude/agents/` for
 codebase audits: `audit-octarine-layers`, `audit-octarine-visibility`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ public API, so we track SemVer discipline closely.
 
 ### Current status: pre-release (0.x)
 
-The workspace is at `0.3.0-beta.1` and is not yet published to crates.io.
+The workspace is at `v0.3.0-beta.3` and is not yet published to crates.io.
 While we're on `0.x`:
 
 - Breaking public-API changes are **allowed** within minor version bumps.

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-octarine = { git = "https://github.com/joshjhall/octarine", tag = "v0.3.0-beta.1" }
+octarine = { git = "https://github.com/joshjhall/octarine", tag = "v0.3.0-beta.3" }
 ```
 
 Enable only the features you need:
 
 ```toml
 [dependencies]
-octarine = { git = "https://github.com/joshjhall/octarine", tag = "v0.3.0-beta.1", default-features = false, features = ["observe", "security"] }
+octarine = { git = "https://github.com/joshjhall/octarine", tag = "v0.3.0-beta.3", default-features = false, features = ["observe", "security"] }
 ```
 
 ## Feature Flags

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,14 @@ Audit logging and operational observability
 - Audit logging
 - Compliance trails
 
+### 📦 [Releases](./releases/)
+
+Release process, versioning policy, and changelog conventions
+
+- Bump-type decision tree
+- Release checklist
+- CHANGELOG format
+
 ## Quick Start
 
 ```bash

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,35 @@
+# Releases
+
+Release process documentation for octarine.
+
+## Contents
+
+- [`versioning.md`](versioning.md) — How to pick a bump type. Decision tree
+  with worked examples from the project's tag history.
+- [`checklist.md`](checklist.md) — What `just release` does for you and what
+  you do manually before/after. The operator-facing reference.
+- [`changelog-format.md`](changelog-format.md) — Section schema, conventional-
+  commit prefix mapping, and the auto-generate-then-curate workflow.
+
+## Quick reference
+
+```bash
+just release-preview <type>      # Read-only smoke test
+just release <type>              # Real release: preflight, bump, tag
+git push && git push --tags
+gh release create v<X.Y.Z> [--prerelease] --generate-notes
+```
+
+Where `<type>` is one of `major | minor | patch | beta | rc` (computed) or a
+literal version like `0.4.0` or `0.4.0-beta.1`.
+
+## See also
+
+- [`.claude/skills/octarine-release/`](../../.claude/skills/octarine-release/)
+  — The release skill (versioning policy, breaking-change catalog).
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) — SemVer policy summary
+  for contributors.
+- [`../../CHANGELOG.md`](../../CHANGELOG.md) — Release history.
+- [`../architecture/layer-architecture.md`](../architecture/layer-architecture.md)
+  — Defines the public-API surface (Layer 3 modules) used by the breaking-
+  change catalog.

--- a/docs/releases/changelog-format.md
+++ b/docs/releases/changelog-format.md
@@ -1,0 +1,137 @@
+# CHANGELOG Format
+
+Octarine's `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/)
+section conventions, with section names tuned for the project's commit
+prefix taxonomy. The `just release` recipe auto-generates a draft entry from
+git history; the operator curates it before push.
+
+## Entry shape
+
+```markdown
+## [VERSION] - YYYY-MM-DD
+
+<!-- TODO: review and curate before push -->
+
+### Added
+
+- feat(scope): summary (#123)
+
+### Fixed
+
+- fix(scope): summary (#124)
+
+### Changed
+
+- refactor(scope): summary (#125)
+- chore(deps): summary
+
+### Documentation
+
+- docs(scope): summary
+
+### Testing
+
+- test(scope): summary
+
+### Performance
+
+- perf(scope): summary
+
+### CI
+
+- ci: summary
+
+### Build
+
+- build: summary
+
+### Other
+
+- summary  # commits without a recognized prefix
+```
+
+Sections are emitted in the order above and only appear when they have
+content. Within a section, commits stay in the order returned by
+`git log <prev-tag>..HEAD --oneline`.
+
+## Conventional-commit prefix mapping
+
+| Prefix | Section |
+|---|---|
+| `feat` | Added |
+| `fix` | Fixed |
+| `refactor` | Changed |
+| `chore` | Changed |
+| `docs` | Documentation |
+| `test` | Testing |
+| `perf` | Performance |
+| `ci` | CI |
+| `build` | Build |
+| (anything else not matching `release:`) | Other |
+
+`release:` commits (the previous release's own commit) are filtered out so
+they don't appear in the next entry.
+
+## Auto-generate then curate
+
+The recipe writes a section bullet for **every** commit in the range that
+matches a known prefix. This is intentionally over-inclusive — better to
+trim than to miss something. Before `git push`:
+
+1. **Drop noise**: clippy fix-ups, lint sweeps, single-character doc
+   tweaks, internal refactors with no API delta.
+2. **Group**: a feature delivered across N commits should usually be one
+   bullet, not N. Reference the umbrella issue or the final commit.
+3. **Mark breaking changes**: prefix the bullet with `**BREAKING:**` so
+   downstream readers can find them with one grep. Add a brief migration
+   note below if non-obvious.
+4. **Remove the TODO marker**: `<!-- TODO: review and curate before push -->`
+   should not survive into a pushed release.
+
+Example of curated output:
+
+```markdown
+## [0.4.0] - 2026-06-15
+
+### Added
+
+- **BREAKING:** new `IdentifierType::Ein` variant — exhaustive `match`
+  arms over `IdentifierType` must be updated. (#239)
+- New PII scanner for hostnames and ports (#291)
+
+### Changed
+
+- **BREAKING:** rand 0.9 → 0.10 propagates to public API: `RngCore` is
+  now imported as `rand_core::Rng`. Callers using `rand::Rng` directly
+  must switch to `rand::RngExt`. (#277-281)
+
+### Fixed
+
+- URL query strings now redacted in observability logs (#241)
+- Plaintext token buffers zeroized on auth reset (#270)
+```
+
+Compared to the raw auto-generated entry, this:
+- Combined 5 dependabot bumps into a single bullet
+- Added explicit migration notes for the rand 0.10 break
+- Marked the IdentifierType variant as breaking (it is — exhaustive matches)
+- Dropped routine refactor / test / build commits the recipe would otherwise
+  list
+
+## Section order rationale
+
+`Added` first because new features are what most readers look for. `Fixed`
+second because regressions on existing functionality are the next-most
+actionable. `Changed` covers internal refactors plus dependency bumps —
+it's where breaking changes most often land, hence the `**BREAKING:**`
+discipline. `Documentation / Testing / Performance / CI / Build` follow in
+descending caller relevance. `Other` is a fall-through for unconventional
+prefixes; treat it as a signal to amend the prefix mapping if the same
+prefix shows up repeatedly.
+
+## See also
+
+- [`versioning.md`](versioning.md) — how to pick the bump type that
+  goes in the entry header
+- [`checklist.md`](checklist.md) — full release flow including curation step
+- [`../../CHANGELOG.md`](../../CHANGELOG.md) — the actual log

--- a/docs/releases/checklist.md
+++ b/docs/releases/checklist.md
@@ -1,0 +1,138 @@
+# Release Checklist
+
+The `just release` recipe automates most of the release flow. This document
+records what it does for you and what's still manual.
+
+## What `just release <type>` automates
+
+In order:
+
+1. **Resolves the new version** — bump keyword via
+   `python3 -m scripts.release bump <type> --current <current>`, or accepts a
+   literal version like `0.4.0` after parsing it through the same validator.
+2. **Validates workspace member sync** — confirms `crates/octarine/Cargo.toml`
+   either uses `version.workspace = true` or matches the current workspace
+   version. `crates/octarine-derive/Cargo.toml` is intentionally ignored
+   (independent versioning).
+3. **Refuses dirty trees** — exits early if `git status --porcelain` is
+   non-empty so unrelated edits don't get rolled into the release commit.
+4. **Runs `just preflight-full`** — fmt-check, clippy, shellcheck,
+   arch-check, all tests, and perf tests.
+5. **Updates Cargo.toml versions** — root `Cargo.toml`, plus
+   `crates/octarine/Cargo.toml` if it carries a literal version (skipped
+   when `version.workspace = true`).
+6. **Sweeps doc references** — rewrites `vX.Y.Z` → `vNEW` in:
+   - `README.md`
+   - `CONTRIBUTING.md`
+
+   The list is intentionally narrow. Historical references (e.g. "Complete
+   as of vX.Y.Z" in `docs/architecture/refactor-plan.md`) and doctest
+   examples in `crates/octarine/src/**/*.rs` are **not** rewritten — those
+   are statements about a specific past version, not pointers to "current".
+7. **Regenerates `Cargo.lock`** via `cargo check --workspace --quiet`.
+8. **Generates the CHANGELOG entry** — parses conventional-commit prefixes
+   from `git log <prev-tag>..HEAD` into `Added / Fixed / Changed /
+   Documentation / Testing / Performance / CI / Build / Other` sections.
+   Prepends an HTML comment marker `<!-- TODO: review and curate before
+   push -->` so the operator sees it in the diff. See
+   [`changelog-format.md`](changelog-format.md) for the schema.
+9. **Commits as `release: vX.Y.Z`** — staging Cargo.toml, Cargo.lock,
+   CHANGELOG.md, and any of the 5 doc files that changed. Retries once if
+   lefthook reformats.
+10. **Tags `vX.Y.Z`** — annotated tag with message `Release vX.Y.Z`.
+
+## What you do manually
+
+### Before pushing
+
+1. **Review the new CHANGELOG entry**. The auto-generated section is a
+   starting point — it captures *what* changed but not *why* it matters
+   for downstream callers. Curate:
+   - Drop or merge purely-internal commits a downstream caller wouldn't
+     care about (clippy lint sweeps, internal refactors with no API delta)
+   - Group multi-PR features into a single bullet
+   - Annotate breaking changes explicitly with **BREAKING:** prefix
+   - Remove the `<!-- TODO: review and curate before push -->` marker
+2. **Amend** if you curated:
+   ```bash
+   git add CHANGELOG.md
+   git commit --amend --no-edit
+   git tag -d vX.Y.Z && git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   ```
+
+### Push
+
+```bash
+git push                    # commit
+git push --tags             # the annotated tag — easy to forget
+```
+
+A bare `git push` ships the commit but not the tag, so `gh release create`
+will fail with "tag does not exist" until you push tags.
+
+### GitHub release
+
+```bash
+gh release create vX.Y.Z [--prerelease] --generate-notes
+```
+
+Use `--prerelease` for any version with a `-` suffix (alpha/beta/rc).
+`--generate-notes` writes the GitHub release body from the same commit
+range; you can edit it via the web UI afterwards.
+
+## Recommended pre-merge dry run
+
+Before merging changes to the release recipe itself (i.e. this PR), do a
+full dry run on a scratch branch:
+
+```bash
+git checkout -b release-dry-run
+just release patch          # or whichever keyword path you want to exercise
+git log -1                  # confirm release commit
+git tag -l --points-at HEAD # confirm tag
+
+# Undo:
+git reset --hard <prev-tag>
+git tag -d v<new-version>
+git checkout main
+git branch -D release-dry-run
+```
+
+This catches Cargo.lock churn, lefthook surprises, or doc-sweep regex
+issues without polluting the real history.
+
+## Known limitations
+
+These are out of scope for the current release recipe and are tracked as
+future work:
+
+- **Doctest version strings** in `crates/octarine/src/**/*.rs` (e.g.
+  `version = "0.2"` in `crypto/validation/mod.rs`,
+  `observe/tracing/otel.rs`, `testing/mod.rs`) reference major.minor only
+  and don't follow the `vX.Y.Z` pattern the doc sweep handles. They go
+  stale silently. Fix manually until a future Phase rewrites them by
+  pattern.
+- **Historical references** (e.g. `docs/architecture/refactor-plan.md`'s
+  "Complete as of vX.Y.Z" header) are intentionally not rewritten — they're
+  factual statements about when something happened, not "current version"
+  pointers. Edit manually if their meaning changes.
+- **`crates/octarine-derive`** versions independently. Bumping the workspace
+  does not touch it. Coordinate manually if the two crates need a coupled
+  release.
+- **`cargo publish`** to crates.io is not yet automated. Octarine is git-
+  dependency-only at present.
+- **Recipe pause for CHANGELOG curation** — the recipe does not pause
+  between writing the CHANGELOG and tagging. The TODO marker is the prompt
+  to review-and-amend before push, not before tag.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ERROR: Working tree is not clean` | Uncommitted edits | `git stash` or commit first |
+| `ERROR: '<x>' is neither a version nor a bump keyword` | Typo in argument | Use `major\|minor\|patch\|beta\|rc` or a literal `X.Y.Z` |
+| `ERROR: crates/octarine/Cargo.toml version is out of sync` | Member crate drifted | Edit `crates/octarine/Cargo.toml` to match workspace before retrying |
+| `release: Cannot bump rc from stable` | Tried `rc` from a non-prerelease | Cut a beta first: `just release beta` |
+| `release: Cannot bump rc from <alpha>` | Skipping the beta cycle | Promote `alpha → beta` first |
+| Lefthook reformats during commit | Trailing newline / formatting hook | Recipe retries once automatically |
+| `git push --tags` fails with auth | SSH key not loaded | `ssh-add ~/.ssh/<key>` then retry |

--- a/docs/releases/versioning.md
+++ b/docs/releases/versioning.md
@@ -1,0 +1,100 @@
+# Versioning
+
+How to pick a bump type for an octarine release. Octarine is a foundation
+library (security primitives + observability) and tracks SemVer discipline
+closely so downstream callers can update with confidence.
+
+## Pre-1.0 vs post-1.0
+
+Octarine is currently `0.x` and not yet on crates.io. We follow the
+[Cargo SemVer convention for `0.y.z`](https://doc.rust-lang.org/cargo/reference/semver.html):
+
+| Pre-1.0 | Post-1.0 |
+|---|---|
+| **minor** = breaking change OR new feature | minor = backwards-compatible feature only |
+| **patch** = backwards-compatible (bugfix, doc, internal refactor) | patch = bugfix only |
+| **major** = intentional `0.x → 1.0` jump | major = breaking change |
+
+`1.0.0` is the contract: from that point on, breaking changes require a
+major bump. Don't ship `1.0` until the public API is something we're willing
+to support across patch releases.
+
+## Decision tree
+
+```
+1. Does the change alter the public API or default behavior in a way callers
+   could depend on?
+   → YES, see step 2
+   → NO  → patch
+
+2. Is it a removal, rename, signature change, tightened validation, or
+   non-`#[non_exhaustive]` field/variant addition?
+   → YES → minor (pre-1.0) or major (post-1.0)
+   → NO, it's purely additive → minor (new feature; pre-1.0 still bumps minor)
+```
+
+See the breaking-change catalog in
+[`.claude/skills/octarine-release/SKILL.md`](../../.claude/skills/octarine-release/SKILL.md)
+for the full list. When in doubt:
+
+```bash
+cargo semver-checks check-release --workspace --baseline-rev origin/main
+```
+
+This catches the structural cases (signature changes, removed exports)
+mechanically. It cannot detect semantic changes (e.g. validation now rejects
+inputs it previously accepted) — those still require human judgment.
+
+## Bump-type formulas
+
+| Keyword | Stable input | Prerelease input |
+|---|---|---|
+| `patch` | `0.X.Y` → `0.X.(Y+1)` | **finalize** to `0.X.Y` |
+| `minor` | `0.X.Y` → `0.(X+1).0` | **finalize** to `0.X.Y` |
+| `major` | `X.Y.Z` → `(X+1).0.0` | `(X+1).0.0` (always advances) |
+| `beta`  | `X.Y.Z` → `X.Y.Z-beta.1` | `beta.N` → `beta.(N+1)`; `alpha.N` → `beta.1`; `rc.N` → **error** |
+| `rc`    | **error** (requires prior beta) | `beta.N` → `rc.1`; `rc.N` → `rc.(N+1)`; `alpha.N` → **error** |
+
+**Finalize semantics**: when the current version is a prerelease and you
+bump `patch` or `minor`, the result drops the prerelease tag. From
+`0.3.0-beta.3`, both `patch` and `minor` produce `0.3.0` — the beta becomes
+the stable release. This avoids skipping the stable line. If you actually
+want `0.3.1` or `0.4.0` from a prerelease, pass the literal version.
+
+## Worked examples (from this project's history)
+
+| From | Action | Reason | To |
+|---|---|---|---|
+| `v0.2.0` | `beta` | Began the 0.3.0 prerelease cycle | `v0.3.0-beta.1` |
+| `v0.3.0-beta.1` | `beta` | Iterated within beta | `v0.3.0-beta.2` |
+| `v0.3.0-beta.2` | `beta` | Iterated within beta | `v0.3.0-beta.3` |
+| `v0.3.0-beta.3` | `rc` (hypothetical) | Promoted to release candidate | `v0.3.0-rc.1` |
+| `v0.3.0-beta.3` | `patch` (hypothetical) | Finalized the in-progress minor | `v0.3.0` |
+| `v0.3.0` | `minor` (hypothetical) | New breaking change while 0.x | `v0.4.0` |
+| `v0.X.Y` | `major` (eventual) | Public API stabilization | `v1.0.0` |
+
+## When `major` makes sense pre-1.0
+
+Bumping `0.x → 1.0` is a deliberate signal that the API surface is something
+we're committing to. Don't do it just to escape `0.x` etiquette. Go to
+`1.0` when:
+
+- Layer 3 module shape is stable (no planned splits/renames)
+- The naming-conventions enforcement catches all callers
+- We have a real downstream consumer that wants `^1.0` semver guarantees
+
+Until then, `0.X.Y` is the right place to be — it lets us iterate on the
+public API while still being responsible about CHANGELOG entries.
+
+## Pre-1.0 → 1.0 transition
+
+When the time comes:
+
+1. Cut a final beta cycle to flush downstream feedback.
+2. Promote to `rc` once the candidate set is frozen.
+3. Finalize via `just release minor` (or `just release 1.0.0` literally) so
+   the prerelease is dropped.
+4. Audit the CHANGELOG — every breaking change since `0.1.0` should be
+   discoverable from a single read of the file.
+5. Add a CONTRIBUTING note: post-1.0 the rules tighten (minor must be
+   additive only).

--- a/justfile
+++ b/justfile
@@ -148,26 +148,69 @@ test-count:
 
 # ─── Release ────────────────────────────────────────────────────────────────
 
-# Create a release: just release 0.3.0 or just release 0.3.0-beta.1
-release VERSION:
+# Create a release. Accepts either a literal version or a bump keyword:
+#   just release 0.3.0              # literal version
+#   just release 0.3.0-beta.1       # literal prerelease
+#   just release patch              # 0.3.0-beta.3 → 0.3.0 (finalize)
+#   just release minor              # 0.3.0-beta.3 → 0.3.0 (finalize)
+#   just release major              # 0.3.0-beta.3 → 1.0.0
+#   just release beta               # 0.3.0-beta.3 → 0.3.0-beta.4
+#   just release rc                 # 0.3.0-beta.3 → 0.3.0-rc.1
+#
+# Keyword bumps shell out to `python3 -m scripts.release` which owns the
+# semver state machine (alpha → beta → rc → stable). See
+# docs/releases/versioning.md for the full bump policy.
+release ARG:
     #!/usr/bin/env bash
     set -euo pipefail
-    VERSION="{{VERSION}}"
+    ARG="{{ARG}}"
 
-    # Validate semver format (X.Y.Z or X.Y.Z-prerelease.N)
-    if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
-        echo "ERROR: Invalid version '$VERSION'"
-        echo "Expected: X.Y.Z or X.Y.Z-{alpha,beta,rc}.N"
+    # Read the current workspace version from Cargo.toml.
+    CURRENT=$(/usr/bin/awk -F'"' '/^version = /{print $2; exit}' Cargo.toml)
+    if [ -z "$CURRENT" ]; then
+        echo "ERROR: could not read current version from Cargo.toml" >&2
+        exit 1
+    fi
+
+    # Distinguish bump keyword from literal version. Literal versions always
+    # contain a dot; keywords never do.
+    if [[ "$ARG" == *.* ]]; then
+        VERSION="$ARG"
+        # Validate the literal via the same parser the helper uses.
+        if ! python3 -m scripts.release parse "$VERSION" >/dev/null; then
+            exit 1
+        fi
+    else
+        case "$ARG" in
+            major|minor|patch|beta|rc) ;;
+            *)
+                echo "ERROR: '$ARG' is neither a version (X.Y.Z[-pre.N]) nor a bump keyword" >&2
+                echo "       Keywords: major | minor | patch | beta | rc" >&2
+                exit 1
+                ;;
+        esac
+        VERSION=$(python3 -m scripts.release bump "$ARG" --current "$CURRENT")
+    fi
+
+    # Workspace member sync: octarine must inherit the workspace version OR
+    # already match it literally. octarine-derive is intentionally untouched
+    # (independent versioning policy).
+    OCTARINE_LINE=$(/usr/bin/awk '/^version/{print; exit}' crates/octarine/Cargo.toml)
+    if [[ "$OCTARINE_LINE" != *"workspace = true"* ]] \
+       && [[ "$OCTARINE_LINE" != "version = \"$CURRENT\""* ]]; then
+        echo "ERROR: crates/octarine/Cargo.toml version is out of sync with workspace" >&2
+        echo "       workspace: $CURRENT" >&2
+        echo "       crate:     $OCTARINE_LINE" >&2
         exit 1
     fi
 
     # Ensure clean working tree
     if [ -n "$(git status --porcelain)" ]; then
-        echo "ERROR: Working tree is not clean. Commit or stash changes first."
+        echo "ERROR: Working tree is not clean. Commit or stash changes first." >&2
         exit 1
     fi
 
-    echo "═══ Releasing v$VERSION ═══"
+    echo "═══ Releasing v$VERSION (from v$CURRENT) ═══"
     echo ""
 
     # Run full pre-flight validation
@@ -181,9 +224,29 @@ release VERSION:
     # Update version in workspace and crate Cargo.toml
     echo "── Updating versions ──"
     sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
-    sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/octarine/Cargo.toml
+    if [[ "$OCTARINE_LINE" != *"workspace = true"* ]]; then
+        sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/octarine/Cargo.toml
+        echo "  crates/octarine/Cargo.toml → $VERSION"
+    fi
     echo "  Cargo.toml → $VERSION"
-    echo "  crates/octarine/Cargo.toml → $VERSION"
+
+    # Sweep version references in human-readable docs. The list is
+    # intentionally explicit and limited to live "current version" callouts —
+    # historical references (e.g. "Complete as of vX.Y.Z" in
+    # docs/architecture/refactor-plan.md) must not be auto-rewritten.
+    # Doctest examples in src/**/*.rs reference major.minor only
+    # (e.g. version = "0.2") and are out of scope here.
+    echo "── Updating doc version references ──"
+    DOC_FILES=(
+        README.md
+        CONTRIBUTING.md
+    )
+    for f in "${DOC_FILES[@]}"; do
+        if [ -f "$f" ] && grep -q "v$CURRENT" "$f"; then
+            sed -i "s|v$CURRENT|v$VERSION|g" "$f"
+            echo "  $f"
+        fi
+    done
 
     # Regenerate lockfile
     cargo check --workspace --quiet 2>/dev/null
@@ -191,7 +254,7 @@ release VERSION:
     # Generate changelog entry
     echo "── Generating changelog ──"
     DATE=$(date +%Y-%m-%d)
-    ENTRY="## [$VERSION] - $DATE"$'\n'
+    ENTRY="## [$VERSION] - $DATE"$'\n'$'\n'"<!-- TODO: review and curate before push -->"$'\n'
 
     if [ -n "$PREV_TAG" ]; then
         # Conventional-commit prefix → CHANGELOG section. Multiple prefixes can
@@ -258,9 +321,15 @@ release VERSION:
     # commit fails because hooks modified files, re-stage and retry once.
     echo "── Committing ──"
     git add Cargo.toml crates/octarine/Cargo.toml Cargo.lock CHANGELOG.md
+    for f in "${DOC_FILES[@]}"; do
+        if [ -f "$f" ]; then git add "$f"; fi
+    done
     if ! git commit -m "release: v$VERSION"; then
         echo "  Lefthook hooks modified files, retrying..."
         git add Cargo.toml crates/octarine/Cargo.toml Cargo.lock CHANGELOG.md
+        for f in "${DOC_FILES[@]}"; do
+            if [ -f "$f" ]; then git add "$f"; fi
+        done
         git commit -m "release: v$VERSION"
     fi
     git tag -a "v$VERSION" -m "Release v$VERSION"
@@ -275,6 +344,62 @@ release VERSION:
     echo ""
     echo "═══ Release v$VERSION ready ═══"
     echo ""
+    echo "Review the new CHANGELOG entry (look for the 'TODO: review' marker)"
+    echo "and amend the commit if needed before pushing."
+    echo ""
     echo "Next steps:"
     echo "  git push && git push --tags"
     echo "  gh release create v$VERSION$PRERELEASE_FLAG --generate-notes"
+
+# Preview a release without touching disk. Prints the proposed version, the
+# doc files that would be rewritten, and a snapshot of commits since the last
+# tag. Use this to smoke-test bump keywords before running the real release.
+release-preview ARG:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ARG="{{ARG}}"
+
+    CURRENT=$(/usr/bin/awk -F'"' '/^version = /{print $2; exit}' Cargo.toml)
+    if [[ "$ARG" == *.* ]]; then
+        VERSION="$ARG"
+        if ! python3 -m scripts.release parse "$VERSION" >/dev/null; then
+            exit 1
+        fi
+    else
+        case "$ARG" in
+            major|minor|patch|beta|rc) ;;
+            *)
+                echo "ERROR: '$ARG' is neither a version nor a bump keyword" >&2
+                exit 1
+                ;;
+        esac
+        VERSION=$(python3 -m scripts.release bump "$ARG" --current "$CURRENT")
+    fi
+
+    PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+    echo "Current: v$CURRENT"
+    echo "New:     v$VERSION"
+    echo ""
+    echo "Doc files that would be rewritten (v$CURRENT → v$VERSION):"
+    DOC_FILES=(
+        README.md
+        CONTRIBUTING.md
+    )
+    for f in "${DOC_FILES[@]}"; do
+        if [ -f "$f" ] && grep -q "v$CURRENT" "$f"; then
+            count=$(grep -c "v$CURRENT" "$f")
+            echo "  $f  ($count occurrence(s))"
+        fi
+    done
+    echo ""
+    if [ -n "$PREV_TAG" ]; then
+        echo "Commits since $PREV_TAG:"
+        git log "$PREV_TAG"..HEAD --oneline | head -20
+    else
+        echo "No prior tag — this would be the initial release."
+    fi
+
+# Run the pytest suite for the release helper.
+release-test:
+    python3 -m pytest tests/release/ -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ dev = ["pytest>=7"]
 packages = []
 
 [tool.pytest.ini_options]
-testpaths = ["tests/arch_check"]
+testpaths = ["tests/arch_check", "tests/release"]

--- a/scripts/release/__main__.py
+++ b/scripts/release/__main__.py
@@ -1,0 +1,4 @@
+from scripts.release.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/cli.py
+++ b/scripts/release/cli.py
@@ -1,0 +1,75 @@
+"""CLI for the release helper.
+
+Two subcommands:
+
+- `bump <kind> --current X.Y.Z` — print the computed next version to stdout.
+  The `release` justfile recipe captures this with `$(...)` to drive
+  Cargo.toml updates.
+- `parse X.Y.Z` — validate a version string; exits 0 on success, non-zero
+  with a message on failure. Used by `release` for literal-version input.
+
+All errors print to stderr and exit non-zero, so failures are visible in the
+recipe output without polluting the captured stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+from scripts.release.version import VersionError, bump, parse
+
+BUMP_KINDS = ("major", "minor", "patch", "beta", "rc")
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="release",
+        description="Compute and validate octarine release versions.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    bump_p = sub.add_parser(
+        "bump",
+        help="Compute the next version from a bump kind and current version.",
+    )
+    bump_p.add_argument("kind", choices=BUMP_KINDS, help="Bump kind.")
+    bump_p.add_argument(
+        "--current",
+        required=True,
+        help="Current version (X.Y.Z or X.Y.Z-{alpha,beta,rc}.N).",
+    )
+
+    parse_p = sub.add_parser(
+        "parse",
+        help="Validate a version string. Prints the canonical form on success.",
+    )
+    parse_p.add_argument("version", help="Version string to validate.")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+
+    try:
+        if args.command == "bump":
+            current = parse(args.current)
+            new = bump(current, args.kind)
+            print(new.format())
+            return 0
+        if args.command == "parse":
+            v = parse(args.version)
+            print(v.format())
+            return 0
+    except VersionError as e:
+        print(f"release: {e}", file=sys.stderr)
+        return 1
+
+    print(f"release: unknown command {args.command!r}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/version.py
+++ b/scripts/release/version.py
@@ -1,0 +1,155 @@
+"""Semantic versioning state machine for octarine releases.
+
+Holds the pure version-arithmetic that powers `just release <type>`. Keeping
+this in Python (rather than inline bash + sed) gives us a tested,
+auditable transition table for the alpha → beta → rc → stable lifecycle.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+PrereleaseKind = Literal["alpha", "beta", "rc"]
+BumpKind = Literal["major", "minor", "patch", "beta", "rc"]
+
+# X.Y.Z or X.Y.Z-{alpha|beta|rc}.N — matches the format the existing
+# `release` recipe accepts.
+_VERSION_RE = re.compile(
+    r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+    r"(?:-(?P<kind>alpha|beta|rc)\.(?P<n>\d+))?$"
+)
+
+
+class VersionError(ValueError):
+    """Raised when a version string or bump operation is invalid."""
+
+
+@dataclass(frozen=True)
+class Prerelease:
+    kind: PrereleaseKind
+    n: int
+
+
+@dataclass(frozen=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+    prerelease: Prerelease | None = None
+
+    def format(self) -> str:
+        base = f"{self.major}.{self.minor}.{self.patch}"
+        if self.prerelease is None:
+            return base
+        return f"{base}-{self.prerelease.kind}.{self.prerelease.n}"
+
+
+def parse(s: str) -> Version:
+    """Parse a version string into a `Version`.
+
+    Raises `VersionError` on anything that doesn't match
+    `X.Y.Z` or `X.Y.Z-{alpha|beta|rc}.N`.
+    """
+    m = _VERSION_RE.match(s)
+    if m is None:
+        raise VersionError(
+            f"Invalid version {s!r}: expected X.Y.Z or X.Y.Z-{{alpha,beta,rc}}.N"
+        )
+    pre: Prerelease | None = None
+    if m.group("kind") is not None:
+        pre = Prerelease(kind=m.group("kind"), n=int(m.group("n")))
+    return Version(
+        major=int(m.group("major")),
+        minor=int(m.group("minor")),
+        patch=int(m.group("patch")),
+        prerelease=pre,
+    )
+
+
+def bump(v: Version, kind: BumpKind) -> Version:
+    """Compute the next version given a bump kind.
+
+    Octarine's release lifecycle (pre-1.0):
+    - `patch` / `minor` from a prerelease finalize the in-progress version
+      (e.g. 0.3.0-beta.3 + patch → 0.3.0). On a stable input, they advance
+      normally.
+    - `major` always advances and resets minor/patch/prerelease.
+    - `beta` initializes from stable or alpha, increments from beta. Going
+      from rc back to beta is a regression (raises VersionError).
+    - `rc` requires a prior beta; promotes beta → rc.1 or increments rc.
+      rc-from-stable and alpha→rc are errors (callers must promote
+      alpha→beta first).
+    """
+    if kind == "major":
+        return Version(major=v.major + 1, minor=0, patch=0, prerelease=None)
+
+    if kind == "minor":
+        if v.prerelease is None:
+            return Version(major=v.major, minor=v.minor + 1, patch=0, prerelease=None)
+        # Finalize the in-progress minor: drop the prerelease tag.
+        return Version(major=v.major, minor=v.minor, patch=v.patch, prerelease=None)
+
+    if kind == "patch":
+        if v.prerelease is None:
+            return Version(
+                major=v.major, minor=v.minor, patch=v.patch + 1, prerelease=None
+            )
+        return Version(major=v.major, minor=v.minor, patch=v.patch, prerelease=None)
+
+    if kind == "beta":
+        if v.prerelease is None:
+            return Version(
+                major=v.major,
+                minor=v.minor,
+                patch=v.patch,
+                prerelease=Prerelease("beta", 1),
+            )
+        if v.prerelease.kind == "alpha":
+            return Version(
+                major=v.major,
+                minor=v.minor,
+                patch=v.patch,
+                prerelease=Prerelease("beta", 1),
+            )
+        if v.prerelease.kind == "beta":
+            return Version(
+                major=v.major,
+                minor=v.minor,
+                patch=v.patch,
+                prerelease=Prerelease("beta", v.prerelease.n + 1),
+            )
+        # rc → beta would step backward in the lifecycle.
+        raise VersionError(
+            f"Cannot bump beta from {v.format()}: "
+            "promoting rc back to beta is a regression"
+        )
+
+    if kind == "rc":
+        if v.prerelease is None:
+            raise VersionError(
+                f"Cannot bump rc from stable {v.format()}: "
+                "rc requires a prior prerelease (use 'beta' first)"
+            )
+        if v.prerelease.kind == "beta":
+            return Version(
+                major=v.major,
+                minor=v.minor,
+                patch=v.patch,
+                prerelease=Prerelease("rc", 1),
+            )
+        if v.prerelease.kind == "rc":
+            return Version(
+                major=v.major,
+                minor=v.minor,
+                patch=v.patch,
+                prerelease=Prerelease("rc", v.prerelease.n + 1),
+            )
+        # alpha → rc would skip the beta cycle.
+        raise VersionError(
+            f"Cannot bump rc from {v.format()}: "
+            "promote alpha → beta first"
+        )
+
+    raise VersionError(f"Unknown bump kind: {kind!r}")

--- a/tests/release/conftest.py
+++ b/tests/release/conftest.py
@@ -1,0 +1,12 @@
+"""Shared fixtures for release helper tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make the repo root importable so `import scripts.release.*` works whether
+# pytest is invoked from the repo root or any subdirectory.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/release/test_cli.py
+++ b/tests/release/test_cli.py
@@ -1,0 +1,68 @@
+"""Tests for the release CLI."""
+
+from __future__ import annotations
+
+import io
+import sys
+from typing import Sequence
+
+import pytest
+
+from scripts.release.cli import main
+
+
+def _run(argv: Sequence[str], capsys: pytest.CaptureFixture[str]) -> tuple[int, str, str]:
+    rc = main(list(argv))
+    captured = capsys.readouterr()
+    return rc, captured.out.strip(), captured.err.strip()
+
+
+def test_bump_prints_new_version(capsys: pytest.CaptureFixture[str]) -> None:
+    rc, out, err = _run(["bump", "patch", "--current", "0.2.0"], capsys)
+    assert rc == 0
+    assert out == "0.2.1"
+    assert err == ""
+
+
+def test_bump_finalizes_prerelease(capsys: pytest.CaptureFixture[str]) -> None:
+    rc, out, _ = _run(["bump", "patch", "--current", "0.3.0-beta.3"], capsys)
+    assert rc == 0
+    assert out == "0.3.0"
+
+
+def test_bump_beta_increment(capsys: pytest.CaptureFixture[str]) -> None:
+    rc, out, _ = _run(["bump", "beta", "--current", "0.3.0-beta.3"], capsys)
+    assert rc == 0
+    assert out == "0.3.0-beta.4"
+
+
+def test_bump_rc_from_stable_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    rc, out, err = _run(["bump", "rc", "--current", "0.3.0"], capsys)
+    assert rc == 1
+    assert out == ""
+    assert "requires a prior prerelease" in err
+
+
+def test_bump_rejects_invalid_current(capsys: pytest.CaptureFixture[str]) -> None:
+    rc, out, err = _run(["bump", "patch", "--current", "not.a.version"], capsys)
+    assert rc == 1
+    assert out == ""
+    assert "Invalid version" in err
+
+
+def test_parse_validates_well_formed(capsys: pytest.CaptureFixture[str]) -> None:
+    rc, out, _ = _run(["parse", "0.3.0-beta.1"], capsys)
+    assert rc == 0
+    assert out == "0.3.0-beta.1"
+
+
+def test_parse_rejects_malformed(capsys: pytest.CaptureFixture[str]) -> None:
+    rc, out, err = _run(["parse", "v0.2.0"], capsys)
+    assert rc == 1
+    assert "Invalid version" in err
+
+
+def test_unknown_subcommand_exits_nonzero(capsys: pytest.CaptureFixture[str]) -> None:
+    # argparse handles this — `required=True` on the subcommand should reject.
+    with pytest.raises(SystemExit):
+        main([])

--- a/tests/release/test_version.py
+++ b/tests/release/test_version.py
@@ -1,0 +1,179 @@
+"""Tests for the version state machine."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.release.version import Prerelease, Version, VersionError, bump, parse
+
+
+# ─── parse / format round-trip ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "s",
+    [
+        "0.0.0",
+        "0.2.0",
+        "1.0.0",
+        "0.3.0-alpha.1",
+        "0.3.0-beta.1",
+        "0.3.0-beta.42",
+        "0.3.0-rc.1",
+        "10.20.30-beta.7",
+    ],
+)
+def test_parse_format_roundtrip(s: str) -> None:
+    assert parse(s).format() == s
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "v0.2.0",
+        "0.2",
+        "0.2.0.0",
+        "0.2.0-",
+        "0.2.0-beta",
+        "0.2.0-beta.x",
+        "0.2.0-rc.0.1",
+        "0.2.0-snapshot.1",
+        "0.2.0+build.1",  # build metadata not supported
+    ],
+)
+def test_parse_rejects_malformed(bad: str) -> None:
+    with pytest.raises(VersionError):
+        parse(bad)
+
+
+# ─── stable → all 5 bump kinds ──────────────────────────────────────────────
+
+
+def test_bump_patch_from_stable() -> None:
+    assert bump(parse("0.2.0"), "patch").format() == "0.2.1"
+
+
+def test_bump_minor_from_stable() -> None:
+    assert bump(parse("0.2.0"), "minor").format() == "0.3.0"
+
+
+def test_bump_minor_from_stable_resets_patch() -> None:
+    assert bump(parse("0.2.5"), "minor").format() == "0.3.0"
+
+
+def test_bump_major_from_stable() -> None:
+    assert bump(parse("0.3.0"), "major").format() == "1.0.0"
+
+
+def test_bump_major_resets_minor_and_patch() -> None:
+    assert bump(parse("1.4.7"), "major").format() == "2.0.0"
+
+
+def test_bump_beta_from_stable_initializes_at_1() -> None:
+    assert bump(parse("0.3.0"), "beta").format() == "0.3.0-beta.1"
+
+
+def test_bump_rc_from_stable_is_error() -> None:
+    with pytest.raises(VersionError, match="requires a prior prerelease"):
+        bump(parse("0.3.0"), "rc")
+
+
+# ─── prerelease finalize on patch / minor ───────────────────────────────────
+
+
+def test_bump_patch_from_prerelease_finalizes() -> None:
+    assert bump(parse("0.3.0-beta.3"), "patch").format() == "0.3.0"
+
+
+def test_bump_minor_from_prerelease_finalizes() -> None:
+    assert bump(parse("0.3.0-beta.3"), "minor").format() == "0.3.0"
+
+
+def test_bump_patch_from_rc_finalizes() -> None:
+    assert bump(parse("0.3.0-rc.2"), "patch").format() == "0.3.0"
+
+
+def test_bump_minor_from_alpha_finalizes() -> None:
+    assert bump(parse("0.4.0-alpha.5"), "minor").format() == "0.4.0"
+
+
+def test_bump_major_from_prerelease_advances() -> None:
+    # Major always advances regardless of prerelease state.
+    assert bump(parse("0.3.0-beta.3"), "major").format() == "1.0.0"
+
+
+# ─── beta state machine ─────────────────────────────────────────────────────
+
+
+def test_bump_beta_increments() -> None:
+    assert bump(parse("0.3.0-beta.3"), "beta").format() == "0.3.0-beta.4"
+
+
+def test_bump_beta_from_alpha_resets_to_1() -> None:
+    # Promoting alpha → beta starts the beta count fresh.
+    assert bump(parse("0.3.0-alpha.7"), "beta").format() == "0.3.0-beta.1"
+
+
+def test_bump_beta_from_rc_is_error() -> None:
+    with pytest.raises(VersionError, match="regression"):
+        bump(parse("0.3.0-rc.1"), "beta")
+
+
+# ─── rc state machine ───────────────────────────────────────────────────────
+
+
+def test_bump_rc_from_beta_resets_to_1() -> None:
+    assert bump(parse("0.3.0-beta.5"), "rc").format() == "0.3.0-rc.1"
+
+
+def test_bump_rc_increments() -> None:
+    assert bump(parse("0.3.0-rc.2"), "rc").format() == "0.3.0-rc.3"
+
+
+def test_bump_rc_from_alpha_is_error() -> None:
+    with pytest.raises(VersionError, match="alpha"):
+        bump(parse("0.3.0-alpha.1"), "rc")
+
+
+# ─── unknown kind ───────────────────────────────────────────────────────────
+
+
+def test_bump_unknown_kind_raises() -> None:
+    with pytest.raises(VersionError):
+        bump(parse("0.3.0"), "snapshot")  # type: ignore[arg-type]
+
+
+# ─── invariant: format always parses back ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "current,kind",
+    [
+        ("0.2.0", "patch"),
+        ("0.2.0", "minor"),
+        ("0.2.0", "major"),
+        ("0.2.0", "beta"),
+        ("0.3.0-beta.3", "patch"),
+        ("0.3.0-beta.3", "beta"),
+        ("0.3.0-beta.3", "rc"),
+        ("0.3.0-rc.1", "rc"),
+        ("0.3.0-alpha.1", "beta"),
+    ],
+)
+def test_bump_output_is_valid_version(current: str, kind: str) -> None:
+    new = bump(parse(current), kind)  # type: ignore[arg-type]
+    # Round-trip via parse to confirm the format string is well-formed.
+    assert parse(new.format()).format() == new.format()
+
+
+# ─── construction sanity ────────────────────────────────────────────────────
+
+
+def test_version_format_with_prerelease() -> None:
+    v = Version(0, 3, 0, Prerelease("beta", 1))
+    assert v.format() == "0.3.0-beta.1"
+
+
+def test_version_format_stable() -> None:
+    assert Version(1, 2, 3).format() == "1.2.3"


### PR DESCRIPTION
## Summary

Phase 1 of the release process. Builds on the existing literal-version `just release` recipe.

- **Keyword bumps**: `just release {major|minor|patch|beta|rc}` computes the new version via `python3 -m scripts.release` and feeds it through the existing release pipeline. Literals (`just release 0.4.0`) still work — the recipe auto-detects which form was passed by checking for a dot.
- **Semver state machine** (`scripts/release/`): pure Python, 56 pytest cases. Encodes the alpha → beta → rc → stable lifecycle, including the regression errors (`rc` from stable, `beta` from `rc`, `rc` from `alpha`) and the prerelease-finalize semantics (`patch`/`minor` from `0.3.0-beta.3` → `0.3.0`).
- **`just release-preview <ARG>`**: read-only smoke test. Prints proposed version, doc files that would be rewritten, and the `git log` window since the last tag.
- **Workspace member sync check**: validates `crates/octarine/Cargo.toml` is `version.workspace = true` or matches the current workspace version. `octarine-derive` is intentionally not touched (independent versioning).
- **Doc-reference sweep**: rewrites `vX.Y.Z` → `vNEW` in `README.md` and `CONTRIBUTING.md` during the release commit. Historical refs in `docs/architecture/` (e.g. "Complete as of v0.3.0-beta.1") are intentionally not on the list — those are factual statements about a past version, not "current" pointers.
- **CHANGELOG curation marker**: auto-generated entries get a `<!-- TODO: review and curate before push -->` HTML comment so the operator notices it in the diff and trims the auto-output before pushing.
- **Stale-reference cleanup**: README (2x) and CONTRIBUTING (1x) were still pointing at `v0.3.0-beta.1` — updated to current `v0.3.0-beta.3`. CONTRIBUTING also normalized to the `v`-prefix form so the recipe catches it on the next bump.
- **Skill**: `.claude/skills/octarine-release/` documents pre-1.0 SemVer policy, breaking-change catalog grounded in Layer 3 modules, lifecycle errors, and operator workflow.
- **Docs**: `docs/releases/{README,versioning,checklist,changelog-format}.md`.

## Out of scope (for follow-up)

- Doctest version strings in `crates/octarine/src/**/*.rs` reference major.minor only (e.g. `version = "0.2"` in `crypto/validation/mod.rs`, `observe/tracing/otel.rs`, `testing/mod.rs`) and don't fit the `vX.Y.Z` sweep pattern. Documented as a known limitation in `docs/releases/checklist.md`.
- `octarine-derive` workspace version migration.
- `cargo publish` automation (octarine is git-only at present).

## Test plan

- [x] `just release-test` — 56/56 pytest cases pass (covers full state-machine matrix incl. all error cases; CLI argparse paths)
- [x] `just release-preview` smoke-tested across all 5 keywords + literal + bad keyword + bad literal
- [x] `just arch-check`, `fmt-check`, `shellcheck`, `clippy`, `arch-check-test` all green
- [x] Workspace member sync check verified against current `version.workspace = true` setup

## Pre-review findings

The pre-review scanner flagged a few items that are not real issues:
- `scripts/release/cli.py` "debug-statement" findings — these are intentional CLI stdout/stderr (`print(new.format())` is the documented output channel that `just release` captures via `\$(...)`)
- `missing-test-file` / `untested-public-api` — tests live at `tests/release/test_*.py`, not co-located with the source. The arch_check package follows the same convention. All public functions are exercised by the 56 pytest cases.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)