### PR TITLE
refactor(data/paths): drop cross-concern security re-exports

### DIFF
--- a/crates/octarine/src/data/paths/builder/mod.rs
+++ b/crates/octarine/src/data/paths/builder/mod.rs
@@ -7,7 +7,6 @@
 //!
 //! Each builder focuses on a specific domain:
 //!
-//! - [`SecurityBuilder`] - Security detection, validation, and sanitization
 //! - [`BoundaryBuilder`] - Directory jailing and boundary validation
 //! - [`FilenameBuilder`] - Filename operations (detection, validation, sanitization, construction)
 //! - [`CharacteristicBuilder`] - Path type and platform detection
@@ -17,6 +16,9 @@
 //! - [`PathContextBuilder`] - Context-specific sanitization (env, ssh, credential, op)
 //! - [`ConstructionBuilder`] - Safe path building
 //! - [`LenientBuilder`] - Lenient sanitization (always returns a value)
+//!
+//! Security detection, validation, and sanitization live in their own concern
+//! at [`crate::security::paths::SecurityBuilder`].
 //!
 //! # Unified PathBuilder
 //!
@@ -36,9 +38,10 @@
 //! ## Using Specialized Builders
 //!
 //! ```
-//! use octarine::data::paths::{SecurityBuilder, FilenameBuilder};
+//! use octarine::data::paths::FilenameBuilder;
+//! use octarine::security::paths::SecurityBuilder;
 //!
-//! // Security operations
+//! // Security operations (lives in the security concern)
 //! let security = SecurityBuilder::new();
 //! if security.is_traversal_present("../secret") {
 //!     // Handle threat

--- a/crates/octarine/src/data/paths/mod.rs
+++ b/crates/octarine/src/data/paths/mod.rs
@@ -19,7 +19,6 @@
 //! This module provides multiple specialized builders for different use cases:
 //!
 //! - [`PathBuilder`] - Unified API for all path operations
-//! - [`SecurityBuilder`] - Security detection, validation, and sanitization
 //! - [`BoundaryBuilder`] - Directory jailing and containment
 //! - [`FilenameBuilder`] - Filename operations (validation, sanitization, construction)
 //! - [`CharacteristicBuilder`] - Path type and platform detection
@@ -29,6 +28,9 @@
 //! - [`PathContextBuilder`] - Context-specific sanitization (env, ssh, credential, op)
 //! - [`ConstructionBuilder`] - Safe path building
 //! - [`LenientBuilder`] - Lenient sanitization (always returns a value)
+//!
+//! Security detection, validation, and sanitization live in their own concern:
+//! see [`crate::security::paths::SecurityBuilder`].
 //!
 //! # Usage
 //!
@@ -73,9 +75,10 @@
 //! ## Specialized Builders
 //!
 //! ```
-//! use octarine::data::paths::{SecurityBuilder, FilenameBuilder, HomeBuilder};
+//! use octarine::data::paths::{FilenameBuilder, HomeBuilder};
+//! use octarine::security::paths::SecurityBuilder;
 //!
-//! // Security operations
+//! // Security operations (lives in the security concern)
 //! let security = SecurityBuilder::new();
 //! if security.is_traversal_present("../secret") {
 //!     // Handle threat
@@ -120,23 +123,19 @@ mod lenient;
 // Re-export the main PathBuilder
 pub use builder::PathBuilder;
 
-// Re-export all specialized builders (except SecurityBuilder, which is in security::paths)
+// Re-export all specialized builders. Security operations are a separate
+// concern — import `SecurityBuilder` from `crate::security::paths`.
 pub use builder::{
     BoundaryBuilder, CharacteristicBuilder, ConstructionBuilder, FilenameBuilder, FiletypeBuilder,
     FormatBuilder, HomeBuilder, LenientBuilder, PathContextBuilder,
 };
 
-// Re-export SecurityBuilder from security::paths for backwards compatibility
-pub use crate::security::paths::SecurityBuilder;
-
 // Re-export types for public API
 pub use types::{
     BoundaryStrategy, FileCategory, FilenameSanitizationStrategy, PathDetectionResult, PathFormat,
     PathType, PathValidationResult, Platform, SanitizationContext, SeparatorStyle,
+    ThreatAnnotation,
 };
-
-// Re-export security types from their canonical location (security::paths)
-pub use crate::security::paths::{PathSanitizationStrategy, SecurityThreat};
 
 // Re-export shortcuts at module level for convenience
 pub use shortcuts::*;

--- a/crates/octarine/src/data/paths/types.rs
+++ b/crates/octarine/src/data/paths/types.rs
@@ -18,9 +18,6 @@
 //! - **CWE-175**: Improper Handling of Mixed Encoding
 //! - **CWE-707**: Improper Neutralization
 
