### PR TITLE
fix(tests): replace fixed sleeps with poll-until-condition loops

### DIFF
--- a/crates/octarine/src/primitives/collections/cache/lru.rs
+++ b/crates/octarine/src/primitives/collections/cache/lru.rs
@@ -382,8 +382,15 @@ mod tests {
         cache.insert("key", "value");
         assert_eq!(cache.get(&"key"), Some("value"));
 
-        // Wait for expiration
-        std::thread::sleep(Duration::from_millis(60));
+        // Poll until the entry expires. CI under coverage instrumentation
+        // can stretch a 50ms TTL well beyond a fixed 60ms sleep.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while cache.get(&"key").is_some() {
+            if Instant::now() > deadline {
+                panic!("Timed out waiting for cache entry to expire");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
 
         assert_eq!(cache.get(&"key"), None);
     }
@@ -398,10 +405,22 @@ mod tests {
 
         assert_eq!(cache.len(), 5);
 
-        // Wait for expiration
-        std::thread::sleep(Duration::from_millis(60));
-
-        let expired = cache.cleanup_expired();
+        // Poll until all entries expire (cleanup_expired sees them as stale).
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let expired = loop {
+            let count = cache.cleanup_expired();
+            if count == 5 {
+                break count;
+            }
+            if Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for 5 entries to expire (got {}, len {})",
+                    count,
+                    cache.len()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        };
         assert_eq!(expired, 5);
         assert_eq!(cache.len(), 0);
     }

--- a/crates/octarine/src/primitives/runtime/async/batch.rs
+++ b/crates/octarine/src/primitives/runtime/async/batch.rs
@@ -147,7 +147,18 @@ mod tests {
         batch.add("test");
         assert!(!batch.should_flush());
 
-        std::thread::sleep(Duration::from_millis(60));
+        // Poll until the age threshold elapses. A fixed 60ms sleep against a
+        // 50ms threshold leaves no margin under loaded CI.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !batch.should_flush() {
+            if Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for batch.should_flush() (elapsed: {:?})",
+                    batch.elapsed()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
         assert!(batch.should_flush());
     }
 
@@ -214,8 +225,17 @@ mod tests {
         let mut batch = BatchProcessor::new(10, Duration::from_millis(50));
         batch.add(1);
 
-        // Wait for age threshold
-        std::thread::sleep(Duration::from_millis(60));
+        // Poll until the age threshold elapses.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !batch.should_flush() {
+            if Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for batch.should_flush() (elapsed: {:?})",
+                    batch.elapsed()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
         assert!(batch.should_flush());
 
         // Take items - should reset timer

--- a/crates/octarine/src/primitives/runtime/async/worker.rs
+++ b/crates/octarine/src/primitives/runtime/async/worker.rs
@@ -630,8 +630,18 @@ mod tests {
         .await
         .expect("execute should succeed");
 
-        // Wait for task to complete
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Poll until the task completes (per pool.stats accounting).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while pool.stats().tasks_completed < 1 {
+            if std::time::Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for task to complete (counter={}, completed={})",
+                    counter.load(Ordering::Relaxed),
+                    pool.stats().tasks_completed
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
 
         assert_eq!(counter.load(Ordering::Relaxed), 1);
         pool.shutdown().await;
@@ -649,8 +659,18 @@ mod tests {
         })
         .expect("spawn should succeed");
 
-        // Wait for task to complete
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Poll until the task completes.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while pool.stats().tasks_completed < 1 {
+            if std::time::Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for task to complete (counter={}, completed={})",
+                    counter.load(Ordering::Relaxed),
+                    pool.stats().tasks_completed
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
 
         assert_eq!(counter.load(Ordering::Relaxed), 1);
         pool.shutdown().await;
@@ -670,8 +690,18 @@ mod tests {
             .expect("spawn should succeed");
         }
 
-        // Wait for tasks to complete
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Poll until all 10 tasks complete.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while pool.stats().tasks_completed < 10 {
+            if std::time::Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for 10 tasks to complete (counter={}, completed={})",
+                    counter.load(Ordering::Relaxed),
+                    pool.stats().tasks_completed
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
 
         assert_eq!(counter.load(Ordering::Relaxed), 10);
         pool.shutdown().await;
@@ -690,8 +720,17 @@ mod tests {
         .await
         .expect("execute should succeed");
 
-        // Wait for task
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Poll until the task completes.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while pool.stats().tasks_completed < 1 {
+            if std::time::Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for task to complete (stats: {:?})",
+                    pool.stats()
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
 
         let stats = pool.stats();
         assert_eq!(stats.name, "test");

--- a/crates/octarine/src/runtime/async/worker.rs
+++ b/crates/octarine/src/runtime/async/worker.rs
@@ -387,8 +387,17 @@ mod tests {
         })
         .expect("spawn should succeed");
 
-        // Give worker time to process
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // Poll until the worker processes the task.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while counter.load(Ordering::SeqCst) < 1 {
+            if std::time::Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for task (counter={})",
+                    counter.load(Ordering::SeqCst)
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
 
         assert_eq!(counter.load(Ordering::SeqCst), 1);
         pool.shutdown().await;
@@ -407,8 +416,17 @@ mod tests {
             .expect("spawn should succeed");
         }
 
-        // Wait for completion
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Poll until all 10 tasks complete.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while counter.load(Ordering::SeqCst) < 10 {
+            if std::time::Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for 10 tasks (counter={})",
+                    counter.load(Ordering::SeqCst)
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
 
         assert_eq!(counter.load(Ordering::SeqCst), 10);
         pool.shutdown().await;

--- a/crates/octarine/tests/observe/async_dispatch.rs
+++ b/crates/octarine/tests/observe/async_dispatch.rs
@@ -13,7 +13,7 @@ use octarine::observe::writers::{
     dispatcher_overflow_strategy, dispatcher_stats, dispatcher_stats_extended,
 };
 use octarine::{debug, error, info, warn};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::time::timeout;
 
 /// Per-test executor timeout. Prevents a stalled runtime or held lock from
@@ -90,8 +90,19 @@ fn test_logging_shortcuts_queue_events() {
     debug("dispatch_test", "Test debug message");
     error("dispatch_test", "Test error message");
 
-    // Give a moment for queuing (should be nearly instant)
-    std::thread::sleep(Duration::from_millis(10));
+    // Poll until at least 4 new events have been queued. CI under coverage
+    // can stretch the queueing window past any fixed sleep.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let queued = dispatcher_stats().total_written - stats_before.total_written;
+        if queued >= 4 {
+            break;
+        }
+        if Instant::now() > deadline {
+            panic!("Timed out waiting for 4 events to queue (got {})", queued);
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
 
     let stats_after = dispatcher_stats();
 
@@ -116,8 +127,23 @@ fn test_many_events_queued_successfully() {
         info("bulk_test", format!("Event {}", i));
     }
 
-    // Brief pause to let queue accept events
-    std::thread::sleep(Duration::from_millis(50));
+    // Poll until at least 90 of the 100 events are queued. The 100-event
+    // burst dominates dispatcher work under coverage instrumentation, so
+    // use a 10s deadline rather than the default 5s.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let queued = dispatcher_stats().total_written - stats_before.total_written;
+        if queued >= 90 {
+            break;
+        }
+        if Instant::now() > deadline {
+            panic!(
+                "Timed out waiting for 90 of 100 events to queue (got {})",
+                queued
+            );
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
 
     let stats_after = dispatcher_stats();
 
@@ -205,8 +231,21 @@ async fn test_dispatch_from_async_context() {
             info("async_test", format!("Async event {}", i));
         }
 
-        // Brief pause
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Poll until 10 events are queued.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let queued = dispatcher_stats().total_written - stats_before.total_written;
+            if queued >= 10 {
+                break;
+            }
+            if Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for 10 events from async context (got {})",
+                    queued
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
 
         let stats_after = dispatcher_stats();
 
@@ -244,8 +283,22 @@ async fn test_concurrent_dispatch_from_tasks() {
             handle.await.expect("Task should complete");
         }
 
-        // Brief pause for queuing
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Poll until at least 45 of 50 events are queued. The dispatcher
+        // tolerates a small number of drops under burst load.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let queued = dispatcher_stats().total_written - stats_before.total_written;
+            if queued >= 45 {
+                break;
+            }
+            if Instant::now() > deadline {
+                panic!(
+                    "Timed out waiting for 45 of 50 concurrent events (got {})",
+                    queued
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
 
         let stats_after = dispatcher_stats();
 

--- a/crates/octarine/tests/observe/metrics_export.rs
+++ b/crates/octarine/tests/observe/metrics_export.rs
@@ -8,7 +8,7 @@ use octarine::observe::metrics::{
     DefaultLabels, MetricName, PrometheusConfig, PrometheusExporter, StatsDConfig, StatsDWriter,
     gauge, increment, increment_by, record,
 };
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 // ============================================================================
 // Prometheus Exporter Tests
@@ -192,20 +192,37 @@ fn test_prometheus_with_live_metrics() {
     gauge(gauge_name, 42);
     record(histogram_name, 0.5);
 
-    // Small delay to allow async dispatch
-    std::thread::sleep(Duration::from_millis(50));
-
-    // Export via Prometheus
+    // Poll the Prometheus exporter until live metrics are observable. The
+    // previous implementation slept 50ms then silently skipped the assertion
+    // when output was empty, which converted "metrics never arrived" into a
+    // passing test. Fail loudly on timeout so a regression is debuggable.
     let exporter = PrometheusExporter::new(PrometheusConfig::new().namespace("integration"));
-    let output = exporter.render().expect("render should succeed");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let output = loop {
+        let rendered = exporter.render().expect("render should succeed");
+        if !rendered.is_empty()
+            && (rendered.contains("# TYPE")
+                || rendered.contains("counter")
+                || rendered.contains("gauge"))
+        {
+            break rendered;
+        }
+        if Instant::now() > deadline {
+            panic!(
+                "Timed out waiting for Prometheus exporter to expose live metrics. \
+                 Last render output (len={}): {:?}",
+                rendered.len(),
+                rendered
+            );
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
 
-    // Should contain metric types and values
-    // Note: metrics may or may not be present depending on timing
-    if !output.is_empty() {
-        assert!(
-            output.contains("# TYPE") || output.contains("counter") || output.contains("gauge")
-        );
-    }
+    assert!(
+        output.contains("# TYPE") || output.contains("counter") || output.contains("gauge"),
+        "Prometheus output missing expected markers: {:?}",
+        output
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

15 tests across worker pools, batch processor, LRU cache, async dispatch, and Prometheus export slept a fixed duration then asserted state with no polling loop. Under CI coverage instrumentation (10-100× timing inflation) the sleep windows were insufficient and the tests flaked.

This change replaces each `sleep(D); assert!(cond)` with a deadline-bounded poll loop, following the pattern prescribed by the `octarine-test-resilience` skill (Rule 2):

- 5 s deadline by default; 10 s for the 100-event burst test where dispatcher work dominates under coverage
- 10 ms inter-poll sleep
- Timeout panics include the observed value so CI failures are debuggable without re-running

It also fixes a behavior bug in `test_prometheus_with_live_metrics`: the previous `if !output.is_empty()` guard converted "metrics never arrived" into a passing test. Now polls until live metrics are observable and panics with the rendered output on timeout.

### Sites fixed (15)

- `primitives/collections/cache/lru.rs` — `test_cache_expiration`, `test_cache_cleanup`
- `primitives/runtime/async/batch.rs` — `test_batch_processor_age`, `test_batch_processor_take_resets_timer`
- `primitives/runtime/async/worker.rs` — `test_worker_pool_execute`, `test_worker_pool_spawn`, `test_worker_pool_multiple_tasks`, `test_worker_pool_stats`
- `runtime/async/worker.rs` — `test_worker_pool_basic`, `test_worker_pool_multiple_tasks`
- `tests/observe/async_dispatch.rs` — `test_logging_shortcuts_queue_events`, `test_many_events_queued_successfully`, `test_dispatch_from_async_context`, `test_concurrent_dispatch_from_tasks`
- `tests/observe/metrics_export.rs` — `test_prometheus_with_live_metrics` (also removes silent-skip)

### Note on inline pattern vs shared helper

8 of 15 sites are unit tests inside `mod tests {}` blocks in production source files. Adding a shared `poll_until` helper to `crates/octarine/src/testing/` would force the `testing` feature on default unit-test runs. Inline poll loops are kept local — if a third batch appears, promote then.

## Test plan

- [x] `just preflight` — fmt + clippy + arch-check + 6486 unit + integration + 241 doctests, all green
- [x] `cargo test -p octarine --test observe_integration -j4 -- async_dispatch test_prometheus_with_live_metrics` × 5 consecutive runs — no flakes
- [x] `cargo test -p octarine --lib -j4 -- primitives::runtime::r#async::worker primitives::runtime::r#async::batch primitives::collections::cache::lru runtime::r#async::worker` × 5 consecutive runs — no flakes
- [ ] CI under coverage instrumentation — the actual proof point

Closes #93