### PR TITLE
fix(pii): emit provider-specific PiiType variants for tokens

### DIFF
--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -118,7 +118,40 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             | PiiType::OnePasswordVaultRef
             | PiiType::BearerToken
             | PiiType::UrlWithCredentials
-            | PiiType::ConnectionString => redact_api_keys(&result, profile),
+            | PiiType::ConnectionString
+            // Provider-specific tokens (issue #97). Per-provider redaction
+            // profiles (e.g., show "sk_live_" prefix for Stripe) are a
+            // follow-up. For now they all route through the generic API-key
+            // redactor, which already handles most provider prefixes.
+            | PiiType::GitHubToken
+            | PiiType::GitLabToken
+            | PiiType::BitbucketToken
+            | PiiType::AwsAccessKey
+            | PiiType::AwsSessionToken
+            | PiiType::GcpApiKey
+            | PiiType::AzureKey
+            | PiiType::StripeKey
+            | PiiType::SquareToken
+            | PiiType::ShopifyToken
+            | PiiType::PayPalToken
+            | PiiType::MailchimpToken
+            | PiiType::MailgunToken
+            | PiiType::ResendToken
+            | PiiType::BrevoToken
+            | PiiType::DatabricksToken
+            | PiiType::VaultToken
+            | PiiType::CloudflareOriginCaKey
+            | PiiType::NpmToken
+            | PiiType::PyPiToken
+            | PiiType::NuGetKey
+            | PiiType::ArtifactoryToken
+            | PiiType::DockerHubToken
+            | PiiType::TelegramToken
+            | PiiType::SendGridToken
+            | PiiType::OpenAiKey
+            | PiiType::DiscordToken
+            | PiiType::SlackToken
+            | PiiType::TwilioToken => redact_api_keys(&result, profile),
             // Government IDs
             PiiType::Ssn => redact_ssns(&result, profile),
             PiiType::DriverLicense => redact_driver_licenses(&result, profile),

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -10,7 +10,7 @@ use crate::primitives::identifiers::{
     BiometricIdentifierBuilder, CredentialIdentifierBuilder, FinancialIdentifierBuilder,
     GovernmentIdentifierBuilder, LocationIdentifierBuilder, MedicalIdentifierBuilder,
     NetworkIdentifierBuilder, OrganizationalIdentifierBuilder, PersonalIdentifierBuilder,
-    TokenIdentifierBuilder,
+    TokenIdentifierBuilder, TokenType,
 };
 
 /// Scan for personal PII (email, phone, name, birthdate)
