### PR TITLE
refactor(observe): convert Layer 3 builders to 2-arg observe API

### DIFF
--- a/crates/octarine/src/data/text/builder.rs
+++ b/crates/octarine/src/data/text/builder.rs
@@ -12,7 +12,7 @@
 use std::borrow::Cow;
 use std::time::Instant;
 
-use crate::observe::event;
+use crate::observe;
 use crate::observe::metrics::{increment_by, record};
 use crate::primitives::data::text::TextBuilder as PrimitiveTextBuilder;
 use crate::primitives::data::text::TextConfig as PrimitiveTextConfig;
@@ -149,7 +149,7 @@ impl<'a> TextBuilder<'a> {
     pub fn is_control_chars_present(&self) -> bool {
         let result = self.inner.is_control_chars_present();
         if self.emit_events && result {
-            event::debug("text.control_chars_detected");
+            observe::debug("control_chars_detected", "Control characters detected");
         }
         result
     }
@@ -158,7 +158,10 @@ impl<'a> TextBuilder<'a> {
     pub fn is_dangerous_control_chars_present(&self) -> bool {
         let result = self.inner.is_dangerous_control_chars_present();
         if self.emit_events && result {
-            event::warn("text.dangerous_control_chars_detected");
+            observe::warn(
+                "dangerous_control_chars_detected",
+                "Dangerous control characters detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -168,7 +171,7 @@ impl<'a> TextBuilder<'a> {
     pub fn is_null_bytes_present(&self) -> bool {
         let result = self.inner.is_null_bytes_present();
         if self.emit_events && result {
-            event::warn("text.null_bytes_detected");
+            observe::warn("null_bytes_detected", "Null bytes detected in text");
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -178,7 +181,7 @@ impl<'a> TextBuilder<'a> {
     pub fn is_ansi_escapes_present(&self) -> bool {
         let result = self.inner.is_ansi_escapes_present();
         if self.emit_events && result {
-            event::debug("text.ansi_escapes_detected");
+            observe::debug("ansi_escapes_detected", "ANSI escape sequences detected");
         }
         result
     }
@@ -205,7 +208,10 @@ impl<'a> TextBuilder<'a> {
     pub fn is_cursor_controls_present(&self) -> bool {
         let result = self.inner.is_cursor_controls_present();
         if self.emit_events && result {
-            event::warn("text.cursor_controls_detected");
+            observe::warn(
+                "cursor_controls_detected",
+                "Cursor control sequences detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -215,7 +221,7 @@ impl<'a> TextBuilder<'a> {
     pub fn is_bell_present(&self) -> bool {
         let result = self.inner.is_bell_present();
         if self.emit_events && result {
-            event::debug("text.bell_char_detected");
+            observe::debug("bell_char_detected", "Bell character detected");
         }
         result
     }
@@ -224,7 +230,7 @@ impl<'a> TextBuilder<'a> {
     pub fn is_backspace_present(&self) -> bool {
         let result = self.inner.is_backspace_present();
         if self.emit_events && result {
-            event::debug("text.backspace_detected");
+            observe::debug("backspace_detected", "Backspace character detected");
         }
         result
     }
@@ -233,7 +239,10 @@ impl<'a> TextBuilder<'a> {
     pub fn is_zero_width_chars_present(&self) -> bool {
         let result = self.inner.is_zero_width_chars_present();
         if self.emit_events && result {
-            event::warn("text.zero_width_chars_detected");
+            observe::warn(
+                "zero_width_chars_detected",
+                "Zero-width characters detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -243,7 +252,10 @@ impl<'a> TextBuilder<'a> {
     pub fn is_bidi_overrides_present(&self) -> bool {
         let result = self.inner.is_bidi_overrides_present();
         if self.emit_events && result {
-            event::warn("text.bidi_overrides_detected");
+            observe::warn(
+                "bidi_overrides_detected",
+                "Bidirectional override characters detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -263,7 +275,10 @@ impl<'a> TextBuilder<'a> {
     pub fn is_mixed_script_present(&self) -> bool {
         let result = self.inner.is_mixed_script_present();
         if self.emit_events && result {
-            event::warn("text.mixed_script_detected");
+            observe::warn(
+                "mixed_script_detected",
+                "Mixed-script (homograph) pattern detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -279,7 +294,10 @@ impl<'a> TextBuilder<'a> {
     pub fn is_confusable_chars_present(&self) -> bool {
         let result = self.inner.is_confusable_chars_present();
         if self.emit_events && result {
-            event::warn("text.confusable_chars_detected");
+            observe::warn(
+                "confusable_chars_detected",
+                "Confusable characters detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -289,7 +307,10 @@ impl<'a> TextBuilder<'a> {
     pub fn is_format_chars_present(&self) -> bool {
         let result = self.inner.is_format_chars_present();
         if self.emit_events && result {
-            event::warn("text.format_chars_detected");
+            observe::warn(
+                "format_chars_detected",
+                "Format control characters detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -299,7 +320,10 @@ impl<'a> TextBuilder<'a> {
     pub fn is_private_use_present(&self) -> bool {
         let result = self.inner.is_private_use_present();
         if self.emit_events && result {
-            event::warn("text.private_use_chars_detected");
+            observe::warn(
+                "private_use_chars_detected",
+                "Private-use area characters detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result

--- a/crates/octarine/src/identifiers/builder/biometric.rs
+++ b/crates/octarine/src/identifiers/builder/biometric.rs
@@ -17,7 +17,7 @@ use std::borrow::Cow;
 use std::time::Instant;
 
 use crate::observe::metrics::{MetricName, increment_by, record};
-use crate::observe::{Problem, event};
+use crate::observe::{self, Problem};
 use crate::primitives::identifiers::BiometricIdentifierBuilder;
 
 use super::super::types::{
@@ -124,7 +124,10 @@ impl BiometricBuilder {
             if result.is_some() {
                 increment_by(metric_names::detected(), 1);
                 increment_by(metric_names::biometric_data_found(), 1);
-                event::debug("Biometric identifier detected".to_string());
+                observe::debug(
+                    "biometric_identifier_detected",
+                    "Biometric identifier detected",
+                );
             }
         }
 
@@ -143,7 +146,7 @@ impl BiometricBuilder {
             );
             if result {
                 increment_by(metric_names::biometric_data_found(), 1);
-                event::debug("Biometric data detected".to_string());
+                observe::debug("biometric_data_detected", "Biometric data detected");
             }
         }
 
@@ -155,7 +158,7 @@ impl BiometricBuilder {
         let result = self.inner.is_fingerprint(value);
 
         if self.emit_events && result {
-            event::debug("Fingerprint identifier detected".to_string());
+            observe::debug("fingerprint_detected", "Fingerprint identifier detected");
         }
 
         result
@@ -166,7 +169,10 @@ impl BiometricBuilder {
         let result = self.inner.is_facial_recognition(value);
 
         if self.emit_events && result {
-            event::debug("Facial recognition data detected".to_string());
+            observe::debug(
+                "facial_recognition_detected",
+                "Facial recognition data detected",
+            );
         }
 
         result
@@ -177,7 +183,7 @@ impl BiometricBuilder {
         let result = self.inner.is_iris_scan(value);
 
         if self.emit_events && result {
-            event::debug("Iris scan detected".to_string());
+            observe::debug("iris_scan_detected", "Iris scan detected");
         }
 
         result
@@ -188,7 +194,7 @@ impl BiometricBuilder {
         let result = self.inner.is_voice_print(value);
 
         if self.emit_events && result {
-            event::debug("Voice print detected".to_string());
+            observe::debug("voice_print_detected", "Voice print detected");
         }
 
         result
@@ -199,7 +205,7 @@ impl BiometricBuilder {
         let result = self.inner.is_dna_sequence(value);
 
         if self.emit_events && result {
-            event::debug("DNA sequence detected".to_string());
+            observe::debug("dna_sequence_detected", "DNA sequence detected");
         }
 
         result
@@ -210,7 +216,7 @@ impl BiometricBuilder {
         let result = self.inner.is_biometric_template(value);
 
         if self.emit_events && result {
-            event::debug("Biometric template detected".to_string());
+            observe::debug("biometric_template_detected", "Biometric template detected");
         }
 
         result
@@ -228,7 +234,10 @@ impl BiometricBuilder {
             );
             if result {
                 increment_by(metric_names::biometric_data_found(), 1);
-                event::debug("Biometric data present in text".to_string());
+                observe::debug(
+                    "biometric_present_in_text",
+                    "Biometric data present in text",
+                );
             }
         }
 
@@ -267,7 +276,10 @@ impl BiometricBuilder {
         let results = self.inner.detect_fingerprints_in_text(text);
 
         if self.emit_events && !results.is_empty() {
-            event::debug(format!("Found {} fingerprint(s) in text", results.len()));
+            observe::debug(
+                "fingerprints_found",
+                format!("Found {} fingerprint(s) in text", results.len()),
+            );
         }
 
         results
@@ -279,10 +291,13 @@ impl BiometricBuilder {
         let results = self.inner.detect_facial_data_in_text(text);
 
         if self.emit_events && !results.is_empty() {
-            event::debug(format!(
-                "Found {} facial recognition identifier(s) in text",
-                results.len()
-            ));
+            observe::debug(
+                "facial_data_found",
+                format!(
+                    "Found {} facial recognition identifier(s) in text",
+                    results.len()
+                ),
+            );
         }
 
         results
@@ -294,7 +309,10 @@ impl BiometricBuilder {
         let results = self.inner.detect_iris_scans_in_text(text);
 
         if self.emit_events && !results.is_empty() {
-            event::debug(format!("Found {} iris scan(s) in text", results.len()));
+            observe::debug(
+                "iris_scans_found",
+                format!("Found {} iris scan(s) in text", results.len()),
+            );
         }
 
         results
@@ -306,7 +324,10 @@ impl BiometricBuilder {
         let results = self.inner.detect_voice_prints_in_text(text);
 
         if self.emit_events && !results.is_empty() {
-            event::debug(format!("Found {} voice print(s) in text", results.len()));
+            observe::debug(
+                "voice_prints_found",
+                format!("Found {} voice print(s) in text", results.len()),
+            );
         }
 
         results
@@ -318,7 +339,10 @@ impl BiometricBuilder {
         let results = self.inner.detect_dna_sequences_in_text(text);
 
         if self.emit_events && !results.is_empty() {
-            event::debug(format!("Found {} DNA sequence(s) in text", results.len()));
+            observe::debug(
+                "dna_sequences_found",
+                format!("Found {} DNA sequence(s) in text", results.len()),
+            );
         }
 
         results
@@ -330,10 +354,10 @@ impl BiometricBuilder {
         let results = self.inner.detect_biometric_templates_in_text(text);
 
         if self.emit_events && !results.is_empty() {
-            event::debug(format!(
-                "Found {} biometric template(s) in text",
-                results.len()
-            ));
+            observe::debug(
+                "biometric_templates_found",
+                format!("Found {} biometric template(s) in text", results.len()),
+            );
         }
 
         results
@@ -352,10 +376,10 @@ impl BiometricBuilder {
             );
             if !results.is_empty() {
                 increment_by(metric_names::detected(), results.len() as u64);
-                event::debug(format!(
-                    "Found {} biometric identifier(s) in text",
-                    results.len()
-                ));
+                observe::debug(
+                    "biometric_identifiers_found",
+                    format!("Found {} biometric identifier(s) in text", results.len()),
+                );
             }
         }
 
@@ -381,7 +405,10 @@ impl BiometricBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid fingerprint ID format".to_string());
+                observe::warn(
+                    "fingerprint_id_validation_failed",
+                    "Invalid fingerprint ID format",
+                );
             }
         }
 
@@ -403,7 +430,7 @@ impl BiometricBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid facial ID format".to_string());
+                observe::warn("facial_id_validation_failed", "Invalid facial ID format");
             }
         }
 
@@ -425,7 +452,7 @@ impl BiometricBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid iris ID format".to_string());
+                observe::warn("iris_id_validation_failed", "Invalid iris ID format");
             }
         }
 
@@ -447,7 +474,7 @@ impl BiometricBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid voice ID format".to_string());
+                observe::warn("voice_id_validation_failed", "Invalid voice ID format");
             }
         }
 

--- a/crates/octarine/src/identifiers/builder/government.rs
+++ b/crates/octarine/src/identifiers/builder/government.rs
@@ -16,7 +16,7 @@
 use std::time::Instant;
 
 use crate::observe::metrics::{MetricName, increment_by, record};
-use crate::observe::{Problem, event};
+use crate::observe::{self, Problem};
 use crate::primitives::identifiers::{
     DriverLicenseRedactionStrategy, GovernmentIdentifierBuilder, NationalIdRedactionStrategy,
     PassportRedactionStrategy, SsnRedactionStrategy, TaxIdRedactionStrategy,
@@ -122,7 +122,7 @@ impl GovernmentBuilder {
             if result {
                 increment_by(metric_names::detected(), 1);
                 increment_by(metric_names::government_data_found(), 1);
-                event::debug("SSN pattern detected".to_string());
+                observe::debug("ssn_detected", "SSN pattern detected");
             }
         }
 
@@ -142,7 +142,10 @@ impl GovernmentBuilder {
             );
             if !results.is_empty() {
                 increment_by(metric_names::detected(), results.len() as u64);
-                event::debug(format!("Found {} SSN(s) in text", results.len()));
+                observe::debug(
+                    "ssns_found",
+                    format!("Found {} SSN(s) in text", results.len()),
+                );
             }
         }
 
@@ -164,7 +167,7 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid SSN format".to_string());
+                observe::warn("ssn_validation_failed", "Invalid SSN format");
             }
         }
 
@@ -376,7 +379,10 @@ impl GovernmentBuilder {
         let result = self.inner.validate_passport(passport);
 
         if self.emit_events && result.is_err() {
-            event::warn("Invalid passport number format".to_string());
+            observe::warn(
+                "passport_validation_failed",
+                "Invalid passport number format",
+            );
         }
 
         result
@@ -428,7 +434,10 @@ impl GovernmentBuilder {
         let result = self.inner.validate_national_id(national_id);
 
         if self.emit_events && result.is_err() {
-            event::warn("Invalid national ID format".to_string());
+            observe::warn(
+                "national_id_validation_failed",
+                "Invalid national ID format",
+            );
         }
 
         result
@@ -509,7 +518,10 @@ impl GovernmentBuilder {
             if !results.is_empty() {
                 increment_by(metric_names::detected(), results.len() as u64);
                 increment_by(metric_names::government_data_found(), results.len() as u64);
-                event::debug(format!("Found {} UK NINO(s) in text", results.len()));
+                observe::debug(
+                    "uk_nis_found",
+                    format!("Found {} UK NINO(s) in text", results.len()),
+                );
             }
         }
         results
@@ -651,7 +663,10 @@ impl GovernmentBuilder {
             );
             if result {
                 increment_by(metric_names::government_data_found(), 1);
-                event::debug("Government identifier present in text".to_string());
+                observe::debug(
+                    "government_id_detected",
+                    "Government identifier present in text",
+                );
             }
         }
 
@@ -844,7 +859,10 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid Australia TFN format".to_string());
+                observe::warn(
+                    "australia_tfn_validation_failed",
+                    "Invalid Australia TFN format",
+                );
             }
         }
         result
@@ -883,7 +901,10 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid Australia ABN format".to_string());
+                observe::warn(
+                    "australia_abn_validation_failed",
+                    "Invalid Australia ABN format",
+                );
             }
         }
         result
@@ -926,7 +947,10 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid India Aadhaar format".to_string());
+                observe::warn(
+                    "india_aadhaar_validation_failed",
+                    "Invalid India Aadhaar format",
+                );
             }
         }
         result
@@ -965,7 +989,7 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid India PAN format".to_string());
+                observe::warn("india_pan_validation_failed", "Invalid India PAN format");
             }
         }
         result
@@ -1003,7 +1027,10 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid Finland HETU format".to_string());
+                observe::warn(
+                    "finland_hetu_validation_failed",
+                    "Invalid Finland HETU format",
+                );
             }
         }
         result
@@ -1046,7 +1073,7 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid Spain NIF format".to_string());
+                observe::warn("spain_nif_validation_failed", "Invalid Spain NIF format");
             }
         }
         result
@@ -1085,7 +1112,7 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid Spain NIE format".to_string());
+                observe::warn("spain_nie_validation_failed", "Invalid Spain NIE format");
             }
         }
         result
@@ -1128,7 +1155,10 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid Italy Codice Fiscale format".to_string());
+                observe::warn(
+                    "italy_fiscal_code_validation_failed",
+                    "Invalid Italy Codice Fiscale format",
+                );
             }
         }
         result
@@ -1171,7 +1201,10 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid Poland PESEL format".to_string());
+                observe::warn(
+                    "poland_pesel_validation_failed",
+                    "Invalid Poland PESEL format",
+                );
             }
         }
         result
@@ -1214,7 +1247,10 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid Singapore NRIC format".to_string());
+                observe::warn(
+                    "singapore_nric_validation_failed",
+                    "Invalid Singapore NRIC format",
+                );
             }
         }
         result
@@ -1257,7 +1293,7 @@ impl GovernmentBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn("Invalid Korea RRN format".to_string());
+                observe::warn("korea_rrn_validation_failed", "Invalid Korea RRN format");
             }
         }
         result

--- a/crates/octarine/src/observe/builder/event_shortcuts.rs
+++ b/crates/octarine/src/observe/builder/event_shortcuts.rs
@@ -46,3 +46,10 @@ pub fn trace(operation: &str, message: impl Into<String>) {
         .message(message)
         .trace();
 }
+
+/// Log critical with operation context
+pub fn critical(operation: &str, message: impl Into<String>) {
+    ObserveBuilder::for_operation(operation)
+        .message(message)
+        .critical();
+}

--- a/crates/octarine/src/observe/mod.rs
+++ b/crates/octarine/src/observe/mod.rs
@@ -336,7 +336,9 @@ pub use context::{LocalNetworkContext, get_local_network, refresh_local_network}
 pub use builder::ObserveBuilder;
 
 // Simple shortcuts for common operations (no Problem return)
-pub use shortcuts::{auth_success, debug, error, info, success, trace, validation_success, warn};
+pub use shortcuts::{
+    auth_success, critical, debug, error, info, success, trace, validation_success, warn,
+};
 
 // Error handling shortcuts (return Problems)
 pub use shortcuts::{fail, fail_permission, fail_security, fail_validation, todo};

--- a/crates/octarine/src/observe/shortcuts.rs
+++ b/crates/octarine/src/observe/shortcuts.rs
@@ -41,6 +41,11 @@ pub fn trace(operation: &str, message: impl Into<String>) {
     event_shortcuts::trace(operation, message);
 }
 
+/// Log a critical message with operation context
+pub fn critical(operation: &str, message: impl Into<String>) {
+    event_shortcuts::critical(operation, message);
+}
+
 /// Log a validation success
 pub fn validation_success(message: impl Into<String>) {
     success("validation", message);

--- a/crates/octarine/src/security/commands/builder.rs
+++ b/crates/octarine/src/security/commands/builder.rs
@@ -81,7 +81,10 @@ impl CommandSecurityBuilder {
     pub fn is_dangerous(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_dangerous(arg);
         if result {
-            observe::event::critical("Command injection detected in argument");
+            observe::critical(
+                "command_injection_detected",
+                "Command injection detected in argument",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -94,10 +97,10 @@ impl CommandSecurityBuilder {
 
         if !threats.is_empty() {
             let threat_names: Vec<_> = threats.iter().map(|t| t.description()).collect();
-            observe::event::critical(format!(
-                "Command threats detected: {}",
-                threat_names.join(", ")
-            ));
+            observe::critical(
+                "command_threats_detected",
+                format!("Command threats detected: {}", threat_names.join(", ")),
+            );
             increment_by(metric_names::threats_detected(), threats.len() as u64);
         }
 
@@ -249,7 +252,10 @@ impl CommandSecurityBuilder {
         );
 
         if let Err(ref e) = result {
-            observe::event::critical(format!("Command argument validation failed: {}", e));
+            observe::critical(
+                "command_argument_validation_failed",
+                format!("Command argument validation failed: {e}"),
+            );
         }
 
         result
@@ -266,7 +272,10 @@ impl CommandSecurityBuilder {
             .validate_command_allowed(command, prim_allowlist);
 
         if result.is_err() {
-            observe::event::critical(format!("Command '{}' not in allow-list", command));
+            observe::critical(
+                "command_not_allowed",
+                format!("Command '{command}' not in allow-list"),
+            );
         }
 
         result
@@ -298,7 +307,10 @@ impl CommandSecurityBuilder {
         let result = PrimitiveCommandSecurityBuilder::new().validate_env(name, value);
 
         if result.is_err() {
-            observe::event::critical(format!("Command env validation failed: {}", name));
+            observe::critical(
+                "command_env_validation_failed",
+                format!("Command env validation failed: {name}"),
+            );
         }
 
         result

--- a/crates/octarine/src/security/network/builder.rs
+++ b/crates/octarine/src/security/network/builder.rs
@@ -12,7 +12,7 @@
 use std::time::Instant;
 
 use crate::observe::metrics::{increment_by, record};
-use crate::observe::{Problem, event};
+use crate::observe::{self, Problem};
 use crate::primitives::security::network::NetworkSecurityBuilder as PrimitiveNetworkSecurityBuilder;
 
 use super::types::{HostType, NetworkSecurityHostnameConfig, NetworkSecurityUrlConfig, PortRange};
@@ -137,7 +137,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_dangerous_scheme(url);
 
         if self.emit_events && result {
-            event::warn(format!("Dangerous scheme detected: {}", url));
+            observe::warn(
+                "dangerous_scheme_detected",
+                format!("Dangerous scheme detected: {url}"),
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
 
@@ -159,7 +162,7 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_localhost(host);
 
         if self.emit_events && result {
-            event::debug(format!("Localhost detected: {}", host));
+            observe::debug("localhost_detected", format!("Localhost detected: {host}"));
         }
 
         result
@@ -170,7 +173,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_internal_domain_pattern(host);
 
         if self.emit_events && result {
-            event::debug(format!("Internal domain pattern detected: {}", host));
+            observe::debug(
+                "internal_domain_detected",
+                format!("Internal domain pattern detected: {host}"),
+            );
         }
 
         result
@@ -181,7 +187,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_private_ipv4_range(ip);
 
         if self.emit_events && result {
-            event::debug(format!("Private IPv4 range detected: {}", ip));
+            observe::debug(
+                "private_ipv4_detected",
+                format!("Private IPv4 range detected: {ip}"),
+            );
         }
 
         result
@@ -192,7 +201,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_loopback_ipv4_range(ip);
 
         if self.emit_events && result {
-            event::debug(format!("Loopback IPv4 range detected: {}", ip));
+            observe::debug(
+                "loopback_ipv4_detected",
+                format!("Loopback IPv4 range detected: {ip}"),
+            );
         }
 
         result
@@ -203,7 +215,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_link_local_ipv4_range(ip);
 
         if self.emit_events && result {
-            event::debug(format!("Link-local IPv4 range detected: {}", ip));
+            observe::debug(
+                "link_local_ipv4_detected",
+                format!("Link-local IPv4 range detected: {ip}"),
+            );
         }
 
         result
@@ -214,7 +229,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_private_ipv6(ip);
 
         if self.emit_events && result {
-            event::debug(format!("Private IPv6 detected: {}", ip));
+            observe::debug(
+                "private_ipv6_detected",
+                format!("Private IPv6 detected: {ip}"),
+            );
         }
 
         result
@@ -225,7 +243,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_internal_host(host);
 
         if self.emit_events && result {
-            event::debug(format!("Internal host detected: {}", host));
+            observe::debug(
+                "internal_host_detected",
+                format!("Internal host detected: {host}"),
+            );
         }
 
         result
@@ -240,7 +261,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_cloud_metadata_endpoint(url);
 
         if self.emit_events && result {
-            event::critical(format!("Cloud metadata access detected: {}", url));
+            observe::critical(
+                "cloud_metadata_endpoint_detected",
+                format!("Cloud metadata access detected: {url}"),
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
 
@@ -252,7 +276,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_metadata_pattern_present(host);
 
         if self.emit_events && result {
-            event::debug(format!("Metadata pattern present: {}", host));
+            observe::debug(
+                "metadata_pattern_detected",
+                format!("Metadata pattern present: {host}"),
+            );
         }
 
         result
@@ -267,7 +294,10 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_url_shortener(url);
 
         if self.emit_events && result {
-            event::debug(format!("URL shortener detected: {}", url));
+            observe::debug(
+                "url_shortener_detected",
+                format!("URL shortener detected: {url}"),
+            );
         }
 
         result
@@ -288,7 +318,7 @@ impl NetworkSecurityBuilder {
         let result = self.inner.is_potential_ssrf(url_or_host);
 
         if self.emit_events && result {
-            event::critical(format!("SSRF detected: {}", url_or_host));
+            observe::critical("ssrf_detected", format!("SSRF detected: {url_or_host}"));
             increment_by(metric_names::threats_detected(), 1);
         }
 
@@ -320,9 +350,15 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::critical(format!("SSRF validation failed: {}", url));
+                observe::critical(
+                    "ssrf_validation_failed",
+                    format!("SSRF validation failed: {url}"),
+                );
             } else {
-                event::debug(format!("SSRF validation passed: {}", url));
+                observe::debug(
+                    "ssrf_validation_passed",
+                    format!("SSRF validation passed: {url}"),
+                );
             }
         }
 
@@ -344,7 +380,10 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::critical(format!("Internal URL blocked: {}", url));
+                observe::critical(
+                    "internal_url_blocked",
+                    format!("Internal URL blocked: {url}"),
+                );
             }
         }
 
@@ -366,7 +405,10 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::critical(format!("Dangerous scheme blocked: {}", url));
+                observe::critical(
+                    "dangerous_scheme_blocked",
+                    format!("Dangerous scheme blocked: {url}"),
+                );
             }
         }
 
@@ -388,7 +430,10 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::critical(format!("Cloud metadata blocked: {}", url));
+                observe::critical(
+                    "cloud_metadata_blocked",
+                    format!("Cloud metadata blocked: {url}"),
+                );
             }
         }
 
@@ -410,7 +455,10 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!("URL shortener blocked: {}", url));
+                observe::warn(
+                    "url_shortener_blocked",
+                    format!("URL shortener blocked: {url}"),
+                );
             }
         }
 
@@ -436,7 +484,7 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!("Invalid URL format: {}", url));
+                observe::warn("url_format_invalid", format!("Invalid URL format: {url}"));
             }
         }
 
@@ -459,7 +507,10 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!("URL scheme not allowed: {}", url));
+                observe::warn(
+                    "url_scheme_not_allowed",
+                    format!("URL scheme not allowed: {url}"),
+                );
             }
         }
 
@@ -482,7 +533,7 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!("HTTPS required: {}", url));
+                observe::warn("https_required", format!("HTTPS required: {url}"));
             }
         }
 
@@ -508,7 +559,7 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!("Invalid hostname: {}", hostname));
+                observe::warn("hostname_invalid", format!("Invalid hostname: {hostname}"));
             }
         }
 
@@ -533,7 +584,7 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!("Invalid hostname: {}", hostname));
+                observe::warn("hostname_invalid", format!("Invalid hostname: {hostname}"));
             }
         }
 
