### PR TITLE
refactor: complete unimplemented checksums and normalizations

### DIFF
--- a/crates/octarine/examples/observe_siem.rs
+++ b/crates/octarine/examples/observe_siem.rs
@@ -232,6 +232,7 @@ fn create_sample_event(
             source_ip_chain: Vec::new(),
             correlation_id: Uuid::new_v4(),
             parent_span_id: None,
+            environment: None,
             contains_pii: false,
             contains_phi: false,
             security_relevant: matches!(

--- a/crates/octarine/src/observe/context/build.rs
+++ b/crates/octarine/src/observe/context/build.rs
@@ -61,6 +61,7 @@ pub(super) fn build_context(config: ContextConfig) -> EventContext {
             source_ip_chain: Vec::new(),
             correlation_id: Uuid::new_v4(),
             parent_span_id: None,
+            environment: None,
             contains_pii: false,
             contains_phi: false,
             security_relevant: true,

--- a/crates/octarine/src/observe/context/capture.rs
+++ b/crates/octarine/src/observe/context/capture.rs
@@ -56,8 +56,8 @@ static CACHED_CONTEXT: Lazy<CachedContext> = Lazy::new(|| CachedContext {
 /// Checks thread-local and task-local storage first, then falls back
 /// to environment variables for any missing values.
 pub(in crate::observe) fn capture_context() -> EventContext {
-    // Get environment context (static) - TODO: use this when EventContext includes environment
-    let _env = get_environment();
+    // Capture deployment environment (static, captured once at startup)
+    let env = get_environment();
 
     // Get tenant context from observe module's thread-local (for TenantContext struct)
     let tenant = get_tenant_context();
@@ -89,6 +89,9 @@ pub(in crate::observe) fn capture_context() -> EventContext {
         // Correlation
         correlation_id: capture_correlation_id(),
         parent_span_id: None,
+
+        // Deployment context
+        environment: Some(env.environment.clone()),
 
         // Compliance flags (conservative defaults)
         contains_pii: false,
@@ -330,4 +333,24 @@ macro_rules! capture_location {
         ctx.line = line!();
         ctx
     }};
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capture_context_populates_environment() {
+        // ENVIRONMENT defaults to "development" when no env vars are set.
+        // The exact value depends on the test runner's environment, but
+        // capture_context() must populate Some(_), never None.
+        let ctx = capture_context();
+        assert!(
+            ctx.environment.is_some(),
+            "capture_context should populate environment from get_environment()"
+        );
+        let env = ctx.environment.expect("checked is_some above");
+        assert!(!env.is_empty(), "environment value should never be empty");
+    }
 }

--- a/crates/octarine/src/observe/types.rs
+++ b/crates/octarine/src/observe/types.rs
@@ -331,6 +331,14 @@ pub struct EventContext {
     /// Parent span ID for distributed tracing
     pub parent_span_id: Option<Uuid>,
 
+    /// Deployment environment name (e.g., "production", "development", "staging")
+    ///
+    /// Captured once at startup from `ENVIRONMENT` or `ENV` env vars.
+    /// Omitted from serialized output when `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub environment: Option<String>,
+
     // Compliance flags
     /// Whether this event contains PII (personally identifiable information)
     pub contains_pii: bool,
@@ -373,6 +381,7 @@ impl Default for EventContext {
             source_ip_chain: Vec::new(),
             correlation_id: Uuid::new_v4(),
             parent_span_id: None,
+            environment: None,
             contains_pii: false,
             contains_phi: false,
             security_relevant: false,

--- a/crates/octarine/src/observe/writers/database/postgres.rs
+++ b/crates/octarine/src/observe/writers/database/postgres.rs
@@ -271,6 +271,7 @@ impl PostgresBackend {
             local_ip: None,
             source_ip: None,
             source_ip_chain: Vec::new(),
+            environment: None,
             contains_pii,
             contains_phi,
             security_relevant,

--- a/crates/octarine/src/observe/writers/database/sqlite.rs
+++ b/crates/octarine/src/observe/writers/database/sqlite.rs
@@ -301,6 +301,7 @@ impl SqliteBackend {
             local_ip: None,
             source_ip: None,
             source_ip_chain: Vec::new(),
+            environment: None,
             contains_pii: contains_pii != 0,
             contains_phi: contains_phi != 0,
             security_relevant: security_relevant != 0,

--- a/crates/octarine/src/primitives/identifiers/government/licenses/north_america.rs
+++ b/crates/octarine/src/primitives/identifiers/government/licenses/north_america.rs
@@ -228,33 +228,15 @@ impl LicenseValidator for NebraskaValidator {
         false
     }
 
-    #[allow(clippy::arithmetic_side_effects)] // Validated format ensures safe arithmetic
     fn is_checksum_valid(&self, license: &str) -> Option<bool> {
         if !self.is_format_valid(license) {
             return None;
         }
 
-        let chars: Vec<char> = license.to_uppercase().chars().collect();
-
-        // Nebraska check digit algorithm (simplified):
-        // This is a basic weighted sum - actual NE algorithm may vary
-        let mut sum: u32 = 0;
-        let mut weight = 1u32;
-
-        for &c in &chars {
-            let value = if c.is_ascii_alphabetic() {
-                u32::from(c).saturating_sub(u32::from('A')) + 1
-            } else {
-                c.to_digit(10)?
-            };
-            sum = sum.saturating_add(value.saturating_mul(weight));
-            weight = weight.saturating_add(1);
-        }
-
-        // For Nebraska, we validate format but checksum verification
-        // requires more research on the exact algorithm
-        // For now, return true if format is valid (checksum not verified)
-        Some(true) // TODO: Implement actual NE checksum when algorithm is documented
+        // Nebraska does not publish its driver's license check-digit
+        // algorithm. Returning None signals format-only validation, the
+        // same pattern used by the Washington validator below.
+        None
     }
 
     fn format_description(&self) -> &'static str {
@@ -420,6 +402,19 @@ mod tests {
         assert!(!v.is_format_valid("1234567")); // 7 digits (not 8)
         assert!(!v.is_format_valid("123456789")); // 9 digits
         assert!(!v.is_format_valid("AB12345")); // Two letters
+    }
+
+    #[test]
+    fn test_nebraska_checksum_is_format_only() {
+        // Nebraska's check-digit algorithm is not publicly documented, so
+        // is_checksum_valid returns None for any input — including
+        // format-valid ones — to signal format-only validation.
+        let v = NebraskaValidator;
+        assert_eq!(v.is_checksum_valid("A12345"), None);
+        assert_eq!(v.is_checksum_valid("12345678"), None);
+        // Format-invalid inputs also return None
+        assert_eq!(v.is_checksum_valid("A12"), None);
+        assert_eq!(v.is_checksum_valid("AB12345"), None);
     }
 
     // ===== Washington Tests =====

--- a/crates/octarine/src/primitives/identifiers/location/sanitization/address.rs
+++ b/crates/octarine/src/primitives/identifiers/location/sanitization/address.rs
@@ -160,16 +160,17 @@ fn sanitize_for_token(text: &str) -> String {
     text.chars().filter(|c| c.is_alphanumeric()).collect()
 }
 
-/// Sanitize street address strict (normalize format + validate)
+/// Sanitize street address strict (normalize whitespace + validate)
 ///
-/// Normalizes street address casing and spacing, and validates format.
-/// Returns normalized address if valid, error otherwise.
+/// Collapses interior whitespace runs to single spaces, trims surrounding
+/// whitespace, and validates that the result still parses as a street
+/// address.
 ///
 /// # Note
 ///
-/// Current implementation validates format but does not normalize casing/spacing
-/// as address normalization is complex and varies by country.
-/// Future enhancement: Implement full address normalization.
+/// Casing and abbreviation normalization (e.g., `"St"` → `"Street"`) are
+/// intentionally not performed — address formats vary by country and full
+/// normalization belongs in a locale-aware higher-level module.
 ///
 /// # Examples
 ///
@@ -180,20 +181,21 @@ fn sanitize_for_token(text: &str) -> String {
 /// let sanitized = sanitization::sanitize_street_address_strict("123 Main Street")?;
 /// assert_eq!(sanitized, "123 Main Street");
 ///
+/// // Whitespace collapse
+/// let sanitized = sanitization::sanitize_street_address_strict("  123  Main   Street  ")?;
+/// assert_eq!(sanitized, "123 Main Street");
+///
 /// // Invalid address
 /// assert!(sanitization::sanitize_street_address_strict("").is_err());
 /// ```
 pub fn sanitize_street_address_strict(address: &str) -> Result<String, Problem> {
-    let trimmed = address.trim();
+    let normalized = address.split_whitespace().collect::<Vec<_>>().join(" ");
 
-    // Validate format using detection
-    if !detection::is_street_address(trimmed) {
+    if !detection::is_street_address(&normalized) {
         return Err(Problem::Validation("Invalid street address format".into()));
     }
 
-    // TODO: Implement full address normalization (casing, spacing, abbreviations)
-    // For now, just return trimmed
-    Ok(trimmed.to_string())
+    Ok(normalized)
 }
 
 #[cfg(test)]
@@ -311,10 +313,34 @@ mod tests {
     fn test_sanitize_street_address_strict() {
         // Valid address
         let result = sanitize_street_address_strict("123 Main Street");
-        assert!(result.is_ok());
+        assert_eq!(result.expect("valid address"), "123 Main Street");
 
         // Empty address
         let result = sanitize_street_address_strict("");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sanitize_street_address_strict_collapses_whitespace() {
+        // Double internal spaces
+        assert_eq!(
+            sanitize_street_address_strict("123  Main  Street").expect("valid"),
+            "123 Main Street"
+        );
+        // Leading and trailing whitespace
+        assert_eq!(
+            sanitize_street_address_strict("  123 Main Street  ").expect("valid"),
+            "123 Main Street"
+        );
+        // Tabs and mixed whitespace
+        assert_eq!(
+            sanitize_street_address_strict("123\tMain\t\tStreet").expect("valid"),
+            "123 Main Street"
+        );
+        // Combination of leading, trailing, and internal
+        assert_eq!(
+            sanitize_street_address_strict("\t  123   Main\t Street \n").expect("valid"),
+            "123 Main Street"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Resolves three tech-debt placeholders flagged by the code-health audit:

- **Nebraska DL checksum** (`north_america.rs:232`) — replaced dead-code weighted sum + misleading `Some(true)` with `None`, matching the Washington validator's format-only signal. NE's check-digit algorithm is not publicly documented; `LicenseValidationResult::is_valid()` already treats `None` as "format-only valid" via `unwrap_or(true)`.
- **Address sanitization** (`address.rs:186`) — `sanitize_street_address_strict` now collapses interior whitespace and trims (`split_whitespace().join(" ")`) instead of trim-only. Casing and abbreviation normalization remain intentionally out of scope (locale-dependent).
- **Environment field** (`types.rs:284`) — added `environment: Option<String>` to `EventContext` with `skip_serializing_if = Option::is_none`. `capture_context()` now populates it from `get_environment()` instead of dropping the value into `_env`. DB writer rehydration sites (sqlite, postgres) set `environment: None` for now; persisting the column is a follow-up.

## Test plan

- [x] `just preflight` green: fmt, clippy, arch-check, all 7273 tests pass
- [x] Added `test_nebraska_checksum_is_format_only` — verifies `None` for both format-valid and format-invalid NE inputs
- [x] Added `test_sanitize_street_address_strict_collapses_whitespace` — covers double spaces, leading/trailing, tabs, and mixed whitespace
- [x] Added `test_capture_context_populates_environment` — asserts `environment` is `Some(_)` after capture

Closes #50