-// Import SecurityThreat from its canonical location
-use crate::security::paths::SecurityThreat;
-
 // ============================================================================
 // Platform Types
 // ============================================================================
@@ -322,11 +319,44 @@ impl From<crate::primitives::data::paths::FileCategory> for FileCategory {
 }
 
 // ============================================================================
-// Security Threat Types
+// Threat Annotation
 // ============================================================================
 
-// SecurityThreat is now in security::paths::types (canonical location)
-// Imported at top of file and re-exported via data::paths::mod.rs
+/// Data-local annotation describing a security threat detected in a path.
+///
+/// `data::paths` operates strictly in the FORMAT concern, so it does not
+/// import the `SecurityThreat` enum from the `security` concern. Instead,
+/// detection results expose just the metadata callers need to log, sort, or
+/// display threats — without coupling the data module to the security
+/// module's type hierarchy.
+///
+/// For full threat handling (variants, validation, sanitization), use
+/// [`crate::security::paths`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ThreatAnnotation {
+    /// CWE identifier (e.g. `"CWE-22"`)
+    pub cwe: &'static str,
+    /// Severity level (1-5, higher = more severe)
+    pub severity: u8,
+    /// Human-readable description
+    pub description: &'static str,
+}
+
+impl std::fmt::Display for ThreatAnnotation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({})", self.description, self.cwe)
+    }
+}
+
+impl From<crate::primitives::data::paths::SecurityThreat> for ThreatAnnotation {
+    fn from(t: crate::primitives::data::paths::SecurityThreat) -> Self {
+        Self {
+            cwe: t.cwe(),
+            severity: t.severity(),
+            description: t.description(),
+        }
+    }
+}
 
 // ============================================================================
 // Result Types
@@ -351,8 +381,8 @@ pub struct PathDetectionResult {
     pub has_extension: bool,
     /// File extension if present
     pub extension: Option<String>,
-    /// Security threats detected
-    pub threats: Vec<SecurityThreat>,
+    /// Security threats detected, expressed as data-local annotations.
+    pub threats: Vec<ThreatAnnotation>,
 }
 
 impl PathDetectionResult {
@@ -371,7 +401,7 @@ impl PathDetectionResult {
     /// Get the highest severity threat (if any)
     #[must_use]
     pub fn max_severity(&self) -> Option<u8> {
-        self.threats.iter().map(SecurityThreat::severity).max()
+        self.threats.iter().map(|t| t.severity).max()
     }
 
     /// Get the number of threats detected
@@ -729,10 +759,15 @@ mod tests {
     }
 
     #[test]
-    fn test_security_threat() {
-        assert_eq!(SecurityThreat::Traversal.cwe(), "CWE-22");
-        assert_eq!(SecurityThreat::CommandInjection.severity(), 5);
-        assert!(!SecurityThreat::Traversal.description().is_empty());
+    fn test_threat_annotation() {
+        let annotation = ThreatAnnotation {
+            cwe: "CWE-22",
+            severity: 4,
+            description: "Directory traversal attempt using '..'",
+        };
+        assert_eq!(annotation.cwe, "CWE-22");
+        assert_eq!(annotation.severity, 4);
+        assert!(annotation.to_string().contains("CWE-22"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove public `pub use` re-exports of `SecurityBuilder`, `SecurityThreat`, and `PathSanitizationStrategy` from `data::paths`.
- Introduce a data-local `ThreatAnnotation` struct (`cwe`, `severity`, `description`) so `PathDetectionResult.threats` no longer imports from the `security` concern.
- Update module rustdoc and doctests to point callers at `octarine::security::paths::SecurityBuilder` for security operations.
- Keep the private Layer 3 → Layer 3 internal `use crate::security::paths::SecurityBuilder` in `data/paths/builder/` — only the *public* re-exports violated the boundary, not internal delegators.

Enforces the CLAUDE.md three-concern boundary: `data/` (FORMAT), `security/` (THREATS), `identifiers/` (CLASSIFICATION).

## Breaking change

Callers writing `octarine::data::paths::{SecurityBuilder, SecurityThreat, PathSanitizationStrategy}` must switch to `octarine::security::paths::…`. `PathDetectionResult.threats` is now `Vec<ThreatAnnotation>` instead of `Vec<SecurityThreat>`. Crate is at `0.3.0-beta.3` (pre-1.0), so the break is acceptable in a beta bump.

## Test plan

- [x] `just fmt-check`, `just clippy`, `just arch-check` — all clean (0 warnings).
- [x] `just test-mod "data::paths"` — 770/770 pass.
- [x] Grep verified: no `pub use crate::security::paths` remains in `data/paths/mod.rs`; no `SecurityThreat` import remains in `data/paths/types.rs`; the private internal `use` in `builder/mod.rs` is preserved.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)