@@ -247,8 +247,34 @@ pub(super) fn scan_network(text: &str, pii_types: &mut Vec<PiiType>) {
 pub(super) fn scan_tokens(text: &str, pii_types: &mut Vec<PiiType>) {
     let token = TokenIdentifierBuilder::new();
 
-    // API keys
-    if token.is_api_key(text) || token.redact_api_keys_in_text(text).as_ref() != text {
+    // Provider-specific token attribution. Iterate whitespace-split words and
+    // dispatch through detect_token_type so each provider gets its own PiiType
+    // variant (issue #97). Suppress the generic ApiKey emission when any
+    // provider matched — it is reserved for unrecognized api-key-shaped input.
+    let mut provider_matched = false;
+    for word in text.split_whitespace() {
+        // Strip surrounding shell punctuation (quotes, commas, parens, colons,
+        // semicolons) but preserve characters that appear inside provider
+        // tokens: `-` `_` `.` (separators) and `=` (base64 padding, e.g.
+        // Azure `AccountKey=...==`).
+        let trimmed = word.trim_matches(|c: char| {
+            !c.is_alphanumeric() && c != '-' && c != '_' && c != '.' && c != '='
+        });
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(token_type) = token.detect_token_type(trimmed)
+            && let Some(pii) = token_type_to_pii(token_type)
+        {
+            pii_types.push(pii);
+            provider_matched = true;
+        }
+    }
+
+    // Generic ApiKey fallback: only when no provider-specific match.
+    if !provider_matched
+        && (token.is_api_key(text) || token.redact_api_keys_in_text(text).as_ref() != text)
+    {
         pii_types.push(PiiType::ApiKey);
     }
 
@@ -307,6 +333,66 @@ pub(super) fn scan_tokens(text: &str, pii_types: &mut Vec<PiiType>) {
     if credential.is_passphrases_present(text) {
         pii_types.push(PiiType::Passphrase);
     }
+}
+
+/// Map a detected `TokenType` to the corresponding provider-specific
+/// `PiiType` variant.
+///
+/// Returns `None` for token types that are already handled by sibling
+/// dispatches in `scan_tokens` (Jwt, SessionId, SshKey*, OnePassword*,
+/// BearerToken, UrlWithCredentials) so they are not double-emitted, and for
+/// `GenericApiKey` (handled by the trailing fallback). `AwsSecretKey` maps
+/// to `ApiKey` because AWS secret keys are 40 base64 chars and
+/// indistinguishable from random high-entropy strings — a dedicated variant
+/// would create false positives.
+fn token_type_to_pii(t: TokenType) -> Option<PiiType> {
+    Some(match t {
+        TokenType::GitHub => PiiType::GitHubToken,
+        TokenType::GitLab => PiiType::GitLabToken,
+        TokenType::BitbucketToken => PiiType::BitbucketToken,
+        TokenType::AwsAccessKey => PiiType::AwsAccessKey,
+        TokenType::AwsSessionToken => PiiType::AwsSessionToken,
+        TokenType::AwsSecretKey => PiiType::ApiKey,
+        TokenType::GcpApiKey => PiiType::GcpApiKey,
+        TokenType::AzureKey => PiiType::AzureKey,
+        TokenType::StripeKey => PiiType::StripeKey,
+        TokenType::SquareToken => PiiType::SquareToken,
+        TokenType::ShopifyToken => PiiType::ShopifyToken,
+        TokenType::PayPalToken => PiiType::PayPalToken,
+        TokenType::MailchimpToken => PiiType::MailchimpToken,
+        TokenType::MailgunToken => PiiType::MailgunToken,
+        TokenType::ResendToken => PiiType::ResendToken,
+        TokenType::BrevoToken => PiiType::BrevoToken,
+        TokenType::DatabricksToken => PiiType::DatabricksToken,
+        TokenType::VaultToken => PiiType::VaultToken,
+        TokenType::CloudflareOriginCaKey => PiiType::CloudflareOriginCaKey,
+        TokenType::NpmToken => PiiType::NpmToken,
+        TokenType::PyPiToken => PiiType::PyPiToken,
+        TokenType::NuGetKey => PiiType::NuGetKey,
+        TokenType::ArtifactoryToken => PiiType::ArtifactoryToken,
+        TokenType::DockerHubToken => PiiType::DockerHubToken,
+        TokenType::TelegramToken => PiiType::TelegramToken,
+        TokenType::SendGridToken => PiiType::SendGridToken,
+        TokenType::OpenAiKey => PiiType::OpenAiKey,
+        TokenType::DiscordToken => PiiType::DiscordToken,
+        TokenType::SlackToken => PiiType::SlackToken,
+        TokenType::TwilioToken => PiiType::TwilioToken,
+        // Already handled by sibling dispatches in scan_tokens — return
+        // None to avoid double-emission.
+        TokenType::Jwt
+        | TokenType::SessionId
+        | TokenType::UrlWithCredentials
+        | TokenType::SshPrivateKey
+        | TokenType::SshPublicKey
+        | TokenType::SshFingerprint
+        | TokenType::OnePasswordServiceToken
+        | TokenType::OnePasswordVaultRef
+        | TokenType::BearerToken
+        // Generic api-key shape — emit ApiKey via the trailing fallback so
+        // it is suppressed when a provider-specific match exists in the
+        // same text.
+        | TokenType::GenericApiKey => return None,
+    })
 }
 
 /// Internal scan function with config (for direct use and cache population)

--- a/crates/octarine/src/observe/pii/scanner/mod.rs
+++ b/crates/octarine/src/observe/pii/scanner/mod.rs
@@ -287,9 +287,13 @@ mod tests {
 
     #[test]
     fn test_scan_for_pii_api_key() {
+        // Stripe-prefixed key now resolves to the dedicated StripeKey variant
+        // (issue #97). Generic ApiKey is the fallback for unrecognized
+        // api-key-shaped input only.
         let text = &format!("Key: sk_test_{}", "EXAMPLE000000000000KEY01");
         let types = scan_for_pii(text);
-        assert!(types.contains(&PiiType::ApiKey));
+        assert!(types.contains(&PiiType::StripeKey));
+        assert!(!types.contains(&PiiType::ApiKey));
     }
 
     #[test]

--- a/crates/octarine/src/observe/pii/types.rs
+++ b/crates/octarine/src/observe/pii/types.rs
@@ -187,6 +187,68 @@ pub enum PiiType {
     /// Connection string with embedded credentials (MSSQL, JDBC, database URLs)
     ConnectionString,
 
+    // -------------------------------------------------------------------------
+    // Provider-specific tokens
+    // -------------------------------------------------------------------------
+    /// GitHub Personal Access Token (ghp_, gho_, ghu_, ghs_, ghr_)
+    GitHubToken,
+    /// GitLab Personal Access Token (glpat-) or Deploy Token
+    GitLabToken,
+    /// Bitbucket Cloud App Password (ATBB...)
+    BitbucketToken,
+    /// AWS Access Key ID (AKIA* long-term, ASIA* temporary STS)
+    AwsAccessKey,
+    /// AWS Session Token (long base64 string from STS)
+    AwsSessionToken,
+    /// Google Cloud Platform API Key (AIza*)
+    GcpApiKey,
+    /// Azure Storage Account Key
+    AzureKey,
+    /// Stripe API Key (sk_live_, sk_test_, pk_live_, pk_test_, rk_*)
+    StripeKey,
+    /// Square API key (sq0atp-*, sq0csp-*, sq0idp-*)
+    SquareToken,
+    /// Shopify API token (shpat_*, shpca_*, shppa_*, shpss_*)
+    ShopifyToken,
+    /// PayPal/Braintree access token
+    PayPalToken,
+    /// Mailchimp API key
+    MailchimpToken,
+    /// Mailgun API key
+    MailgunToken,
+    /// Resend API key
+    ResendToken,
+    /// Brevo/Sendinblue API key
+    BrevoToken,
+    /// Databricks access token
+    DatabricksToken,
+    /// HashiCorp Vault token (hvs., s., b.)
+    VaultToken,
+    /// Cloudflare Origin CA key
+    CloudflareOriginCaKey,
+    /// NPM access token
+    NpmToken,
+    /// PyPI API token
+    PyPiToken,
+    /// NuGet API key
+    NuGetKey,
+    /// JFrog Artifactory API key
+    ArtifactoryToken,
+    /// Docker Hub Personal Access Token
+    DockerHubToken,
+    /// Telegram bot token
+    TelegramToken,
+    /// SendGrid API key
+    SendGridToken,
+    /// OpenAI API key (sk-*, sk-proj-*, org-*)
+    OpenAiKey,
+    /// Discord bot token or webhook URL
+    DiscordToken,
+    /// Slack token (bot/user/app/config/legacy) or webhook URL
+    SlackToken,
+    /// Twilio Account SID (AC...) or API Key SID (SK...)
+    TwilioToken,
+
     // =========================================================================
     // Credential Domain (NIST 800-63 Factor 1: Something You Know)
     // =========================================================================
@@ -284,6 +346,36 @@ impl PiiType {
             Self::BearerToken => "bearer_token",
             Self::UrlWithCredentials => "url_with_credentials",
             Self::ConnectionString => "connection_string",
+            // Provider-specific tokens
+            Self::GitHubToken => "github_token",
+            Self::GitLabToken => "gitlab_token",
+            Self::BitbucketToken => "bitbucket_token",
+            Self::AwsAccessKey => "aws_access_key",
+            Self::AwsSessionToken => "aws_session_token",
+            Self::GcpApiKey => "gcp_api_key",
+            Self::AzureKey => "azure_key",
+            Self::StripeKey => "stripe_key",
+            Self::SquareToken => "square_token",
+            Self::ShopifyToken => "shopify_token",
+            Self::PayPalToken => "paypal_token",
+            Self::MailchimpToken => "mailchimp_token",
+            Self::MailgunToken => "mailgun_token",
+            Self::ResendToken => "resend_token",
+            Self::BrevoToken => "brevo_token",
+            Self::DatabricksToken => "databricks_token",
+            Self::VaultToken => "vault_token",
+            Self::CloudflareOriginCaKey => "cloudflare_origin_ca_key",
+            Self::NpmToken => "npm_token",
+            Self::PyPiToken => "pypi_token",
+            Self::NuGetKey => "nuget_key",
+            Self::ArtifactoryToken => "artifactory_token",
+            Self::DockerHubToken => "docker_hub_token",
+            Self::TelegramToken => "telegram_token",
+            Self::SendGridToken => "sendgrid_token",
+            Self::OpenAiKey => "openai_key",
+            Self::DiscordToken => "discord_token",
+            Self::SlackToken => "slack_token",
+            Self::TwilioToken => "twilio_token",
             // Credential
             Self::Password => "password",
             Self::Pin => "pin",
@@ -353,7 +445,36 @@ impl PiiType {
             | Self::OnePasswordVaultRef
             | Self::BearerToken
             | Self::UrlWithCredentials
-            | Self::ConnectionString => "token",
+            | Self::ConnectionString
+            | Self::GitHubToken
+            | Self::GitLabToken
+            | Self::BitbucketToken
+            | Self::AwsAccessKey
+            | Self::AwsSessionToken
+            | Self::GcpApiKey
+            | Self::AzureKey
+            | Self::StripeKey
+            | Self::SquareToken
+            | Self::ShopifyToken
+            | Self::PayPalToken
+            | Self::MailchimpToken
+            | Self::MailgunToken
+            | Self::ResendToken
+            | Self::BrevoToken
+            | Self::DatabricksToken
+            | Self::VaultToken
+            | Self::CloudflareOriginCaKey
+            | Self::NpmToken
+            | Self::PyPiToken
+            | Self::NuGetKey
+            | Self::ArtifactoryToken
+            | Self::DockerHubToken
+            | Self::TelegramToken
+            | Self::SendGridToken
+            | Self::OpenAiKey
+            | Self::DiscordToken
+            | Self::SlackToken
+            | Self::TwilioToken => "token",
             Self::Password | Self::Pin | Self::SecurityAnswer | Self::Passphrase => "credential",
             Self::Generic => "generic",
         }
@@ -382,7 +503,16 @@ impl PiiType {
             Self::Password | Self::Pin | Self::SecurityAnswer | Self::Passphrase |
             Self::ApiKey | Self::Jwt | Self::SessionId | Self::OAuthToken | Self::SshKey |
             Self::OnePasswordToken | Self::OnePasswordVaultRef | Self::BearerToken | Self::UrlWithCredentials |
-            Self::ConnectionString
+            Self::ConnectionString |
+            Self::GitHubToken | Self::GitLabToken | Self::BitbucketToken |
+            Self::AwsAccessKey | Self::AwsSessionToken |
+            Self::GcpApiKey | Self::AzureKey | Self::StripeKey |
+            Self::SquareToken | Self::ShopifyToken | Self::PayPalToken |
+            Self::MailchimpToken | Self::MailgunToken | Self::ResendToken | Self::BrevoToken |
+            Self::DatabricksToken | Self::VaultToken | Self::CloudflareOriginCaKey |
+            Self::NpmToken | Self::PyPiToken | Self::NuGetKey | Self::ArtifactoryToken | Self::DockerHubToken |
+            Self::TelegramToken | Self::SendGridToken | Self::OpenAiKey |
+            Self::DiscordToken | Self::SlackToken | Self::TwilioToken
         )
     }
 
@@ -463,6 +593,35 @@ impl PiiType {
                 | Self::UrlWithCredentials
                 | Self::ConnectionString
                 | Self::PaymentToken
+                | Self::GitHubToken
+                | Self::GitLabToken
+                | Self::BitbucketToken
+                | Self::AwsAccessKey
+                | Self::AwsSessionToken
+                | Self::GcpApiKey
+                | Self::AzureKey
+                | Self::StripeKey
+                | Self::SquareToken
+                | Self::ShopifyToken
+                | Self::PayPalToken
+                | Self::MailchimpToken
+                | Self::MailgunToken
+                | Self::ResendToken
+                | Self::BrevoToken
+                | Self::DatabricksToken
+                | Self::VaultToken
+                | Self::CloudflareOriginCaKey
+                | Self::NpmToken
+                | Self::PyPiToken
+                | Self::NuGetKey
+                | Self::ArtifactoryToken
+                | Self::DockerHubToken
+                | Self::TelegramToken
+                | Self::SendGridToken
+                | Self::OpenAiKey
+                | Self::DiscordToken
+                | Self::SlackToken
+                | Self::TwilioToken
         )
     }
 }
@@ -517,12 +676,15 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::OnePasswordVaultRef => Self::OnePasswordVaultRef,
             IdentifierType::BearerToken => Self::BearerToken,
             IdentifierType::UrlWithCredentials => Self::UrlWithCredentials,
-            // fallback: no dedicated PiiType variants for developer tokens
-            IdentifierType::GitHubToken
-            | IdentifierType::GitLabToken
-            | IdentifierType::AwsAccessKey
-            | IdentifierType::AwsSessionToken
-            | IdentifierType::HighEntropyString => Self::ApiKey,
+            // Provider-specific developer tokens — each maps to its dedicated
+            // PiiType variant. AWS secret keys still fall back via
+            // HighEntropyString (no dedicated variant — they're 40 base64
+            // chars, indistinguishable from random high-entropy strings).
+            IdentifierType::GitHubToken => Self::GitHubToken,
+            IdentifierType::GitLabToken => Self::GitLabToken,
+            IdentifierType::AwsAccessKey => Self::AwsAccessKey,
+            IdentifierType::AwsSessionToken => Self::AwsSessionToken,
+            IdentifierType::HighEntropyString => Self::ApiKey,
 
             // Database
             IdentifierType::ConnectionString => Self::ConnectionString,
@@ -1100,20 +1262,31 @@ mod tests {
         // dedicated PiiType variant is eventually added, the corresponding
         // assertion here will flip and signal the mapping needs review.
 
-        // Developer-token fallbacks (all collapse to ApiKey)
-        for id in [
-            IdentifierType::GitHubToken,
-            IdentifierType::GitLabToken,
-            IdentifierType::AwsAccessKey,
-            IdentifierType::AwsSessionToken,
-            IdentifierType::HighEntropyString,
-        ] {
-            assert_eq!(
-                PiiType::from(id.clone()),
-                PiiType::ApiKey,
-                "{id:?} should fall back to ApiKey"
-            );
-        }
+        // Provider-specific developer tokens now map to dedicated variants
+        // (issue #97). HighEntropyString remains the only ApiKey fallback —
+        // AWS secret keys are 40 base64 chars and indistinguishable from
+        // random high-entropy strings without context.
+        assert_eq!(
+            PiiType::from(IdentifierType::GitHubToken),
+            PiiType::GitHubToken
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::GitLabToken),
+            PiiType::GitLabToken
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::AwsAccessKey),
+            PiiType::AwsAccessKey
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::AwsSessionToken),
+            PiiType::AwsSessionToken
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::HighEntropyString),
+            PiiType::ApiKey,
+            "HighEntropyString remains the ApiKey fallback (no dedicated variant)"
+        );
 
         // Generic catch-all
         assert_eq!(PiiType::from(IdentifierType::Unknown), PiiType::Generic);