@@ -559,11 +610,10 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!(
-                    "Hostname too long: {} (max {})",
-                    hostname.len(),
-                    max_length
-                ));
+                observe::warn(
+                    "hostname_too_long",
+                    format!("Hostname too long: {} (max {})", hostname.len(), max_length),
+                );
             }
         }
 
@@ -589,7 +639,7 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!("Invalid port: {}", port));
+                observe::warn("port_invalid", format!("Invalid port: {port}"));
             }
         }
 
@@ -611,7 +661,7 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!("Port {} out of range", port));
+                observe::warn("port_out_of_range", format!("Port {port} out of range"));
             }
         }
 
@@ -633,7 +683,7 @@ impl NetworkSecurityBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if result.is_err() {
-                event::warn(format!("Invalid port string: {}", s));
+                observe::warn("port_parse_failed", format!("Invalid port string: {s}"));
             }
         }
 

--- a/crates/octarine/src/security/queries/builder.rs
+++ b/crates/octarine/src/security/queries/builder.rs
@@ -4,7 +4,7 @@
 
 use std::time::Instant;
 
-use crate::observe::event;
+use crate::observe;
 use crate::observe::metrics::{increment_by, record};
 use crate::primitives::security::queries::{
     GraphqlAnalysis, GraphqlConfig, GraphqlSchema, QuerySecurityBuilder as PrimitiveBuilder,
@@ -83,7 +83,7 @@ impl QueryBuilder {
     pub fn is_sql_injection_present(&self, input: &str) -> bool {
         let result = self.inner.is_sql_injection_present(input);
         if self.emit_events && result {
-            event::warn("security: SQL injection pattern detected");
+            observe::warn("sql_injection_detected", "SQL injection pattern detected");
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -100,10 +100,10 @@ impl QueryBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if !threats.is_empty() {
-                event::warn(format!(
-                    "security: Detected {} SQL injection threats",
-                    threats.len()
-                ));
+                observe::warn(
+                    "sql_threats_detected",
+                    format!("Detected {} SQL injection threats", threats.len()),
+                );
                 increment_by(metric_names::threats_detected(), threats.len() as u64);
             }
         }
@@ -121,7 +121,10 @@ impl QueryBuilder {
             );
         }
         if result.is_err() {
-            event::warn("security: SQL parameter validation failed");
+            observe::warn(
+                "sql_parameter_validation_failed",
+                "SQL parameter validation failed",
+            );
         }
         result
     }
@@ -147,7 +150,10 @@ impl QueryBuilder {
     pub fn is_nosql_injection_present(&self, input: &str) -> bool {
         let result = self.inner.is_nosql_injection_present(input);
         if self.emit_events && result {
-            event::warn("security: NoSQL injection pattern detected");
+            observe::warn(
+                "nosql_injection_detected",
+                "NoSQL injection pattern detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -164,10 +170,10 @@ impl QueryBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if !threats.is_empty() {
-                event::warn(format!(
-                    "security: Detected {} NoSQL injection threats",
-                    threats.len()
-                ));
+                observe::warn(
+                    "nosql_threats_detected",
+                    format!("Detected {} NoSQL injection threats", threats.len()),
+                );
                 increment_by(metric_names::threats_detected(), threats.len() as u64);
             }
         }
@@ -185,7 +191,10 @@ impl QueryBuilder {
             );
         }
         if result.is_err() {
-            event::warn("security: NoSQL value validation failed");
+            observe::warn(
+                "nosql_value_validation_failed",
+                "NoSQL value validation failed",
+            );
         }
         result
     }
@@ -223,7 +232,7 @@ impl QueryBuilder {
     pub fn is_ldap_injection_present(&self, input: &str) -> bool {
         let result = self.inner.is_ldap_injection_present(input);
         if self.emit_events && result {
-            event::warn("security: LDAP injection pattern detected");
+            observe::warn("ldap_injection_detected", "LDAP injection pattern detected");
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -240,10 +249,10 @@ impl QueryBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if !threats.is_empty() {
-                event::warn(format!(
-                    "security: Detected {} LDAP injection threats",
-                    threats.len()
-                ));
+                observe::warn(
+                    "ldap_threats_detected",
+                    format!("Detected {} LDAP injection threats", threats.len()),
+                );
                 increment_by(metric_names::threats_detected(), threats.len() as u64);
             }
         }
@@ -261,7 +270,10 @@ impl QueryBuilder {
             );
         }
         if result.is_err() {
-            event::warn("security: LDAP filter validation failed");
+            observe::warn(
+                "ldap_filter_validation_failed",
+                "LDAP filter validation failed",
+            );
         }
         result
     }
@@ -287,7 +299,10 @@ impl QueryBuilder {
     pub fn is_graphql_injection_present(&self, query: &str) -> bool {
         let result = self.inner.is_graphql_injection_present(query);
         if self.emit_events && result {
-            event::warn("security: GraphQL abuse pattern detected");
+            observe::warn(
+                "graphql_injection_detected",
+                "GraphQL abuse pattern detected",
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result
@@ -304,10 +319,10 @@ impl QueryBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if !threats.is_empty() {
-                event::warn(format!(
-                    "security: Detected {} GraphQL threats",
-                    threats.len()
-                ));
+                observe::warn(
+                    "graphql_threats_detected",
+                    format!("Detected {} GraphQL threats", threats.len()),
+                );
                 increment_by(metric_names::threats_detected(), threats.len() as u64);
             }
         }
@@ -336,7 +351,10 @@ impl QueryBuilder {
             );
         }
         if result.is_err() {
-            event::warn("security: GraphQL query validation failed");
+            observe::warn(
+                "graphql_query_validation_failed",
+                "GraphQL query validation failed",
+            );
         }
         result
     }
@@ -356,11 +374,10 @@ impl QueryBuilder {
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
             if !threats.is_empty() {
-                event::warn(format!(
-                    "security: Detected {} {} threats",
-                    threats.len(),
-                    query_type
-                ));
+                observe::warn(
+                    "query_threats_detected",
+                    format!("Detected {} {} threats", threats.len(), query_type),
+                );
                 increment_by(metric_names::threats_detected(), threats.len() as u64);
             }
         }
@@ -372,10 +389,10 @@ impl QueryBuilder {
     pub fn is_injection_present(&self, input: &str, query_type: QueryType) -> bool {
         let result = self.inner.is_injection_present(input, query_type);
         if self.emit_events && result {
-            event::warn(format!(
-                "security: {} injection pattern detected",
-                query_type
-            ));
+            observe::warn(
+                "query_injection_detected",
+                format!("{query_type} injection pattern detected"),
+            );
             increment_by(metric_names::threats_detected(), 1);
         }
         result


### PR DESCRIPTION
## Summary

Layer 3 builders should call `observe::warn(operation, message)` (2-arg) so the operation name is captured in the audit trail. Six builders still used the legacy 1-arg `event::warn(message)` form, dropping operation context that downstream writers and SOC2/HIPAA reporting depend on.

This PR adds the missing `observe::critical(op, msg)` shortcut and converts ~97 callsites across 6 Layer 3 builders. Severity is preserved exactly (warn→warn, debug→debug, critical→critical) and message text is unchanged where reasonable — module-prefix tags (`text.`, `security:`) are dropped from messages since the operation arg now carries that context.

### New shortcut
- `observe::critical(operation, message)` — wraps `ObserveBuilder::for_operation(op).message(msg).critical()` (mirrors the existing warn/debug/info/error/success/trace shortcuts).

### Files converted
| File | Calls |
|---|---|
| `data/text/builder.rs` | 13 |
| `security/queries/builder.rs` | 14 |
| `identifiers/builder/government.rs` | 18 |
| `identifiers/builder/biometric.rs` | 20 |
| `security/commands/builder.rs` | 5 |
| `security/network/builder.rs` | 27 |

### Out of scope
`crypto/validation/builder.rs`, `runtime/process/command.rs`, and `observe/problem/create.rs` also contain `event::*` calls but are not in #88's scope; they belong to a future issue.

## Test plan

- [x] `just preflight` clean (fmt-check + clippy + arch-check + tests)
- [x] All 7,275 tests pass, 0 failures
- [x] `grep -nE '\bevent::(warn|debug|critical|...)' ` returns zero hits in the 6 target files
- [x] Out-of-scope files (`crypto/validation`, `runtime/process`) untouched
- [x] Imports cleaned up (`event` removed where no longer used)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)