### PR TITLE
fix(observe): add silent mode to 5 Layer 3 builders

### DIFF
--- a/crates/octarine/src/data/formats/builder.rs
+++ b/crates/octarine/src/data/formats/builder.rs
@@ -67,16 +67,16 @@ impl FormatBuilder {
     /// Parse JSON content
     pub fn parse_json(&self, input: &str) -> Result<JsonValue> {
         let start = Instant::now();
-        debug("format.parse", "Parsing JSON content");
         let result = self.inner.parse_json(input);
         if self.emit_events {
+            debug("format.parse", "Parsing JSON content");
             record(
                 metric_names::parse_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            warn("format.parse", "JSON parsing failed");
+            if result.is_err() {
+                warn("format.parse", "JSON parsing failed");
+            }
         }
         result
     }
@@ -84,9 +84,9 @@ impl FormatBuilder {
     /// Serialize value to JSON
     pub fn serialize_json<T: Serialize>(&self, value: &T) -> Result<String> {
         let start = Instant::now();
-        debug("format.serialize", "Serializing to JSON");
         let result = self.inner.serialize_json(value);
         if self.emit_events {
+            debug("format.serialize", "Serializing to JSON");
             record(
                 metric_names::serialize_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
@@ -98,9 +98,9 @@ impl FormatBuilder {
     /// Serialize value to pretty JSON
     pub fn serialize_json_pretty<T: Serialize>(&self, value: &T) -> Result<String> {
         let start = Instant::now();
-        debug("format.serialize", "Serializing to pretty JSON");
         let result = self.inner.serialize_json_pretty(value);
         if self.emit_events {
+            debug("format.serialize", "Serializing to pretty JSON");
             record(
                 metric_names::serialize_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
@@ -116,16 +116,16 @@ impl FormatBuilder {
     /// Parse XML content
     pub fn parse_xml(&self, input: &str) -> Result<XmlDocument> {
         let start = Instant::now();
-        debug("format.parse", "Parsing XML content");
         let result = self.inner.parse_xml(input);
         if self.emit_events {
+            debug("format.parse", "Parsing XML content");
             record(
                 metric_names::parse_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            warn("format.parse", "XML parsing failed");
+            if result.is_err() {
+                warn("format.parse", "XML parsing failed");
+            }
         }
         result
     }
@@ -133,9 +133,9 @@ impl FormatBuilder {
     /// Serialize XML document to string
     pub fn serialize_xml(&self, doc: &XmlDocument) -> Result<String> {
         let start = Instant::now();
-        debug("format.serialize", "Serializing to XML");
         let result = self.inner.serialize_xml(doc);
         if self.emit_events {
+            debug("format.serialize", "Serializing to XML");
             record(
                 metric_names::serialize_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
@@ -151,16 +151,16 @@ impl FormatBuilder {
     /// Parse YAML content
     pub fn parse_yaml(&self, input: &str) -> Result<serde_yaml::Value> {
         let start = Instant::now();
-        debug("format.parse", "Parsing YAML content");
         let result = self.inner.parse_yaml(input);
         if self.emit_events {
+            debug("format.parse", "Parsing YAML content");
             record(
                 metric_names::parse_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            warn("format.parse", "YAML parsing failed");
+            if result.is_err() {
+                warn("format.parse", "YAML parsing failed");
+            }
         }
         result
     }
@@ -168,9 +168,9 @@ impl FormatBuilder {
     /// Serialize value to YAML
     pub fn serialize_yaml<T: Serialize>(&self, value: &T) -> Result<String> {
         let start = Instant::now();
-        debug("format.serialize", "Serializing to YAML");
         let result = self.inner.serialize_yaml(value);
         if self.emit_events {
+            debug("format.serialize", "Serializing to YAML");
             record(
                 metric_names::serialize_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
@@ -187,16 +187,16 @@ impl FormatBuilder {
     #[must_use]
     pub fn detect_format(&self, input: &str) -> Option<FormatType> {
         let start = Instant::now();
-        debug("format.detect", "Detecting format from content");
         let format = self.inner.detect_from_content(input);
         if self.emit_events {
+            debug("format.detect", "Detecting format from content");
             record(
                 metric_names::detect_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if format.is_none() {
-            debug("format.detect", "Could not detect format");
+            if format.is_none() {
+                debug("format.detect", "Could not detect format");
+            }
         }
         format
     }

--- a/crates/octarine/src/identifiers/builder/financial.rs
+++ b/crates/octarine/src/identifiers/builder/financial.rs
@@ -108,6 +108,12 @@ impl FinancialBuilder {
         self
     }
 
+    /// Whether observe events are enabled (used by parent builder tests)
+    #[cfg(test)]
+    pub(crate) fn emit_events(&self) -> bool {
+        self.emit_events
+    }
+
     // ========================================================================
     // Detection Methods
     // ========================================================================

--- a/crates/octarine/src/identifiers/builder/mod.rs
+++ b/crates/octarine/src/identifiers/builder/mod.rs
@@ -140,6 +140,12 @@ mod metric_names {
 /// Provides a single entry point for all identifier operations, delegating to
 /// specialized builders internally.
 ///
+/// Use [`IdentifierBuilder::silent`] or [`IdentifierBuilder::with_events`] to
+/// suppress all observe events and metrics. The silent flag propagates through
+/// the domain accessors (`personal()`, `financial()`, etc.) so that
+/// `IdentifierBuilder::silent().personal()` returns a silent
+/// `PersonalBuilder`.
+///
 /// # Examples
 ///
 /// ```
@@ -157,14 +163,35 @@ mod metric_names {
 /// // Scan text for all identifiers
 /// let matches = builder.scan_text("Email: user@example.com, SSN: 123-45-6789");
 /// ```
-#[derive(Debug, Clone, Copy, Default)]
-pub struct IdentifierBuilder;
+#[derive(Debug, Clone, Copy)]
+pub struct IdentifierBuilder {
+    emit_events: bool,
+}
+
+impl Default for IdentifierBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl IdentifierBuilder {
-    /// Create a new IdentifierBuilder
+    /// Create a new IdentifierBuilder with observe events enabled
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self { emit_events: true }
+    }
+
+    /// Create an IdentifierBuilder that suppresses all observe events and metrics
+    #[must_use]
+    pub fn silent() -> Self {
+        Self { emit_events: false }
+    }
+
+    /// Toggle observe event/metric emission
+    #[must_use]
+    pub fn with_events(mut self, emit: bool) -> Self {
+        self.emit_events = emit;
+        self
     }
 
     // ========================================================================
@@ -174,110 +201,110 @@ impl IdentifierBuilder {
     /// Get personal identifier builder (emails, phones, names, birthdates)
     #[must_use]
     pub fn personal(&self) -> PersonalBuilder {
-        PersonalBuilder::new()
+        PersonalBuilder::new().with_events(self.emit_events)
     }
 
     /// Get financial identifier builder (credit cards, bank accounts)
     #[must_use]
     pub fn financial(&self) -> FinancialBuilder {
-        FinancialBuilder::new()
+        FinancialBuilder::new().with_events(self.emit_events)
     }
 
     /// Get government identifier builder (SSNs, driver licenses, passports)
     #[must_use]
     pub fn government(&self) -> GovernmentBuilder {
-        GovernmentBuilder::new()
+        GovernmentBuilder::new().with_events(self.emit_events)
     }
 
     /// Get network identifier builder (IPs, MACs, URLs, UUIDs)
     #[must_use]
     pub fn network(&self) -> NetworkBuilder {
-        NetworkBuilder::new()
+        NetworkBuilder::new().with_events(self.emit_events)
     }
 
     /// Get credentials identifier builder (API keys, passwords, tokens)
     #[must_use]
     pub fn credentials(&self) -> CredentialsBuilder {
-        CredentialsBuilder::new()
+        CredentialsBuilder::new().with_events(self.emit_events)
     }
 
     /// Get location identifier builder (addresses, GPS coordinates)
     #[must_use]
     pub fn location(&self) -> LocationBuilder {
-        LocationBuilder::new()
+        LocationBuilder::new().with_events(self.emit_events)
     }
 
     /// Get token identifier builder (JWTs, OAuth tokens)
     #[must_use]
     pub fn token(&self) -> TokenBuilder {
-        TokenBuilder::new()
+        TokenBuilder::new().with_events(self.emit_events)
     }
 
     /// Get medical identifier builder (MRNs, health insurance)
     #[must_use]
     pub fn medical(&self) -> MedicalBuilder {
-        MedicalBuilder::new()
+        MedicalBuilder::new().with_events(self.emit_events)
     }
 
     /// Get biometric identifier builder (fingerprints, facial recognition)
     #[must_use]
     pub fn biometric(&self) -> BiometricBuilder {
-        BiometricBuilder::new()
+        BiometricBuilder::new().with_events(self.emit_events)
     }
 
     /// Get organizational identifier builder (employee IDs, badge numbers)
     #[must_use]
     pub fn organizational(&self) -> OrganizationalBuilder {
-        OrganizationalBuilder::new()
+        OrganizationalBuilder::new().with_events(self.emit_events)
     }
 
     /// Get database identifier builder (connection strings)
     #[must_use]
     pub fn database(&self) -> DatabaseBuilder {
-        DatabaseBuilder::new()
+        DatabaseBuilder::new().with_events(self.emit_events)
     }
 
     /// Get environment identifier builder (env vars)
     #[must_use]
     pub fn environment(&self) -> EnvironmentBuilder {
-        EnvironmentBuilder::new()
+        EnvironmentBuilder::new().with_events(self.emit_events)
     }
 
     /// Get generic identifier builder
     #[must_use]
     pub fn generic(&self) -> GenericBuilder {
-        GenericBuilder::new()
+        GenericBuilder::new().with_events(self.emit_events)
     }
 
     /// Get metrics identifier builder
     #[must_use]
     pub fn metrics(&self) -> MetricsBuilder {
-        MetricsBuilder::new()
+        MetricsBuilder::new().with_events(self.emit_events)
     }
 
     /// Get crypto identifier builder (keys, certificates, signatures)
     #[cfg(feature = "crypto-validation")]
     #[must_use]
     pub fn crypto(&self) -> CryptoBuilder {
-        CryptoBuilder::new()
+        CryptoBuilder::new().with_events(self.emit_events)
     }
 
     /// Get entropy identifier builder (high-entropy string detection)
     #[must_use]
     pub fn entropy(&self) -> EntropyBuilder {
-        EntropyBuilder::new()
+        EntropyBuilder::new().with_events(self.emit_events)
     }
 
     /// Get confidence scoring builder (context-aware confidence boosting)
     #[must_use]
     pub fn confidence(&self) -> ConfidenceBuilder {
-        ConfidenceBuilder::new()
+        ConfidenceBuilder::new().with_events(self.emit_events)
     }
 
     /// Get credential pair correlation builder
     #[must_use]
     pub fn correlation(&self) -> CorrelationBuilder {
-        CorrelationBuilder::new()
+        CorrelationBuilder::new().with_events(self.emit_events)
     }
 
     // ========================================================================
@@ -311,10 +338,12 @@ impl IdentifierBuilder {
         // Note: government and credentials builders don't have detect() methods
         // They use specific detection methods like is_ssn(), contains_passwords(), etc.
 
-        record(
-            metric_names::detect_ms(),
-            start.elapsed().as_micros() as f64 / 1000.0,
-        );
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
         None
     }
 
@@ -329,13 +358,14 @@ impl IdentifierBuilder {
         let scanner = StreamingScanner::new(1000);
         let count = scanner.scan_all_identifiers(text);
 
-        record(
-            metric_names::scan_ms(),
-            start.elapsed().as_micros() as f64 / 1000.0,
-        );
-
-        if count > 0 {
-            increment_by(metric_names::detected(), count as u64);
+        if self.emit_events {
+            record(
+                metric_names::scan_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if count > 0 {
+                increment_by(metric_names::detected(), count as u64);
+            }
         }
 
         // Drain and convert matches from primitive to local types
@@ -352,7 +382,7 @@ impl IdentifierBuilder {
             }
         }
 
-        if !matches.is_empty() {
+        if self.emit_events && !matches.is_empty() {
             // Check for sensitive types
             let has_pii = matches.iter().any(|m| is_pii_type(&m.identifier_type));
             if has_pii {
@@ -389,18 +419,20 @@ impl IdentifierBuilder {
     // ========================================================================
 
     fn emit_detection_metrics(&self, start: Instant, id_type: &IdentifierType) {
-        record(
-            metric_names::detect_ms(),
-            start.elapsed().as_micros() as f64 / 1000.0,
-        );
-        increment_by(metric_names::detected(), 1);
-
-        if is_pii_type(id_type) {
-            increment_by(metric_names::pii_found(), 1);
-            observe::debug(
-                "identifier_detected",
-                format!("Identifier type detected: {:?}", id_type),
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
             );
+            increment_by(metric_names::detected(), 1);
+
+            if is_pii_type(id_type) {
+                increment_by(metric_names::pii_found(), 1);
+                observe::debug(
+                    "identifier_detected",
+                    format!("Identifier type detected: {:?}", id_type),
+                );
+            }
         }
     }
 }
@@ -433,7 +465,46 @@ mod tests {
     #[test]
     fn test_identifier_builder_creation() {
         let builder = IdentifierBuilder::new();
+        assert!(builder.emit_events);
         assert!(builder.detect("user@example.com").is_some());
+
+        let silent = IdentifierBuilder::silent();
+        assert!(!silent.emit_events);
+    }
+
+    #[test]
+    fn test_with_events_toggle() {
+        let b = IdentifierBuilder::new().with_events(false);
+        assert!(!b.emit_events);
+
+        let b = IdentifierBuilder::silent().with_events(true);
+        assert!(b.emit_events);
+    }
+
+    #[test]
+    fn test_silent_propagates_to_domain_accessors() {
+        let s = IdentifierBuilder::silent();
+        assert!(!s.personal().emit_events());
+        assert!(!s.financial().emit_events());
+        assert!(!s.network().emit_events());
+
+        let n = IdentifierBuilder::new();
+        assert!(n.personal().emit_events());
+        assert!(n.financial().emit_events());
+        assert!(n.network().emit_events());
+    }
+
+    #[test]
+    fn test_silent_mode_does_not_panic() {
+        // Structural test only — behavioral delta-assertions race with
+        // concurrent tests across the workspace.
+        let s = IdentifierBuilder::silent();
+        assert!(!s.emit_events);
+
+        // Functional sanity: silent builder still detects identifiers.
+        assert_eq!(s.detect("user@example.com"), Some(IdentifierType::Email));
+        let _ = s.scan_text("Email: user@example.com");
+        assert!(s.is_pii_present("Email: user@example.com"));
     }
 
     #[test]

--- a/crates/octarine/src/identifiers/builder/network.rs
+++ b/crates/octarine/src/identifiers/builder/network.rs
@@ -68,6 +68,12 @@ impl NetworkBuilder {
         self
     }
 
+    /// Whether observe events are enabled (used by parent builder tests)
+    #[cfg(test)]
+    pub(crate) fn emit_events(&self) -> bool {
+        self.emit_events
+    }
+
     // ========================================================================
     // Detection Methods
     // ========================================================================

--- a/crates/octarine/src/identifiers/builder/personal.rs
+++ b/crates/octarine/src/identifiers/builder/personal.rs
@@ -80,6 +80,12 @@ impl PersonalBuilder {
         self
     }
 
+    /// Whether observe events are enabled (used by parent builder tests)
+    #[cfg(test)]
+    pub(crate) fn emit_events(&self) -> bool {
+        self.emit_events
+    }
+
     // ========================================================================
     // Detection Methods
     // ========================================================================

--- a/crates/octarine/src/security/commands/builder.rs
+++ b/crates/octarine/src/security/commands/builder.rs
@@ -60,16 +60,40 @@ mod metric_names {
 /// Provides comprehensive security detection, validation, and sanitization
 /// for command arguments with full audit trail via observe.
 ///
-/// This builder always emits observe events. For operations without
-/// observability overhead, use the shortcut functions or primitives directly.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct CommandSecurityBuilder;
+/// Use [`CommandSecurityBuilder::silent`] or
+/// [`CommandSecurityBuilder::with_events`] to suppress observe events when
+/// the builder is invoked from contexts where log/metric noise would be
+/// harmful (recursive observe paths, hot loops). Metric recording is gated
+/// alongside event emission.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandSecurityBuilder {
+    emit_events: bool,
+}
+
+impl Default for CommandSecurityBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl CommandSecurityBuilder {
-    /// Create a new command security builder
+    /// Create a new command security builder with observe events enabled
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self { emit_events: true }
+    }
+
+    /// Create a builder that suppresses all observe events and metrics
+    #[must_use]
+    pub fn silent() -> Self {
+        Self { emit_events: false }
+    }
+
+    /// Toggle observe event/metric emission
+    #[must_use]
+    pub fn with_events(mut self, emit: bool) -> Self {
+        self.emit_events = emit;
+        self
     }
 
     // ========================================================================
@@ -80,7 +104,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_dangerous(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_dangerous(arg);
-        if result {
+        if self.emit_events && result {
             observe::critical(
                 "command_injection_detected",
                 "Command injection detected in argument",
@@ -95,7 +119,7 @@ impl CommandSecurityBuilder {
     pub fn detect_threats(&self, arg: &str) -> Vec<CommandThreat> {
         let threats = PrimitiveCommandSecurityBuilder::new().detect_threats(arg);
 
-        if !threats.is_empty() {
+        if self.emit_events && !threats.is_empty() {
             let threat_names: Vec<_> = threats.iter().map(|t| t.description()).collect();
             observe::critical(
                 "command_threats_detected",
@@ -111,7 +135,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_any_chain_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_any_chain_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::warn(
                 "command_chain_detected",
                 "Command chaining pattern detected",
@@ -125,7 +149,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_shell_expansion_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_shell_expansion_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::error(
                 "shell_expansion_detected",
                 "Shell expansion pattern detected",
@@ -139,7 +163,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_command_substitution_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_command_substitution_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::error(
                 "command_substitution_detected",
                 "Command substitution pattern detected",
@@ -153,7 +177,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_variable_expansion_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_variable_expansion_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::warn(
                 "variable_expansion_detected",
                 "Variable expansion in argument",
@@ -167,7 +191,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_indirect_expansion_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_indirect_expansion_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::warn(
                 "indirect_expansion_detected",
                 "Indirect variable expansion in argument",
@@ -181,7 +205,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_arithmetic_expansion_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_arithmetic_expansion_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::warn(
                 "arithmetic_expansion_detected",
                 "Arithmetic expansion in argument",
@@ -195,7 +219,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_redirection_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_redirection_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::warn("redirection_detected", "Redirection pattern in argument");
             increment_by(metric_names::threats_detected(), 1);
         }
@@ -206,7 +230,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_glob_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_glob_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::warn("glob_detected", "Glob pattern in argument");
             increment_by(metric_names::threats_detected(), 1);
         }
@@ -217,7 +241,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_null_byte_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_null_byte_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::error("null_byte_detected", "Null byte detected in argument");
             increment_by(metric_names::threats_detected(), 1);
         }
@@ -228,7 +252,7 @@ impl CommandSecurityBuilder {
     #[must_use]
     pub fn is_control_character_present(&self, arg: &str) -> bool {
         let result = PrimitiveCommandSecurityBuilder::new().is_control_character_present(arg);
-        if result {
+        if self.emit_events && result {
             observe::warn("control_char_detected", "Control character in argument");
             increment_by(metric_names::threats_detected(), 1);
         }
@@ -246,16 +270,17 @@ impl CommandSecurityBuilder {
         let start = Instant::now();
         let result = PrimitiveCommandSecurityBuilder::new().validate_safe(arg);
 
-        record(
-            metric_names::validate_ms(),
-            start.elapsed().as_micros() as f64 / 1000.0,
-        );
-
-        if let Err(ref e) = result {
-            observe::critical(
-                "command_argument_validation_failed",
-                format!("Command argument validation failed: {e}"),
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
             );
+            if let Err(ref e) = result {
+                observe::critical(
+                    "command_argument_validation_failed",
+                    format!("Command argument validation failed: {e}"),
+                );
+            }
         }
 
         result
@@ -271,7 +296,7 @@ impl CommandSecurityBuilder {
         let result = PrimitiveCommandSecurityBuilder::new()
             .validate_command_allowed(command, prim_allowlist);
 
-        if result.is_err() {
+        if self.emit_events && result.is_err() {
             observe::critical(
                 "command_not_allowed",
                 format!("Command '{command}' not in allow-list"),
@@ -284,7 +309,9 @@ impl CommandSecurityBuilder {
     /// Validate a command name
     pub fn validate_command_name(&self, command: &str) -> Result<(), Problem> {
         let result = PrimitiveCommandSecurityBuilder::new().validate_command_name(command);
-        if let Err(ref e) = result {
+        if self.emit_events
+            && let Err(ref e) = result
+        {
             observe::warn(
                 "command_name_invalid",
                 format!("Invalid command name: {}", e),
@@ -306,7 +333,7 @@ impl CommandSecurityBuilder {
     pub fn validate_env(&self, name: &str, value: &str) -> Result<(), Problem> {
         let result = PrimitiveCommandSecurityBuilder::new().validate_env(name, value);
 
-        if result.is_err() {
+        if self.emit_events && result.is_err() {
             observe::critical(
                 "command_env_validation_failed",
                 format!("Command env validation failed: {name}"),
@@ -325,10 +352,12 @@ impl CommandSecurityBuilder {
         let start = Instant::now();
         let result = PrimitiveCommandSecurityBuilder::new().escape_shell_arg(arg);
 
-        record(
-            metric_names::escape_ms(),
-            start.elapsed().as_micros() as f64 / 1000.0,
-        );
+        if self.emit_events {
+            record(
+                metric_names::escape_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
 
         result
     }
@@ -371,8 +400,36 @@ mod tests {
 
     #[test]
     fn test_builder_creation() {
-        let _builder = CommandSecurityBuilder::new();
-        // Builder is a unit struct, nothing to assert
+        let b = CommandSecurityBuilder::new();
+        assert!(b.emit_events);
+
+        let s = CommandSecurityBuilder::silent();
+        assert!(!s.emit_events);
+    }
+
+    #[test]
+    fn test_with_events_toggle() {
+        let b = CommandSecurityBuilder::new().with_events(false);
+        assert!(!b.emit_events);
+
+        let b = CommandSecurityBuilder::silent().with_events(true);
+        assert!(b.emit_events);
+    }
+
+    #[test]
+    fn test_silent_mode_does_not_panic() {
+        // Structural test: `silent()` returns a builder with emit_events=false,
+        // and every observe/metric call site in this module is gated by
+        // `if self.emit_events`. A behavioral delta-assertion would race with
+        // concurrent tests across the workspace that hit these same global
+        // metric names.
+        let s = CommandSecurityBuilder::silent();
+        assert!(!s.emit_events);
+
+        // Functional sanity: silent builder still detects threats correctly.
+        assert!(s.is_dangerous("$(whoami)"));
+        assert!(s.validate_safe("$(rm -rf /)").is_err());
+        let _ = s.detect_threats("; rm -rf /");
     }
 
     #[test]

--- a/crates/octarine/src/security/formats/builder.rs
+++ b/crates/octarine/src/security/formats/builder.rs
@@ -127,16 +127,16 @@ impl FormatSecurityBuilder {
     /// Validate XML input against policy
     pub fn validate_xml(&self, input: &str, policy: &XmlPolicy) -> Result<()> {
         let start = Instant::now();
-        debug("security.format", "Validating XML against policy");
         let result = self.inner.validate_xml(input, policy);
         if self.emit_events {
+            debug("security.format", "Validating XML against policy");
             record(
                 metric_names::validate_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            warn("security.format", "XML validation failed");
+            if result.is_err() {
+                warn("security.format", "XML validation failed");
+            }
         }
         result
     }
@@ -197,16 +197,16 @@ impl FormatSecurityBuilder {
     /// Validate JSON input against policy
     pub fn validate_json(&self, input: &str, policy: &JsonPolicy) -> Result<()> {
         let start = Instant::now();
-        debug("security.format", "Validating JSON against policy");
         let result = self.inner.validate_json(input, policy);
         if self.emit_events {
+            debug("security.format", "Validating JSON against policy");
             record(
                 metric_names::validate_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            warn("security.format", "JSON validation failed");
+            if result.is_err() {
+                warn("security.format", "JSON validation failed");
+            }
         }
         result
     }
@@ -282,16 +282,16 @@ impl FormatSecurityBuilder {
     /// Validate YAML input against policy
     pub fn validate_yaml(&self, input: &str, policy: &YamlPolicy) -> Result<()> {
         let start = Instant::now();
-        debug("security.format", "Validating YAML against policy");
         let result = self.inner.validate_yaml(input, policy);
         if self.emit_events {
+            debug("security.format", "Validating YAML against policy");
             record(
                 metric_names::validate_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            warn("security.format", "YAML validation failed");
+            if result.is_err() {
+                warn("security.format", "YAML validation failed");
+            }
         }
         result
     }
@@ -304,9 +304,9 @@ impl FormatSecurityBuilder {
     #[must_use]
     pub fn detect_threats(&self, input: &str, format: FormatType) -> Vec<FormatThreat> {
         let start = Instant::now();
-        debug("security.format", "Detecting format threats");
         let threats = self.inner.detect_threats(input, format);
         if self.emit_events {
+            debug("security.format", "Detecting format threats");
             record(
                 metric_names::detect_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
@@ -332,9 +332,9 @@ impl FormatSecurityBuilder {
     /// Validate input with default strict policies
     pub fn validate_strict(&self, input: &str, format: FormatType) -> Result<()> {
         let start = Instant::now();
-        debug("security.format", "Validating with strict policy");
         let result = self.inner.validate_strict(input, format);
         if self.emit_events {
+            debug("security.format", "Validating with strict policy");
             record(
                 metric_names::validate_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,

--- a/crates/octarine/src/security/queries/builder.rs
+++ b/crates/octarine/src/security/queries/builder.rs
@@ -119,12 +119,12 @@ impl QueryBuilder {
                 metric_names::validate_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            observe::warn(
-                "sql_parameter_validation_failed",
-                "SQL parameter validation failed",
-            );
+            if result.is_err() {
+                observe::warn(
+                    "sql_parameter_validation_failed",
+                    "SQL parameter validation failed",
+                );
+            }
         }
         result
     }
@@ -189,12 +189,12 @@ impl QueryBuilder {
                 metric_names::validate_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            observe::warn(
-                "nosql_value_validation_failed",
-                "NoSQL value validation failed",
-            );
+            if result.is_err() {
+                observe::warn(
+                    "nosql_value_validation_failed",
+                    "NoSQL value validation failed",
+                );
+            }
         }
         result
     }
@@ -268,12 +268,12 @@ impl QueryBuilder {
                 metric_names::validate_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            observe::warn(
-                "ldap_filter_validation_failed",
-                "LDAP filter validation failed",
-            );
+            if result.is_err() {
+                observe::warn(
+                    "ldap_filter_validation_failed",
+                    "LDAP filter validation failed",
+                );
+            }
         }
         result
     }
@@ -349,12 +349,12 @@ impl QueryBuilder {
                 metric_names::validate_ms(),
                 start.elapsed().as_micros() as f64 / 1000.0,
             );
-        }
-        if result.is_err() {
-            observe::warn(
-                "graphql_query_validation_failed",
-                "GraphQL query validation failed",
-            );
+            if result.is_err() {
+                observe::warn(
+                    "graphql_query_validation_failed",
+                    "GraphQL query validation failed",
+                );
+            }
         }
         result
     }


### PR DESCRIPTION
## Summary

Per the audit (`octarine-observe`, findings 001-005), 5 Layer 3 builders violated the silent-mode convention:

- **`CommandSecurityBuilder`** and **`IdentifierBuilder`** — unit structs with no silent mode at all. Converted to structs with `emit_events: bool`, added `new()` / `silent()` / `with_events(bool)` constructors+setter, and guarded every `observe::*` / `record()` / `increment_by()` call with `if self.emit_events`.
- **`FormatBuilder`**, **`FormatSecurityBuilder`**, **`QueryBuilder`** — already had the silent-mode infrastructure, but contained unguarded `debug()` / `warn()` / `observe::warn()` call sites that emitted regardless of `emit_events`. Consolidated each affected method into a single `if self.emit_events { ... }` block.

`IdentifierBuilder`'s silent flag propagates through all 18 domain accessors (`personal()`, `financial()`, `network()`, ...) via `with_events(self.emit_events)`. Without this, `IdentifierBuilder::silent().personal()` would have returned a noisy builder — a footgun because `scan_text()` and `is_pii_present()` route through these accessors.

To make the propagation testable across the module boundary, added `#[cfg(test)] pub(crate) fn emit_events()` accessors to `PersonalBuilder`, `FinancialBuilder`, and `NetworkBuilder`.

## Test plan

- [x] `just clippy` — passes; one collapsible-if lint required rewriting to `if A && let Err(...) = result` in `validate_command_name`
- [x] `just preflight` — exit 0; 14 test-result blocks, 0 failures
- [x] 3 new silent-mode tests in `CommandSecurityBuilder` (creation, with_events toggle, structural silent-mode sanity)
- [x] 4 new tests in `IdentifierBuilder` (creation, with_events, **silent propagates to domain accessors**, structural silent-mode sanity)
- [x] AWK sweep over all 5 files: zero unguarded `observe::*` / `record()` / `increment_by()` / `debug()` / `warn()` calls outside `if self.emit_events` blocks

Closes #87