--- a/crates/octarine/src/primitives/identifiers/token/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/token/builder.rs
@@ -162,6 +162,11 @@ impl TokenIdentifierBuilder {
         detection::is_sendgrid_key(value)
     }
 
+    /// Check if value is an OpenAI API key
+    pub fn is_openai_key(&self, value: &str) -> bool {
+        detection::is_openai_key(value)
+    }
+
     /// Check if value is a Twilio Account SID
     pub fn is_twilio_account_sid(&self, value: &str) -> bool {
         detection::is_twilio_account_sid(value)

--- a/crates/octarine/tests/observe/pii_pipeline.rs
+++ b/crates/octarine/tests/observe/pii_pipeline.rs
@@ -62,11 +62,15 @@ fn test_detects_phone_number() {
 
 #[test]
 fn test_detects_api_key() {
+    // Stripe-prefixed key now resolves to PiiType::StripeKey (issue #97).
+    // Generic ApiKey is reserved as the fallback for unrecognized
+    // api-key-shaped input.
     let text = &format!("Key: sk_test_{}", "EXAMPLE000000000000KEY01");
     assert!(is_pii_present(text));
 
     let types = scan_for_pii(text);
-    assert!(types.contains(&PiiType::ApiKey));
+    assert!(types.contains(&PiiType::StripeKey));
+    assert!(!types.contains(&PiiType::ApiKey));
 }
 
 #[test]
@@ -417,5 +421,269 @@ fn test_detects_port_in_scan() {
     assert!(
         types.contains(&PiiType::Port),
         "expected PiiType::Port in {types:?}",
+    );
+}
+
+// ============================================================================
+// Provider-specific token attribution (issue #97)
+//
+// Each test confirms that a recognizable provider token is reported with its
+// dedicated PiiType variant and that the generic ApiKey fallback is suppressed.
+// Fixtures are constructed via format!() to avoid pre-commit secret-scanner
+// false positives — same convention as the unit tests in
+// primitives/identifiers/token/detection/mod.rs.
+// ============================================================================
+
+fn assert_provider(text: &str, expected: PiiType) {
+    let types = scan_for_pii(text);
+    assert!(
+        types.contains(&expected),
+        "expected {expected:?} in {types:?} for input {text:?}"
+    );
+    assert!(
+        !types.contains(&PiiType::ApiKey),
+        "generic ApiKey should be suppressed when {expected:?} matches; got {types:?}"
+    );
+}
+
+#[test]
+fn test_detects_github_token() {
+    assert_provider(
+        &format!("token: ghp_{}", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"),
+        PiiType::GitHubToken,
+    );
+}
+
+#[test]
+fn test_detects_gitlab_token() {
+    assert_provider(
+        &format!("Auth: glpat-{}", "xxxxxxxxxxxxxxxxxxxx"),
+        PiiType::GitLabToken,
+    );
+}
+
+#[test]
+fn test_detects_bitbucket_token() {
+    assert_provider(&format!("ATBB{}", "x".repeat(32)), PiiType::BitbucketToken);
+}
+
+#[test]
+fn test_detects_aws_access_key() {
+    let akia = format!("AKIA{}", "IOSFODNN7EXAMPLE");
+    assert_provider(&format!("AWS_KEY={akia}"), PiiType::AwsAccessKey);
+}
+
+// AwsSessionToken is intentionally not tested here. The session-token regex
+// (`[A-Za-z0-9/+=]{100,}`) is a strict superset of the AWS secret-key regex
+// (`[A-Za-z0-9/+=]{40}`) which is checked first in `detect_token_type`,
+// and AwsSecretKey routes to PiiType::ApiKey by design (see plan §F.4 —
+// AWS secret keys are indistinguishable from random high-entropy strings
+// without context). Real session-token attribution requires the
+// `is_aws_session_token` short-circuit on the From<IdentifierType> path,
+// which is exercised by the unit test
+// `from_identifier_type_fallback_mappings` in observe/pii/types.rs.
+
+#[test]
+fn test_detects_gcp_api_key() {
+    // Constructed via format! so gitleaks doesn't flag a literal AIza key.
+    let key = format!("AIza{}", "SyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe");
+    assert_provider(&format!("GOOGLE_KEY={key}"), PiiType::GcpApiKey);
+}
+
+#[test]
+fn test_detects_azure_key() {
+    let key = format!(
+        "AccountKey={}",
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/abcdefghijklmnopqrstuvwx=="
+    );
+    assert_provider(&key, PiiType::AzureKey);
+}
+
+#[test]
+fn test_detects_stripe_key() {
+    assert_provider(
+        &format!("STRIPE=sk_live_{}", "EXAMPLE000000000KEY01abcdef"),
+        PiiType::StripeKey,
+    );
+}
+
+#[test]
+fn test_detects_square_token() {
+    assert_provider(
+        &format!("token=sq0atp-{}", "ABCDEFghijklmnopqrstuv"),
+        PiiType::SquareToken,
+    );
+}
+
+#[test]
+fn test_detects_shopify_token() {
+    assert_provider(
+        &format!("shpat_{}", "abcdef1234567890abcdef1234567890"),
+        PiiType::ShopifyToken,
+    );
+}
+
+#[test]
+fn test_detects_paypal_token() {
+    assert_provider(
+        &format!(
+            "access_token$production${}${}",
+            "abc1234567890xyz", "abcdef1234567890abcdef1234567890"
+        ),
+        PiiType::PayPalToken,
+    );
+}
+
+#[test]
+fn test_detects_mailchimp_token() {
+    assert_provider(
+        &format!("{}{}-us6", "abcdef1234567890", "abcdef1234567890"),
+        PiiType::MailchimpToken,
+    );
+}
+
+#[test]
+fn test_detects_mailgun_token() {
+    assert_provider(
+        &format!("key-{}", "ABCDEFghijklmnopqrstuv1234567890"),
+        PiiType::MailgunToken,
+    );
+}
+
+#[test]
+fn test_detects_resend_token() {
+    assert_provider(
+        &format!("re_{}", "ABCDEFghijklmnopqrstuv1234567890ab"),
+        PiiType::ResendToken,
+    );
+}
+
+#[test]
+fn test_detects_brevo_token() {
+    assert_provider(
+        &format!("xkeysib-{}-{}", "a".repeat(64), "B".repeat(16)),
+        PiiType::BrevoToken,
+    );
+}
+
+#[test]
+fn test_detects_databricks_token() {
+    assert_provider(&format!("dapi{}", "a".repeat(32)), PiiType::DatabricksToken);
+}
+
+#[test]
+fn test_detects_vault_token() {
+    assert_provider(&format!("hvs.{}", "A".repeat(24)), PiiType::VaultToken);
+}
+
+#[test]
+fn test_detects_cloudflare_origin_ca_key() {
+    assert_provider(
+        &format!("v1.0-{}-{}", "a".repeat(24), "b".repeat(146)),
+        PiiType::CloudflareOriginCaKey,
+    );
+}
+
+#[test]
+fn test_detects_npm_token() {
+    assert_provider(&format!("npm_{}", "A".repeat(36)), PiiType::NpmToken);
+}
+
+#[test]
+fn test_detects_pypi_token() {
+    assert_provider(
+        &format!("pypi-AgEIcHlwaS5vcmc{}", "A".repeat(50)),
+        PiiType::PyPiToken,
+    );
+}
+
+#[test]
+fn test_detects_nuget_key() {
+    assert_provider(&format!("oy2{}", "a".repeat(43)), PiiType::NuGetKey);
+}
+
+#[test]
+fn test_detects_artifactory_token() {
+    assert_provider(&format!("AKC{}", "a".repeat(10)), PiiType::ArtifactoryToken);
+}
+
+#[test]
+fn test_detects_docker_hub_token() {
+    assert_provider(
+        &format!("dckr_pat_{}", "A".repeat(27)),
+        PiiType::DockerHubToken,
+    );
+}
+
+#[test]
+fn test_detects_telegram_token() {
+    assert_provider(
+        &format!("12345678:{}", "A".repeat(35)),
+        PiiType::TelegramToken,
+    );
+}
+
+#[test]
+fn test_detects_sendgrid_token() {
+    assert_provider(
+        &format!("SG.{}.{}", "A".repeat(22), "b".repeat(43)),
+        PiiType::SendGridToken,
+    );
+}
+
+#[test]
+fn test_detects_openai_key() {
+    assert_provider(
+        &format!("sk-{}T3BlbkFJ{}", "A".repeat(20), "B".repeat(20)),
+        PiiType::OpenAiKey,
+    );
+}
+
+#[test]
+fn test_detects_discord_token() {
+    assert_provider(
+        &format!("M{}.{}.{}", "A".repeat(23), "AbCdEf", "a".repeat(27)),
+        PiiType::DiscordToken,
+    );
+}
+
+#[test]
+fn test_detects_slack_token() {
+    assert_provider(
+        &format!("xoxb-{}-{}", "1".repeat(12), "A".repeat(24)),
+        PiiType::SlackToken,
+    );
+}
+
+#[test]
+fn test_detects_twilio_token() {
+    assert_provider(&format!("AC{}", "a".repeat(32)), PiiType::TwilioToken);
+}
+
+#[test]
+fn test_unrecognized_api_key_falls_back_to_generic() {
+    // api_key=... shape with no provider prefix. The redact_api_keys_in_text
+    // primitive recognises the labeled form and the generic fallback fires.
+    let text = "config: api_key=zzzz9999aaaa8888bbbb7777cccc6666";
+    let types = scan_for_pii(text);
+    assert!(
+        types.contains(&PiiType::ApiKey),
+        "unrecognized api-key shape should fall back to ApiKey: {types:?}"
+    );
+}
+
+#[test]
+fn test_multiple_providers_in_one_text() {
+    let text = format!(
+        "GH: ghp_{} STRIPE: sk_live_{} AWS: AKIA{}",
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", "EXAMPLE000000000KEY01abcdef", "IOSFODNN7EXAMPLE"
+    );
+    let types = scan_for_pii(&text);
+    assert!(types.contains(&PiiType::GitHubToken), "{types:?}");
+    assert!(types.contains(&PiiType::StripeKey), "{types:?}");
+    assert!(types.contains(&PiiType::AwsAccessKey), "{types:?}");
+    assert!(
+        !types.contains(&PiiType::ApiKey),
+        "generic ApiKey must be suppressed when providers matched: {types:?}"
     );
 }


### PR DESCRIPTION
## Summary

`scan_tokens()` collapsed every provider-specific token (AWS, GitHub, GitLab, GCP, Azure, Stripe, Slack, Discord, Twilio, NPM, PyPI, …) into a single `PiiType::ApiKey`, dropping attribution at the PII boundary. This made it impossible to drive provider-specific redaction policies, attribute incident-response findings to the right vendor, or distinguish a Stripe key from a GitHub token in compliance reports.

This PR wires the existing `TokenType` enum (which already distinguishes 30+ providers) through to PII output:

- **29 new `PiiType` variants** — `GitHubToken`, `GitLabToken`, `BitbucketToken`, `AwsAccessKey`, `AwsSessionToken`, `GcpApiKey`, `AzureKey`, `StripeKey`, `SquareToken`, `ShopifyToken`, `PayPalToken`, `MailchimpToken`, `MailgunToken`, `ResendToken`, `BrevoToken`, `DatabricksToken`, `VaultToken`, `CloudflareOriginCaKey`, `NpmToken`, `PyPiToken`, `NuGetKey`, `ArtifactoryToken`, `DockerHubToken`, `TelegramToken`, `SendGridToken`, `OpenAiKey`, `DiscordToken`, `SlackToken`, `TwilioToken`. Variant names mirror `TokenType` so the dispatch arms read symmetrically.
- **`scan_tokens()` rewritten** — splits the input on whitespace, dispatches each candidate word through `detect_token_type`, and maps the result to the matching `PiiType`. When any provider matches, the generic `ApiKey` is suppressed; it now emits only as the fallback for unrecognized api-key-shaped input.
- **`From<IdentifierType> for PiiType`** no longer collapses the four IdentifierTypes that already carry provider identity (`GitHubToken`, `GitLabToken`, `AwsAccessKey`, `AwsSessionToken`) into `ApiKey`. `HighEntropyString` stays at `ApiKey` — AWS secret keys are 40 base64 chars and indistinguishable from random high-entropy strings without context.
- **`is_openai_key`** wrapper added to `TokenIdentifierBuilder` so OpenAI is exposed on the public dual-API like every other provider.
- **All four PiiType classification arms** (`name`, `domain`, `is_high_risk`, `is_secret`) extended to cover the new variants. Provider tokens are token-domain, secret, and high-risk; they are not GDPR/PCI/HIPAA-protected (mirroring `ApiKey`'s treatment — they identify systems, not data subjects).
- **`redactor/mod.rs`** match arms extended to route every new variant through `redact_api_keys` for now. Per-provider redaction profiles (e.g., show "sk_live_" prefix for Stripe) are intentionally out of scope.

### Out of scope (follow-up issues worth filing)

- `AzureConnectionString` as its own `PiiType` (not dispatched by `detect_token_type` today).
- Webhook-vs-token granularity for Slack / Discord — `TokenType` collapses them.
- AccountSid-vs-ApiKeySid granularity for Twilio — `TokenType` collapses them.
- Per-provider redaction profile in `observe/pii/redactor/tokens.rs`.
- Adding `IdentifierType` variants for the ~25 providers that currently fold into `IdentifierType::ApiKey` at the primitives layer.

## Test plan

- [x] `just preflight` — fmt, clippy, arch-check, full test suite (6486 unit + 33 + 9 + 30 + 77 + 43 + 5 + 264 + 61 + 7 + 9 integration/doc tests, 0 failures)
- [x] 28 new per-provider integration tests in `tests/observe/pii_pipeline.rs` (`test_detects_*`), each asserting both that the dedicated variant is emitted and that the generic `ApiKey` is suppressed
- [x] `test_multiple_providers_in_one_text` — text mixing GitHub + Stripe + AWS produces all three dedicated variants
- [x] `test_unrecognized_api_key_falls_back_to_generic` — `api_key=...` with no provider prefix still emits `PiiType::ApiKey`
- [x] Existing `test_scan_for_pii_api_key` flipped: `sk_test_...` now asserts `StripeKey` + `!ApiKey`
- [x] Existing `from_identifier_type_fallback_mappings` flipped: 4 IdentifierTypes assert dedicated variants; `HighEntropyString` keeps the documented `ApiKey` fallback
- [x] Test fixtures use `format!()` to dodge gitleaks pre-commit hook (canonical convention from `primitives/identifiers/token/detection/mod.rs:341-343`)

## Notes for reviewers

- `AwsSessionToken` is intentionally not integration-tested via `scan_tokens`. The session-token regex (`[A-Za-z0-9/+=]{100,}`) is a strict superset of the AWS secret-key regex (`[A-Za-z0-9/+=]{40}`), and `detect_token_type` checks `is_aws_secret_key` first — by design (per the source ordering at `detection/mod.rs:235-243`). The session-token attribution path that does work is via `From<IdentifierType>`, exercised by `from_identifier_type_fallback_mappings`.
- The trim filter in the per-word dispatch preserves `=` (Azure base64 padding) in addition to `-_.`.
- Pre-review scanner flagged one advisory finding: `domains.rs` has no co-located test module. The dispatch is exhaustively covered by the integration suite above.

Closes #97