### PR TITLE
refactor(primitives): tighten inline pub mod to pub(crate) mod in pattern files

### DIFF
--- a/crates/octarine/src/primitives/identifiers/common/patterns/credentials.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/credentials.rs
@@ -30,7 +30,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 /// Password field patterns
-pub mod password {
+pub(crate) mod password {
     use super::*;
 
     /// Password field pattern (key=value or key: value format)
@@ -63,7 +63,7 @@ pub mod password {
 }
 
 /// PIN field patterns
-pub mod pin {
+pub(crate) mod pin {
     use super::*;
 
     /// PIN field pattern (key=value or key: value format)
@@ -89,7 +89,7 @@ pub mod pin {
 }
 
 /// Security question/answer patterns
-pub mod security_answer {
+pub(crate) mod security_answer {
     use super::*;
 
     /// Security answer field pattern
@@ -116,7 +116,7 @@ pub mod security_answer {
 }
 
 /// Passphrase field patterns
-pub mod passphrase {
+pub(crate) mod passphrase {
     use super::*;
 
     /// Passphrase field pattern

--- a/crates/octarine/src/primitives/identifiers/common/patterns/financial.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/financial.rs
@@ -9,7 +9,7 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-pub mod credit_card {
+pub(crate) mod credit_card {
     use super::*;
 
     /// Credit card with spaces (4 groups of 4)
@@ -73,7 +73,7 @@ pub mod credit_card {
     }
 
     /// Card brand validation patterns (for strict validation)
-    pub mod brand {
+    pub(crate) mod brand {
         use super::*;
 
         /// Visa: Starts with 4, 13 or 16 digits
@@ -111,7 +111,7 @@ pub mod credit_card {
 }
 
 /// Payment token patterns (Stripe, PayPal, etc.)
-pub mod payment_token {
+pub(crate) mod payment_token {
     use super::*;
 
     /// Stripe tokens (various types)
@@ -132,7 +132,7 @@ pub mod payment_token {
 }
 
 /// Routing number patterns
-pub mod routing_number {
+pub(crate) mod routing_number {
     use super::*;
 
     /// Standalone routing number (9 digits with word boundary)
@@ -152,7 +152,7 @@ pub mod routing_number {
 }
 
 /// Bank account patterns
-pub mod bank_account {
+pub(crate) mod bank_account {
     use super::*;
 
     /// IBAN format: 2 letters + 2 check digits + 11-30 alphanumeric BBAN
@@ -184,7 +184,7 @@ pub mod bank_account {
 }
 
 /// Cryptocurrency wallet address patterns
-pub mod crypto {
+pub(crate) mod crypto {
     use super::*;
 
     /// Bitcoin P2PKH (Legacy) address: starts with '1', Base58Check

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -34,9 +34,9 @@ pub(crate) mod personal;
 pub(crate) mod vehicle_id;
 
 // Re-export all pattern modules for backward compatibility
-pub use financial::{bank_account, credit_card, payment_token, routing_number};
-pub use network::{email, phone, username};
-pub use personal::{
+pub(crate) use financial::{bank_account, credit_card, payment_token, routing_number};
+pub(crate) use network::{email, phone, username};
+pub(crate) use personal::{
     australia_abn, australia_tfn, birthdate, driver_license, employee_id, finland_hetu,
     india_aadhaar, india_pan, italy_fiscal_code, korea_rrn, national_id, passport, personal_name,
     poland_pesel, singapore_nric, spain_nie, spain_nif, ssn, student_id, tax_id, uk_ni,

--- a/crates/octarine/src/primitives/identifiers/common/patterns/network.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/network.rs
@@ -9,7 +9,7 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-pub mod email {
+pub(crate) mod email {
     use super::*;
 
     /// Standard email pattern (for text scanning)
@@ -38,7 +38,7 @@ pub mod email {
         vec![&*STANDARD, &*IP_LITERAL]
     }
 }
-pub mod phone {
+pub(crate) mod phone {
     use super::*;
 
     /// US phone with country code
@@ -159,7 +159,7 @@ pub mod phone {
     }
 }
 
-pub mod username {
+pub(crate) mod username {
     use super::*;
 
     /// Standard username pattern (alphanumeric with underscore, dot, dash)

--- a/crates/octarine/src/primitives/identifiers/common/patterns/organizational.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/organizational.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 // Employee ID Patterns
 // ============================================================================
 
-pub mod employee_id {
+pub(crate) mod employee_id {
     use super::*;
 
     /// Employee ID with explicit prefix
@@ -40,7 +40,7 @@ pub mod employee_id {
 // Student ID Patterns
 // ============================================================================
 
-pub mod student_id {
+pub(crate) mod student_id {
     use super::*;
 
     /// Student ID with explicit prefix
@@ -71,7 +71,7 @@ pub mod student_id {
 // Badge Number Patterns
 // ============================================================================
 
-pub mod badge_number {
+pub(crate) mod badge_number {
     use super::*;
 
     /// Badge number with explicit prefix

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal.rs
@@ -32,7 +32,7 @@ use regex::Regex;
 use std::collections::HashMap;
 
 /// SSN (Social Security Number) patterns
-pub mod ssn {
+pub(crate) mod ssn {
     use super::*;
 
     /// SSN with explicit label (highest confidence)
@@ -65,7 +65,7 @@ pub mod ssn {
 }
 
 /// Tax ID patterns (EIN, TIN, ITIN)
-pub mod tax_id {
+pub(crate) mod tax_id {
     use super::*;
 
     /// Tax ID with explicit label (highest confidence)
@@ -109,7 +109,7 @@ pub mod tax_id {
 }
 
 /// Driver's license patterns
-pub mod driver_license {
+pub(crate) mod driver_license {
     use super::*;
 
     /// Generic driver's license pattern with context
@@ -144,7 +144,7 @@ pub mod driver_license {
 }
 
 /// Passport patterns
-pub mod passport {
+pub(crate) mod passport {
     use super::*;
 
     /// Explicit passport mention (highest confidence)
@@ -173,7 +173,7 @@ pub mod passport {
 }
 
 /// Employee ID patterns
-pub mod employee_id {
+pub(crate) mod employee_id {
     use super::*;
 
     /// Employee ID with explicit prefix
@@ -200,7 +200,7 @@ pub mod employee_id {
 }
 
 /// Student ID patterns
-pub mod student_id {
+pub(crate) mod student_id {
     use super::*;
 
     /// Student ID with explicit prefix
@@ -227,7 +227,7 @@ pub mod student_id {
 }
 
 /// National ID patterns (international)
-pub mod national_id {
+pub(crate) mod national_id {
     use super::*;
 
     /// UK National Insurance Number
@@ -253,7 +253,7 @@ pub mod national_id {
     }
 }
 /// South Korea Resident Registration Number patterns
-pub mod korea_rrn {
+pub(crate) mod korea_rrn {
     use super::*;
 
     /// Korea RRN with dash: YYMMDD-GNNNNNN (13 digits total)
@@ -275,7 +275,7 @@ pub mod korea_rrn {
 }
 
 /// Australian Tax File Number patterns
-pub mod australia_tfn {
+pub(crate) mod australia_tfn {
     use super::*;
 
     /// TFN with spaces: NNN NNN NNN (9 digits)
@@ -294,7 +294,7 @@ pub mod australia_tfn {
 }
 
 /// Australian Business Number patterns
-pub mod australia_abn {
+pub(crate) mod australia_abn {
     use super::*;
 
     /// ABN with spaces: NN NNN NNN NNN (11 digits)
@@ -316,7 +316,7 @@ pub mod australia_abn {
 }
 
 /// India Aadhaar number patterns (12 digits, starts with 2-9)
-pub mod india_aadhaar {
+pub(crate) mod india_aadhaar {
     use super::*;
 
     /// Aadhaar with spaces: NNNN NNNN NNNN (starts with 2-9)
@@ -336,7 +336,7 @@ pub mod india_aadhaar {
 }
 
 /// India PAN (Permanent Account Number) patterns
-pub mod india_pan {
+pub(crate) mod india_pan {
     use super::*;
 
     /// PAN format: AAAAA9999A (5 letters + 4 digits + 1 letter)
@@ -357,7 +357,7 @@ pub mod india_pan {
 }
 
 /// Singapore NRIC/FIN patterns
-pub mod singapore_nric {
+pub(crate) mod singapore_nric {
     use super::*;
 
     /// NRIC/FIN format: [STFGM] + 7 digits + check letter
@@ -376,7 +376,7 @@ pub mod singapore_nric {
 }
 
 /// Finland HETU (personal identity code) patterns
-pub mod finland_hetu {
+pub(crate) mod finland_hetu {
     use super::*;
 
     /// HETU format: DDMMYY[+-A]NNNC (6 digits + century + 3 digits + check)
@@ -403,7 +403,7 @@ pub mod finland_hetu {
 /// The `is_uk_ni` / `find_uk_nis_in_text` detection functions apply HMRC
 /// prefix/suffix validation (BG, GB, NK, KN, TN, NT, ZZ excluded; suffix
 /// must be A-D) on top of these shape-only patterns.
-pub mod uk_ni {
+pub(crate) mod uk_ni {
     use super::*;
 
     /// Bare UK NINO shape: 2 letters + 6 digits + 1 letter
@@ -427,7 +427,7 @@ pub mod uk_ni {
 }
 
 /// Spain NIF (Numero de Identificacion Fiscal) patterns
-pub mod spain_nif {
+pub(crate) mod spain_nif {
     use super::*;
 
     /// NIF format: 8 digits + 1 check letter
@@ -446,7 +446,7 @@ pub mod spain_nif {
 }
 
 /// Spain NIE (Numero de Identidad de Extranjero) patterns
-pub mod spain_nie {
+pub(crate) mod spain_nie {
     use super::*;
 
     /// NIE format: X/Y/Z + 7 digits + 1 check letter
@@ -465,7 +465,7 @@ pub mod spain_nie {
 }
 
 /// Italy Codice Fiscale (fiscal code) patterns
-pub mod italy_fiscal_code {
+pub(crate) mod italy_fiscal_code {
     use super::*;
 
     /// Codice Fiscale format: 6 letters + 2 digits + 1 letter + 2 digits + 1 letter + 3 digits + 1 letter
@@ -488,7 +488,7 @@ pub mod italy_fiscal_code {
 }
 
 /// Poland PESEL (personal identity number) patterns
-pub mod poland_pesel {
+pub(crate) mod poland_pesel {
     use super::*;
 
     /// PESEL format: 11 consecutive digits (YYMMDDNNNCC)
@@ -508,7 +508,7 @@ pub mod poland_pesel {
     }
 }
 
-pub mod personal_name {
+pub(crate) mod personal_name {
     use super::*;
 
     /// First Last (with optional middle initial/name)
@@ -541,7 +541,7 @@ pub mod personal_name {
 /// Birthdate and date patterns
 ///
 /// Supports multiple date formats commonly used for birthdates.
-pub mod birthdate {
+pub(crate) mod birthdate {
     use super::*;
 
     /// ISO format: YYYY-MM-DD


### PR DESCRIPTION
## Summary

Narrow **37 inline `pub mod foo { ... }` blocks** across 5 pattern files in `primitives/identifiers/common/patterns/` to `pub(crate) mod`. The effective visibility was already crate-internal (the parent `common/mod.rs:18` declares `pub(crate) mod patterns;`), so this is a clarity / future-proofing change with no behavioral impact.

The `pub use` re-exports in `patterns/mod.rs` are also narrowed to `pub(crate) use` because Rust forbids `pub use`-ing a `pub(crate)` module. No external caller used the short re-export path (`common::patterns::ssn` etc.) — Layer 3 code reaches in via the deeper path (`common::patterns::personal::ssn` etc.), so these re-exports are dead code at the public-API boundary.

### Files changed (6)

| File | Sites |
| ---- | ----- |
| `credentials.rs` | 4 |
| `financial.rs` | 6 (incl. nested `pub mod brand` inside `pub mod credit_card`) |
| `network.rs` | 3 |
| `organizational.rs` | 3 |
| `personal.rs` | 21 |
| `mod.rs` | 3 `pub use` → `pub(crate) use` |

### Note: issue body was stale

The issue claimed "93 `pub mod` declarations across 36 `mod.rs` files" with a per-subdirectory breakdown (auth=10, crypto=2, data/paths=22, identifiers=37, io=3, runtime=1, security=18). That work was already done in earlier PRs — independent verification confirms:

- All `mod.rs` files under `primitives/` already use `pub(crate) mod` for child declarations.
- The `runtime/mod.rs:345` doctest already has `,ignore`.

The only residual sites were the 37 inline blocks fixed here.

### Why arch-check didn't catch this

`scripts/arch_check/checks/` covers `builder_visibility`, `layer_boundary`, `naming_prefix`, `naming_return_type`, `type_visibility`, and `unwrapped_fn`. None enforce inline `pub mod` visibility — a follow-up rule could be filed if these keep slipping.

## Test plan

- [x] `cargo check -p octarine --all-features --all-targets` — clean
- [x] `just preflight` — fmt + clippy + arch-check + 6486 unit + 33+9+30+77+43+5+264+61+7 integration + 241 doctests, all green
- [ ] CI under coverage instrumentation — the actual proof point

Closes #91