### PR TITLE
feat(identifiers): add LATAM/Africa government IDs (Brazil CPF/CNPJ, Mexico CURP, Nigeria NIN, Thailand TNIN)

### DIFF
--- a/crates/octarine/src/identifiers/builder/government.rs
+++ b/crates/octarine/src/identifiers/builder/government.rs
@@ -1237,6 +1237,318 @@ impl GovernmentBuilder {
     }
 
     // ========================================================================
+    // Brazil: CPF
+    // ========================================================================
+
+    /// Check if value matches a Brazilian CPF pattern
+    #[must_use]
+    pub fn is_brazil_cpf(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_brazil_cpf(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Brazilian CPFs in text
+    #[must_use]
+    pub fn find_brazil_cpfs_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_brazil_cpfs_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+                increment_by(metric_names::government_data_found(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate Brazilian CPF format (without checksum)
+    pub fn validate_brazil_cpf(&self, cpf: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_brazil_cpf(cpf);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn("brazil_cpf_validation_failed", "Invalid Brazil CPF format");
+            }
+        }
+        result
+    }
+
+    /// Validate Brazilian CPF with mod-11 dual check digit verification
+    pub fn validate_brazil_cpf_with_checksum(&self, cpf: &str) -> Result<(), Problem> {
+        self.inner.validate_brazil_cpf_with_checksum(cpf)
+    }
+
+    // ========================================================================
+    // Brazil: CNPJ
+    // ========================================================================
+
+    /// Check if value matches a Brazilian CNPJ pattern
+    #[must_use]
+    pub fn is_brazil_cnpj(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_brazil_cnpj(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Brazilian CNPJs in text
+    #[must_use]
+    pub fn find_brazil_cnpjs_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_brazil_cnpjs_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+                increment_by(metric_names::government_data_found(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate Brazilian CNPJ format (without checksum)
+    pub fn validate_brazil_cnpj(&self, cnpj: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_brazil_cnpj(cnpj);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "brazil_cnpj_validation_failed",
+                    "Invalid Brazil CNPJ format",
+                );
+            }
+        }
+        result
+    }
+
+    /// Validate Brazilian CNPJ with mod-11 dual check digit verification
+    pub fn validate_brazil_cnpj_with_checksum(&self, cnpj: &str) -> Result<(), Problem> {
+        self.inner.validate_brazil_cnpj_with_checksum(cnpj)
+    }
+
+    // ========================================================================
+    // Mexico: CURP
+    // ========================================================================
+
+    /// Check if value matches a Mexican CURP pattern
+    #[must_use]
+    pub fn is_mexico_curp(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_mexico_curp(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Mexican CURPs in text
+    #[must_use]
+    pub fn find_mexico_curps_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_mexico_curps_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+                increment_by(metric_names::government_data_found(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate Mexican CURP format (without checksum)
+    pub fn validate_mexico_curp(&self, curp: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_mexico_curp(curp);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "mexico_curp_validation_failed",
+                    "Invalid Mexico CURP format",
+                );
+            }
+        }
+        result
+    }
+
+    /// Validate Mexican CURP with check digit verification
+    pub fn validate_mexico_curp_with_checksum(&self, curp: &str) -> Result<(), Problem> {
+        self.inner.validate_mexico_curp_with_checksum(curp)
+    }
+
+    // ========================================================================
+    // Nigeria: NIN
+    // ========================================================================
+
+    /// Check if value matches a Nigerian NIN pattern
+    #[must_use]
+    pub fn is_nigeria_nin(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_nigeria_nin(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Nigerian NINs in text (label-gated)
+    #[must_use]
+    pub fn find_nigeria_nins_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_nigeria_nins_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+                increment_by(metric_names::government_data_found(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate Nigerian NIN format (no checksum algorithm exists)
+    pub fn validate_nigeria_nin(&self, nin: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_nigeria_nin(nin);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "nigeria_nin_validation_failed",
+                    "Invalid Nigeria NIN format",
+                );
+            }
+        }
+        result
+    }
+
+    // ========================================================================
+    // Thailand: TNIN
+    // ========================================================================
+
+    /// Check if value matches a Thai TNIN pattern
+    #[must_use]
+    pub fn is_thailand_tnin(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_thailand_tnin(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Thai TNINs in text
+    #[must_use]
+    pub fn find_thailand_tnins_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_thailand_tnins_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+                increment_by(metric_names::government_data_found(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate Thai TNIN format (without checksum)
+    pub fn validate_thailand_tnin(&self, tnin: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_thailand_tnin(tnin);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "thailand_tnin_validation_failed",
+                    "Invalid Thailand TNIN format",
+                );
+            }
+        }
+        result
+    }
+
+    /// Validate Thai TNIN with mod-11 check digit verification
+    pub fn validate_thailand_tnin_with_checksum(&self, tnin: &str) -> Result<(), Problem> {
+        self.inner.validate_thailand_tnin_with_checksum(tnin)
+    }
+
+    // ========================================================================
     // Finland: HETU
     // ========================================================================
 

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -169,6 +169,11 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             | PiiType::IndiaVehicleReg
             | PiiType::IndiaVoterId
             | PiiType::IndiaPassport
+            | PiiType::BrazilCpf
+            | PiiType::BrazilCnpj
+            | PiiType::MexicoCurp
+            | PiiType::NigeriaNin
+            | PiiType::ThailandTnin
             | PiiType::SingaporeNric
             | PiiType::FinlandHetu
             | PiiType::PolandPesel

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -117,6 +117,21 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
     if !government.find_india_passports_in_text(text).is_empty() {
         pii_types.push(PiiType::IndiaPassport);
     }
+    if !government.find_brazil_cpfs_in_text(text).is_empty() {
+        pii_types.push(PiiType::BrazilCpf);
+    }
+    if !government.find_brazil_cnpjs_in_text(text).is_empty() {
+        pii_types.push(PiiType::BrazilCnpj);
+    }
+    if !government.find_mexico_curps_in_text(text).is_empty() {
+        pii_types.push(PiiType::MexicoCurp);
+    }
+    if !government.find_nigeria_nins_in_text(text).is_empty() {
+        pii_types.push(PiiType::NigeriaNin);
+    }
+    if !government.find_thailand_tnins_in_text(text).is_empty() {
+        pii_types.push(PiiType::ThailandTnin);
+    }
     if !government.find_singapore_nrics_in_text(text).is_empty() {
         pii_types.push(PiiType::SingaporeNric);
     }

--- a/crates/octarine/src/observe/pii/types.rs
+++ b/crates/octarine/src/observe/pii/types.rs
@@ -86,6 +86,16 @@ pub enum PiiType {
     IndiaVoterId,
     /// Indian passport (P/S/D type indicator + 7 digits)
     IndiaPassport,
+    /// Brazilian Cadastro de Pessoas Físicas (CPF, mod-11 dual check digits)
+    BrazilCpf,
+    /// Brazilian Cadastro Nacional da Pessoa Jurídica (CNPJ, mod-11 dual check digits)
+    BrazilCnpj,
+    /// Mexican Clave Única de Registro de Población (CURP)
+    MexicoCurp,
+    /// Nigerian National Identification Number (NIN)
+    NigeriaNin,
+    /// Thai National Identification Number (TNIN, mod-11 check digit)
+    ThailandTnin,
     /// Singapore NRIC / FIN
     SingaporeNric,
     /// Finnish personal identity code (HETU)
@@ -310,6 +320,11 @@ impl PiiType {
             Self::IndiaVehicleReg => "india_vehicle_reg",
             Self::IndiaVoterId => "india_voter_id",
             Self::IndiaPassport => "india_passport",
+            Self::BrazilCpf => "brazil_cpf",
+            Self::BrazilCnpj => "brazil_cnpj",
+            Self::MexicoCurp => "mexico_curp",
+            Self::NigeriaNin => "nigeria_nin",
+            Self::ThailandTnin => "thailand_tnin",
             Self::SingaporeNric => "singapore_nric",
             Self::FinlandHetu => "finland_hetu",
             Self::PolandPesel => "poland_pesel",
@@ -424,6 +439,11 @@ impl PiiType {
             | Self::IndiaVehicleReg
             | Self::IndiaVoterId
             | Self::IndiaPassport
+            | Self::BrazilCpf
+            | Self::BrazilCnpj
+            | Self::MexicoCurp
+            | Self::NigeriaNin
+            | Self::ThailandTnin
             | Self::SingaporeNric
             | Self::FinlandHetu
             | Self::PolandPesel
@@ -510,6 +530,7 @@ impl PiiType {
             Self::Ssn | Self::DriverLicense | Self::Passport | Self::Ein | Self::TaxId | Self::NationalId | Self::Vin |
             Self::KoreaRrn | Self::AustraliaTfn | Self::AustraliaAbn | Self::IndiaAadhaar | Self::IndiaPan |
             Self::IndiaGstin | Self::IndiaVehicleReg | Self::IndiaVoterId | Self::IndiaPassport |
+            Self::BrazilCpf | Self::BrazilCnpj | Self::MexicoCurp | Self::NigeriaNin | Self::ThailandTnin |
             Self::SingaporeNric | Self::FinlandHetu | Self::PolandPesel | Self::ItalyFiscalCode |
             Self::SpainNif | Self::SpainNie | Self::UkNi |
             // Medical (HIPAA)
@@ -722,6 +743,11 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::IndiaVehicleReg => Self::IndiaVehicleReg,
             IdentifierType::IndiaVoterId => Self::IndiaVoterId,
             IdentifierType::IndiaPassport => Self::IndiaPassport,
+            IdentifierType::BrazilCpf => Self::BrazilCpf,
+            IdentifierType::BrazilCnpj => Self::BrazilCnpj,
+            IdentifierType::MexicoCurp => Self::MexicoCurp,
+            IdentifierType::NigeriaNin => Self::NigeriaNin,
+            IdentifierType::ThailandTnin => Self::ThailandTnin,
             IdentifierType::SingaporeNric => Self::SingaporeNric,
             IdentifierType::FinlandHetu => Self::FinlandHetu,
             IdentifierType::PolandPesel => Self::PolandPesel,
@@ -973,6 +999,11 @@ mod tests {
             PiiType::IndiaVehicleReg,
             PiiType::IndiaVoterId,
             PiiType::IndiaPassport,
+            PiiType::BrazilCpf,
+            PiiType::BrazilCnpj,
+            PiiType::MexicoCurp,
+            PiiType::NigeriaNin,
+            PiiType::ThailandTnin,
             PiiType::SingaporeNric,
         ] {
             assert_eq!(pii.domain(), "government", "{pii:?} domain");
@@ -1180,6 +1211,23 @@ mod tests {
             PiiType::IndiaAadhaar
         );
         assert_eq!(PiiType::from(IdentifierType::IndiaPan), PiiType::IndiaPan);
+        assert_eq!(PiiType::from(IdentifierType::BrazilCpf), PiiType::BrazilCpf);
+        assert_eq!(
+            PiiType::from(IdentifierType::BrazilCnpj),
+            PiiType::BrazilCnpj
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::MexicoCurp),
+            PiiType::MexicoCurp
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::NigeriaNin),
+            PiiType::NigeriaNin
+        );
+        assert_eq!(
+            PiiType::from(IdentifierType::ThailandTnin),
+            PiiType::ThailandTnin
+        );
         assert_eq!(
             PiiType::from(IdentifierType::SingaporeNric),
             PiiType::SingaporeNric

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -37,10 +37,11 @@ pub(crate) mod vehicle_id;
 pub(crate) use financial::{bank_account, credit_card, payment_token, routing_number};
 pub(crate) use network::{email, phone, username};
 pub(crate) use personal::{
-    australia_abn, australia_tfn, birthdate, driver_license, employee_id, finland_hetu,
-    india_aadhaar, india_gstin, india_pan, india_passport, india_vehicle_reg, india_voter_id,
-    italy_fiscal_code, korea_rrn, national_id, passport, personal_name, poland_pesel,
-    singapore_nric, spain_nie, spain_nif, ssn, student_id, tax_id, uk_ni,
+    australia_abn, australia_tfn, birthdate, brazil_cnpj, brazil_cpf, driver_license, employee_id,
+    finland_hetu, india_aadhaar, india_gstin, india_pan, india_passport, india_vehicle_reg,
+    india_voter_id, italy_fiscal_code, korea_rrn, mexico_curp, national_id, nigeria_nin, passport,
+    personal_name, poland_pesel, singapore_nric, spain_nie, spain_nif, ssn, student_id, tax_id,
+    thailand_tnin, uk_ni,
 };
 
 // medical, biometric, location, and vehicle modules are already accessible via pub mod declarations

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal.rs
@@ -463,6 +463,133 @@ pub(crate) mod india_passport {
     }
 }
 
+/// Brazil CPF (Cadastro de Pessoas Físicas) patterns
+///
+/// Format: `NNN.NNN.NNN-NN` or 11 plain digits.
+pub(crate) mod brazil_cpf {
+    use super::*;
+
+    /// Formatted CPF: NNN.NNN.NNN-NN
+    pub static FORMATTED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b\d{3}\.\d{3}\.\d{3}-\d{2}\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// CPF with explicit label (accepts formatted or unformatted)
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:CPF|cadastro[\s-]?de[\s-]?pessoas[\s-]?f[ií]sicas)[\s:#-]*(\d{3}\.?\d{3}\.?\d{3}-?\d{2})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    /// Scanning patterns. Plain 11-digit form is too ambiguous (matches phone
+    /// numbers, IDs, etc.) so we only scan formatted or labeled occurrences.
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*FORMATTED]
+    }
+}
+
+/// Brazil CNPJ (Cadastro Nacional da Pessoa Jurídica) patterns
+///
+/// Format: `NN.NNN.NNN/NNNN-NN` or 14 plain digits.
+pub(crate) mod brazil_cnpj {
+    use super::*;
+
+    /// Formatted CNPJ: NN.NNN.NNN/NNNN-NN
+    pub static FORMATTED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b\d{2}\.\d{3}\.\d{3}/\d{4}-\d{2}\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// CNPJ with explicit label
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:CNPJ|cadastro[\s-]?nacional)[\s:#-]*(\d{2}\.?\d{3}\.?\d{3}/?\d{4}-?\d{2})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*FORMATTED]
+    }
+}
+
+/// Mexico CURP (Clave Única de Registro de Población) patterns
+///
+/// Format: 4 letters + 6 digits (YYMMDD) + gender (H/M) + 2 letters (state) +
+/// 3 letters + alphanumeric + digit.
+pub(crate) mod mexico_curp {
+    use super::*;
+
+    /// CURP standard format (18 characters)
+    pub static STANDARD: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b[A-Z]{4}\d{6}[HM][A-Z]{5}[0-9A-Z]\d\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// CURP with explicit label
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:CURP|clave[\s-]?[uú]nica[\s-]?de[\s-]?registro)[\s:#-]*([A-Z]{4}\d{6}[HM][A-Z]{5}[0-9A-Z]\d)\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
+    }
+}
+
+/// Nigeria NIN (National Identification Number) patterns
+///
+/// Format: 11 plain digits. The unlabeled form is identical to phone numbers
+/// and many other identifiers, so scanning uses LABELED only — analogous to
+/// `india_passport`. Direct `is_nigeria_nin()` checks still accept the bare
+/// 11-digit form.
+pub(crate) mod nigeria_nin {
+    use super::*;
+
+    /// NIN standard format (11 digits, no separators)
+    pub static STANDARD: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\b\d{11}\b").expect("BUG: Invalid regex pattern"));
+
+    /// NIN with explicit label
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\b(?:NIN|national[\s-]?identification[\s-]?number|NIMC)[\s:#-]*(\d{11})\b")
+            .expect("BUG: Invalid regex pattern")
+    });
+
+    /// Returns patterns used for text scanning (LABELED only — STANDARD is
+    /// `\d{11}` which matches phone numbers and many other 11-digit strings).
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED]
+    }
+}
+
+/// Thailand TNIN (National Identification Number) patterns
+///
+/// Format: 13 digits. Display form `N-NNNN-NNNNN-NN-N`.
+pub(crate) mod thailand_tnin {
+    use super::*;
+
+    /// Formatted TNIN: N-NNNN-NNNNN-NN-N
+    pub static FORMATTED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b\d-\d{4}-\d{5}-\d{2}-\d\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// TNIN with explicit label
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:TNIN|Thai[\s-]?national[\s-]?ID|TID)[\s:#-]*(\d-?\d{4}-?\d{5}-?\d{2}-?\d)\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    /// Scanning patterns. Plain 13-digit form is too ambiguous, so only
+    /// formatted or labeled occurrences are scanned.
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*FORMATTED]
+    }
+}
+
 /// Singapore NRIC/FIN patterns
 pub(crate) mod singapore_nric {
     use super::*;

--- a/crates/octarine/src/primitives/identifiers/government/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder.rs
@@ -803,6 +803,197 @@ impl GovernmentIdentifierBuilder {
     }
 
     // ========================================================================
+    // Brazil CPF Operations
+    // ========================================================================
+
+    /// Check if value matches Brazil CPF format
+    #[must_use]
+    pub fn is_brazil_cpf(&self, value: &str) -> bool {
+        detection::is_brazil_cpf(value)
+    }
+
+    /// Find all Brazil CPF numbers in text
+    #[must_use]
+    pub fn find_brazil_cpfs_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_brazil_cpfs_in_text(text)
+    }
+
+    /// Validate Brazil CPF format (without checksum)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the CPF format is invalid
+    pub fn validate_brazil_cpf(&self, cpf: &str) -> Result<(), Problem> {
+        validation::validate_brazil_cpf(cpf)
+    }
+
+    /// Validate Brazil CPF with mod-11 dual check digit verification
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the CPF format or checksum is invalid
+    pub fn validate_brazil_cpf_with_checksum(&self, cpf: &str) -> Result<(), Problem> {
+        validation::validate_brazil_cpf_with_checksum(cpf)
+    }
+
+    /// Check if a Brazil CPF is a test/dummy pattern
+    #[must_use]
+    pub fn is_test_brazil_cpf(&self, cpf: &str) -> bool {
+        validation::is_test_brazil_cpf(cpf)
+    }
+
+    // ========================================================================
+    // Brazil CNPJ Operations
+    // ========================================================================
+
+    /// Check if value matches Brazil CNPJ format
+    #[must_use]
+    pub fn is_brazil_cnpj(&self, value: &str) -> bool {
+        detection::is_brazil_cnpj(value)
+    }
+
+    /// Find all Brazil CNPJ numbers in text
+    #[must_use]
+    pub fn find_brazil_cnpjs_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_brazil_cnpjs_in_text(text)
+    }
+
+    /// Validate Brazil CNPJ format (without checksum)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the CNPJ format is invalid
+    pub fn validate_brazil_cnpj(&self, cnpj: &str) -> Result<(), Problem> {
+        validation::validate_brazil_cnpj(cnpj)
+    }
+
+    /// Validate Brazil CNPJ with mod-11 dual check digit verification
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the CNPJ format or checksum is invalid
+    pub fn validate_brazil_cnpj_with_checksum(&self, cnpj: &str) -> Result<(), Problem> {
+        validation::validate_brazil_cnpj_with_checksum(cnpj)
+    }
+
+    /// Check if a Brazil CNPJ is a test/dummy pattern
+    #[must_use]
+    pub fn is_test_brazil_cnpj(&self, cnpj: &str) -> bool {
+        validation::is_test_brazil_cnpj(cnpj)
+    }
+
+    // ========================================================================
+    // Mexico CURP Operations
+    // ========================================================================
+
+    /// Check if value matches Mexico CURP format
+    #[must_use]
+    pub fn is_mexico_curp(&self, value: &str) -> bool {
+        detection::is_mexico_curp(value)
+    }
+
+    /// Find all Mexico CURPs in text
+    #[must_use]
+    pub fn find_mexico_curps_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_mexico_curps_in_text(text)
+    }
+
+    /// Validate Mexico CURP format (without checksum)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the CURP format is invalid
+    pub fn validate_mexico_curp(&self, curp: &str) -> Result<(), Problem> {
+        validation::validate_mexico_curp(curp)
+    }
+
+    /// Validate Mexico CURP with check digit verification
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the CURP format or checksum is invalid
+    pub fn validate_mexico_curp_with_checksum(&self, curp: &str) -> Result<(), Problem> {
+        validation::validate_mexico_curp_with_checksum(curp)
+    }
+
+    /// Check if a Mexico CURP is a test/dummy pattern
+    #[must_use]
+    pub fn is_test_mexico_curp(&self, curp: &str) -> bool {
+        validation::is_test_mexico_curp(curp)
+    }
+
+    // ========================================================================
+    // Nigeria NIN Operations
+    // ========================================================================
+
+    /// Check if value matches Nigeria NIN format
+    #[must_use]
+    pub fn is_nigeria_nin(&self, value: &str) -> bool {
+        detection::is_nigeria_nin(value)
+    }
+
+    /// Find all Nigeria NINs in text (labeled occurrences only — see pattern docs)
+    #[must_use]
+    pub fn find_nigeria_nins_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_nigeria_nins_in_text(text)
+    }
+
+    /// Validate Nigeria NIN format (no checksum algorithm exists)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the NIN format is invalid
+    pub fn validate_nigeria_nin(&self, nin: &str) -> Result<(), Problem> {
+        validation::validate_nigeria_nin(nin)
+    }
+
+    /// Check if a Nigeria NIN is a test/dummy pattern
+    #[must_use]
+    pub fn is_test_nigeria_nin(&self, nin: &str) -> bool {
+        validation::is_test_nigeria_nin(nin)
+    }
+
+    // ========================================================================
+    // Thailand TNIN Operations
+    // ========================================================================
+
+    /// Check if value matches Thailand TNIN format
+    #[must_use]
+    pub fn is_thailand_tnin(&self, value: &str) -> bool {
+        detection::is_thailand_tnin(value)
+    }
+
+    /// Find all Thailand TNINs in text
+    #[must_use]
+    pub fn find_thailand_tnins_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_thailand_tnins_in_text(text)
+    }
+
+    /// Validate Thailand TNIN format (without checksum)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the TNIN format is invalid
+    pub fn validate_thailand_tnin(&self, tnin: &str) -> Result<(), Problem> {
+        validation::validate_thailand_tnin(tnin)
+    }
+
+    /// Validate Thailand TNIN with mod-11 check digit verification
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the TNIN format or checksum is invalid
+    pub fn validate_thailand_tnin_with_checksum(&self, tnin: &str) -> Result<(), Problem> {
+        validation::validate_thailand_tnin_with_checksum(tnin)
+    }
+
+    /// Check if a Thailand TNIN is a test/dummy pattern
+    #[must_use]
+    pub fn is_test_thailand_tnin(&self, tnin: &str) -> bool {
+        validation::is_test_thailand_tnin(tnin)
+    }
+
+    // ========================================================================
     // Finland HETU Operations
     // ========================================================================
 

--- a/crates/octarine/src/primitives/identifiers/government/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection.rs
@@ -549,6 +549,232 @@ pub fn find_india_passports_in_text(text: &str) -> Vec<IdentifierMatch> {
     deduplicate_matches(matches)
 }
 
+// ============================================================================
+// Brazil CPF
+// ============================================================================
+
+/// Check if a value matches Brazil CPF format
+#[must_use]
+pub fn is_brazil_cpf(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    // Accept plain 11-digit form for direct checks (only text scanning is
+    // restricted to labeled/formatted to avoid false positives).
+    if value.chars().filter(|c| c.is_ascii_digit()).count() == 11
+        && value
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '.' | '-' | ' '))
+    {
+        return true;
+    }
+    patterns::brazil_cpf::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Brazil CPF patterns in text
+#[must_use]
+pub fn find_brazil_cpfs_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::brazil_cpf::all() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::BrazilCpf,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+// ============================================================================
+// Brazil CNPJ
+// ============================================================================
+
+/// Check if a value matches Brazil CNPJ format
+#[must_use]
+pub fn is_brazil_cnpj(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    if value.chars().filter(|c| c.is_ascii_digit()).count() == 14
+        && value
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '.' | '-' | '/' | ' '))
+    {
+        return true;
+    }
+    patterns::brazil_cnpj::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Brazil CNPJ patterns in text
+#[must_use]
+pub fn find_brazil_cnpjs_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::brazil_cnpj::all() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::BrazilCnpj,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+// ============================================================================
+// Mexico CURP
+// ============================================================================
+
+/// Check if a value matches Mexico CURP format
+#[must_use]
+pub fn is_mexico_curp(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    patterns::mexico_curp::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Mexico CURP patterns in text
+#[must_use]
+pub fn find_mexico_curps_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::mexico_curp::all() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::MexicoCurp,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+// ============================================================================
+// Nigeria NIN
+// ============================================================================
+
+/// Check if a value matches Nigeria NIN format (11 digits)
+#[must_use]
+pub fn is_nigeria_nin(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    // Direct value check: 11 digits with optional separators
+    if value.chars().filter(|c| c.is_ascii_digit()).count() == 11
+        && value
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '-' | ' '))
+    {
+        return true;
+    }
+    patterns::nigeria_nin::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Nigeria NIN patterns in text (LABELED only — see pattern docs)
+#[must_use]
+pub fn find_nigeria_nins_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::nigeria_nin::all() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::NigeriaNin,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+// ============================================================================
+// Thailand TNIN
+// ============================================================================
+
+/// Check if a value matches Thailand TNIN format
+#[must_use]
+pub fn is_thailand_tnin(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    if value.chars().filter(|c| c.is_ascii_digit()).count() == 13
+        && value
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '-' | ' '))
+    {
+        return true;
+    }
+    patterns::thailand_tnin::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Thailand TNIN patterns in text
+#[must_use]
+pub fn find_thailand_tnins_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::thailand_tnin::all() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::ThailandTnin,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
 /// Check if a value matches Singapore NRIC/FIN format
 #[must_use]
 pub fn is_singapore_nric(value: &str) -> bool {
@@ -865,6 +1091,16 @@ pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
         Some(IdentifierType::IndiaAadhaar)
     } else if is_india_pan(value) {
         Some(IdentifierType::IndiaPan)
+    } else if is_brazil_cpf(value) {
+        Some(IdentifierType::BrazilCpf)
+    } else if is_brazil_cnpj(value) {
+        Some(IdentifierType::BrazilCnpj)
+    } else if is_mexico_curp(value) {
+        Some(IdentifierType::MexicoCurp)
+    } else if is_thailand_tnin(value) {
+        Some(IdentifierType::ThailandTnin)
+    } else if is_nigeria_nin(value) {
+        Some(IdentifierType::NigeriaNin)
     } else if is_singapore_nric(value) {
         Some(IdentifierType::SingaporeNric)
     } else if is_finland_hetu(value) {
@@ -1331,6 +1567,11 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
     all_matches.extend(find_india_vehicle_registrations_in_text(text));
     all_matches.extend(find_india_voter_ids_in_text(text));
     all_matches.extend(find_india_passports_in_text(text));
+    all_matches.extend(find_brazil_cpfs_in_text(text));
+    all_matches.extend(find_brazil_cnpjs_in_text(text));
+    all_matches.extend(find_mexico_curps_in_text(text));
+    all_matches.extend(find_nigeria_nins_in_text(text));
+    all_matches.extend(find_thailand_tnins_in_text(text));
     all_matches.extend(find_singapore_nrics_in_text(text));
     all_matches.extend(find_finland_hetus_in_text(text));
     all_matches.extend(find_poland_pesels_in_text(text));

--- a/crates/octarine/src/primitives/identifiers/government/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/mod.rs
@@ -117,11 +117,13 @@ pub use validation::{clear_government_caches, ssn_cache_stats, vin_cache_stats};
 
 // Export test pattern detection functions (observe module testing)
 pub use validation::{
-    is_test_australia_abn, is_test_australia_tfn, is_test_driver_license, is_test_ein,
-    is_test_finland_hetu, is_test_india_aadhaar, is_test_india_gstin, is_test_india_pan,
-    is_test_india_passport, is_test_india_vehicle_registration, is_test_india_voter_id,
-    is_test_italy_fiscal_code, is_test_korea_rrn, is_test_poland_pesel, is_test_singapore_nric,
-    is_test_spain_nie, is_test_spain_nif, is_test_vin,
+    is_test_australia_abn, is_test_australia_tfn, is_test_brazil_cnpj, is_test_brazil_cpf,
+    is_test_driver_license, is_test_ein, is_test_finland_hetu, is_test_india_aadhaar,
+    is_test_india_gstin, is_test_india_pan, is_test_india_passport,
+    is_test_india_vehicle_registration, is_test_india_voter_id, is_test_italy_fiscal_code,
+    is_test_korea_rrn, is_test_mexico_curp, is_test_nigeria_nin, is_test_poland_pesel,
+    is_test_singapore_nric, is_test_spain_nie, is_test_spain_nif, is_test_thailand_tnin,
+    is_test_vin,
 };
 
 // Export Australia validation functions
@@ -157,6 +159,21 @@ pub use validation::{validate_singapore_nric, validate_singapore_nric_with_check
 
 // Export Korea RRN validation functions
 pub use validation::{validate_korea_rrn, validate_korea_rrn_with_checksum};
+
+// Export Brazil validation functions (CPF + CNPJ)
+pub use validation::{
+    validate_brazil_cnpj, validate_brazil_cnpj_with_checksum, validate_brazil_cpf,
+    validate_brazil_cpf_with_checksum,
+};
+
+// Export Mexico validation functions
+pub use validation::{validate_mexico_curp, validate_mexico_curp_with_checksum};
+
+// Export Nigeria validation functions
+pub use validation::validate_nigeria_nin;
+
+// Export Thailand validation functions
+pub use validation::{validate_thailand_tnin, validate_thailand_tnin_with_checksum};
 
 // Export strategy types for explicit redaction control
 pub use sanitization::{

--- a/crates/octarine/src/primitives/identifiers/government/validation/brazil.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/brazil.rs
@@ -1,0 +1,484 @@
+//! Brazil CPF and CNPJ validation
+//!
+//! - CPF (Cadastro de Pessoas Físicas): 11 digits with mod-11 dual check digits.
+//!   Format `NNN.NNN.NNN-NN` or 11 plain digits.
+//! - CNPJ (Cadastro Nacional da Pessoa Jurídica): 14 digits with mod-11 dual
+//!   check digits using fixed weight sequences. Format `NN.NNN.NNN/NNNN-NN`
+//!   or 14 plain digits.
+//!
+//! Both formats reject all-same-digit inputs (e.g. `111.111.111-11`) — the
+//! Brazilian Federal Revenue Service explicitly excludes those even though
+//! the mod-11 math would otherwise validate them.
+
+use crate::primitives::types::Problem;
+
+// ============================================================================
+// CPF Validation
+// ============================================================================
+
+/// Validate Brazil CPF format (without checksum)
+///
+/// Checks: 11 digits, not all the same digit.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format is invalid.
+pub fn validate_brazil_cpf(value: &str) -> Result<(), Problem> {
+    let digits = extract_digits(value)?;
+
+    if digits.len() != 11 {
+        return Err(Problem::Validation(format!(
+            "CPF must be 11 digits, got {}",
+            digits.len()
+        )));
+    }
+
+    if all_same_digit(&digits) {
+        return Err(Problem::Validation(
+            "CPF cannot have all identical digits".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate Brazil CPF with mod-11 dual check digits
+///
+/// First check digit weight sequence: 10, 9, 8, 7, 6, 5, 4, 3, 2.
+/// Second check digit weight sequence: 11, 10, 9, 8, 7, 6, 5, 4, 3, 2.
+/// Each check digit: `let r = sum % 11; if r < 2 { 0 } else { 11 - r }`.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format or checksum is invalid.
+pub fn validate_brazil_cpf_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_brazil_cpf(value)?;
+
+    let digits = extract_digits(value)?;
+
+    let d10 = cpf_check_digit(&digits, 0, 9, 10);
+    if digits.get(9).copied() != Some(d10) {
+        return Err(Problem::Validation(
+            "CPF first check digit mismatch".to_string(),
+        ));
+    }
+
+    let d11 = cpf_check_digit(&digits, 0, 10, 11);
+    if digits.get(10).copied() != Some(d11) {
+        return Err(Problem::Validation(
+            "CPF second check digit mismatch".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check if a CPF is a test/dummy pattern (all-same-digit)
+#[must_use]
+pub fn is_test_brazil_cpf(value: &str) -> bool {
+    let Ok(digits) = extract_digits(value) else {
+        return false;
+    };
+    digits.len() == 11 && all_same_digit(&digits)
+}
+
+// ============================================================================
+// CNPJ Validation
+// ============================================================================
+
+/// Validate Brazil CNPJ format (without checksum)
+///
+/// Checks: 14 digits, not all the same digit.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format is invalid.
+pub fn validate_brazil_cnpj(value: &str) -> Result<(), Problem> {
+    let digits = extract_digits(value)?;
+
+    if digits.len() != 14 {
+        return Err(Problem::Validation(format!(
+            "CNPJ must be 14 digits, got {}",
+            digits.len()
+        )));
+    }
+
+    if all_same_digit(&digits) {
+        return Err(Problem::Validation(
+            "CNPJ cannot have all identical digits".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate Brazil CNPJ with mod-11 dual check digits
+///
+/// First check digit weights: 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2.
+/// Second check digit weights: 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format or checksum is invalid.
+pub fn validate_brazil_cnpj_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_brazil_cnpj(value)?;
+
+    let digits = extract_digits(value)?;
+
+    const W1: [u32; 12] = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+    const W2: [u32; 13] = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+    let first_12 = digits.get(..12).unwrap_or(&[]);
+    let d13 = mod11_check_digit(first_12, &W1);
+    if digits.get(12).copied() != Some(d13) {
+        return Err(Problem::Validation(
+            "CNPJ first check digit mismatch".to_string(),
+        ));
+    }
+
+    let first_13 = digits.get(..13).unwrap_or(&[]);
+    let d14 = mod11_check_digit(first_13, &W2);
+    if digits.get(13).copied() != Some(d14) {
+        return Err(Problem::Validation(
+            "CNPJ second check digit mismatch".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check if a CNPJ is a test/dummy pattern (all-same-digit)
+#[must_use]
+pub fn is_test_brazil_cnpj(value: &str) -> bool {
+    let Ok(digits) = extract_digits(value) else {
+        return false;
+    };
+    digits.len() == 14 && all_same_digit(&digits)
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn extract_digits(value: &str) -> Result<Vec<u8>, Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation("input cannot be empty".to_string()));
+    }
+
+    // Reject characters that aren't digits, separators, or whitespace.
+    for ch in trimmed.chars() {
+        if !ch.is_ascii_digit() && !matches!(ch, '.' | '-' | '/' | ' ' | '\t') {
+            return Err(Problem::Validation(format!(
+                "invalid character '{ch}' in identifier"
+            )));
+        }
+    }
+
+    let digits: Vec<u8> = trimmed
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+
+    Ok(digits)
+}
+
+fn all_same_digit(digits: &[u8]) -> bool {
+    digits
+        .first()
+        .is_some_and(|&first| digits.iter().all(|&d| d == first))
+}
+
+/// Compute a CPF check digit over `digits[start..start+len]` using descending
+/// weights from `start_weight` down to 2.
+fn cpf_check_digit(digits: &[u8], start: usize, len: usize, start_weight: u32) -> u8 {
+    let mut sum: u32 = 0;
+    for i in 0..len {
+        let Some(&d) = digits.get(start.saturating_add(i)) else {
+            continue;
+        };
+        let weight = start_weight.saturating_sub(i as u32);
+        sum = sum.saturating_add(u32::from(d).saturating_mul(weight));
+    }
+    let remainder = sum.checked_rem(11).unwrap_or(0);
+    if remainder < 2 {
+        0
+    } else {
+        u8::try_from(11_u32.saturating_sub(remainder)).unwrap_or(0)
+    }
+}
+
+/// Compute a mod-11 check digit over `digits` with fixed `weights`.
+fn mod11_check_digit(digits: &[u8], weights: &[u32]) -> u8 {
+    let mut sum: u32 = 0;
+    for (i, &d) in digits.iter().enumerate() {
+        let weight = weights.get(i).copied().unwrap_or(0);
+        sum = sum.saturating_add(u32::from(d).saturating_mul(weight));
+    }
+    let remainder = sum.checked_rem(11).unwrap_or(0);
+    if remainder < 2 {
+        0
+    } else {
+        u8::try_from(11_u32.saturating_sub(remainder)).unwrap_or(0)
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn make_valid_cpf(first_9: &str) -> String {
+        let digits: Vec<u8> = first_9
+            .chars()
+            .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+            .collect();
+        assert_eq!(digits.len(), 9, "make_valid_cpf needs 9 digits");
+        let mut all = digits.clone();
+        let d10 = cpf_check_digit(&all, 0, 9, 10);
+        all.push(d10);
+        let d11 = cpf_check_digit(&all, 0, 10, 11);
+        all.push(d11);
+        let s: String = all
+            .iter()
+            .map(|d| char::from_digit(u32::from(*d), 10).unwrap_or('0'))
+            .collect();
+        format!("{}.{}.{}-{}", &s[..3], &s[3..6], &s[6..9], &s[9..])
+    }
+
+    fn make_valid_cnpj(first_12: &str) -> String {
+        let digits: Vec<u8> = first_12
+            .chars()
+            .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+            .collect();
+        assert_eq!(digits.len(), 12, "make_valid_cnpj needs 12 digits");
+        const W1: [u32; 12] = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+        const W2: [u32; 13] = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+        let mut all = digits.clone();
+        let d13 = mod11_check_digit(&all, &W1);
+        all.push(d13);
+        let d14 = mod11_check_digit(&all, &W2);
+        all.push(d14);
+        let s: String = all
+            .iter()
+            .map(|d| char::from_digit(u32::from(*d), 10).unwrap_or('0'))
+            .collect();
+        format!(
+            "{}.{}.{}/{}-{}",
+            &s[..2],
+            &s[2..5],
+            &s[5..8],
+            &s[8..12],
+            &s[12..]
+        )
+    }
+
+    // ===== CPF Format Tests =====
+
+    #[test]
+    fn test_validate_cpf_formatted_accepted() {
+        assert!(validate_brazil_cpf("123.456.789-09").is_ok());
+    }
+
+    #[test]
+    fn test_validate_cpf_unformatted_accepted() {
+        assert!(validate_brazil_cpf("12345678909").is_ok());
+    }
+
+    #[test]
+    fn test_validate_cpf_rejects_wrong_length() {
+        assert!(validate_brazil_cpf("1234567890").is_err()); // 10
+        assert!(validate_brazil_cpf("123456789012").is_err()); // 12
+    }
+
+    #[test]
+    fn test_validate_cpf_rejects_empty() {
+        assert!(validate_brazil_cpf("").is_err());
+        assert!(validate_brazil_cpf("   ").is_err());
+    }
+
+    #[test]
+    fn test_validate_cpf_rejects_invalid_chars() {
+        assert!(validate_brazil_cpf("123abc78909").is_err());
+    }
+
+    #[test]
+    fn test_validate_cpf_rejects_all_same() {
+        assert!(validate_brazil_cpf("111.111.111-11").is_err());
+        assert!(validate_brazil_cpf("00000000000").is_err());
+    }
+
+    // ===== CPF Checksum Tests =====
+
+    #[test]
+    fn test_validate_cpf_with_checksum_canonical() {
+        // Known valid test CPF from public sources
+        assert!(validate_brazil_cpf_with_checksum("111.444.777-35").is_ok());
+    }
+
+    #[test]
+    fn test_validate_cpf_with_checksum_generated() {
+        let cpf = make_valid_cpf("123456789");
+        assert!(
+            validate_brazil_cpf_with_checksum(&cpf).is_ok(),
+            "generated CPF {cpf} should validate"
+        );
+    }
+
+    #[test]
+    fn test_validate_cpf_with_checksum_tampered_first_check() {
+        let cpf = make_valid_cpf("123456789");
+        let mut chars: Vec<char> = cpf.chars().collect();
+        // Tamper digit at position 12 (the first check digit, after the dash)
+        let dash_pos = cpf.find('-').expect("formatted CPF contains a dash");
+        let target = dash_pos.saturating_add(1);
+        if let Some(c) = chars.get_mut(target) {
+            *c = if *c == '0' { '1' } else { '0' };
+        }
+        let tampered: String = chars.into_iter().collect();
+        assert!(
+            validate_brazil_cpf_with_checksum(&tampered).is_err(),
+            "tampered CPF {tampered} should fail"
+        );
+    }
+
+    #[test]
+    fn test_validate_cpf_with_checksum_tampered_second_check() {
+        let cpf = make_valid_cpf("123456789");
+        // Flip the last digit
+        let mut chars: Vec<char> = cpf.chars().collect();
+        if let Some(c) = chars.last_mut() {
+            *c = if *c == '0' { '1' } else { '0' };
+        }
+        let tampered: String = chars.into_iter().collect();
+        assert!(validate_brazil_cpf_with_checksum(&tampered).is_err());
+    }
+
+    #[test]
+    fn test_validate_cpf_with_checksum_all_same_rejected() {
+        // Even though the mod-11 math would technically pass for some all-same
+        // CPFs, the spec excludes them.
+        assert!(validate_brazil_cpf_with_checksum("111.111.111-11").is_err());
+        assert!(validate_brazil_cpf_with_checksum("222.222.222-22").is_err());
+    }
+
+    // ===== CPF Test Pattern Tests =====
+
+    #[test]
+    fn test_is_test_brazil_cpf_detects_all_same() {
+        assert!(is_test_brazil_cpf("111.111.111-11"));
+        assert!(is_test_brazil_cpf("00000000000"));
+    }
+
+    #[test]
+    fn test_is_test_brazil_cpf_rejects_real() {
+        assert!(!is_test_brazil_cpf("111.444.777-35"));
+    }
+
+    #[test]
+    fn test_is_test_brazil_cpf_rejects_wrong_length() {
+        assert!(!is_test_brazil_cpf("111"));
+    }
+
+    // ===== CNPJ Format Tests =====
+
+    #[test]
+    fn test_validate_cnpj_formatted_accepted() {
+        assert!(validate_brazil_cnpj("11.222.333/0001-81").is_ok());
+    }
+
+    #[test]
+    fn test_validate_cnpj_unformatted_accepted() {
+        assert!(validate_brazil_cnpj("11222333000181").is_ok());
+    }
+
+    #[test]
+    fn test_validate_cnpj_rejects_wrong_length() {
+        assert!(validate_brazil_cnpj("123").is_err());
+        assert!(validate_brazil_cnpj("123456789012345").is_err()); // 15
+    }
+
+    #[test]
+    fn test_validate_cnpj_rejects_empty() {
+        assert!(validate_brazil_cnpj("").is_err());
+    }
+
+    #[test]
+    fn test_validate_cnpj_rejects_all_same() {
+        assert!(validate_brazil_cnpj("11.111.111/1111-11").is_err());
+    }
+
+    // ===== CNPJ Checksum Tests =====
+
+    #[test]
+    fn test_validate_cnpj_with_checksum_canonical() {
+        // Known valid public test CNPJ
+        assert!(validate_brazil_cnpj_with_checksum("11.222.333/0001-81").is_ok());
+    }
+
+    #[test]
+    fn test_validate_cnpj_with_checksum_generated() {
+        let cnpj = make_valid_cnpj("112223330001");
+        assert!(
+            validate_brazil_cnpj_with_checksum(&cnpj).is_ok(),
+            "generated CNPJ {cnpj} should validate"
+        );
+    }
+
+    #[test]
+    fn test_validate_cnpj_with_checksum_tampered() {
+        let cnpj = make_valid_cnpj("112223330001");
+        let mut chars: Vec<char> = cnpj.chars().collect();
+        if let Some(c) = chars.last_mut() {
+            *c = if *c == '0' { '1' } else { '0' };
+        }
+        let tampered: String = chars.into_iter().collect();
+        assert!(validate_brazil_cnpj_with_checksum(&tampered).is_err());
+    }
+
+    #[test]
+    fn test_validate_cnpj_with_checksum_all_same_rejected() {
+        assert!(validate_brazil_cnpj_with_checksum("11.111.111/1111-11").is_err());
+    }
+
+    // ===== CNPJ Test Pattern Tests =====
+
+    #[test]
+    fn test_is_test_brazil_cnpj_detects_all_same() {
+        assert!(is_test_brazil_cnpj("11.111.111/1111-11"));
+        assert!(is_test_brazil_cnpj("00000000000000"));
+    }
+
+    #[test]
+    fn test_is_test_brazil_cnpj_rejects_real() {
+        assert!(!is_test_brazil_cnpj("11.222.333/0001-81"));
+    }
+
+    // ===== Round-Trip Tests =====
+
+    #[test]
+    fn test_cpf_round_trip_multiple_seeds() {
+        for seed in &["123456789", "987654321", "111222333", "456789012"] {
+            let cpf = make_valid_cpf(seed);
+            assert!(
+                validate_brazil_cpf_with_checksum(&cpf).is_ok(),
+                "CPF from seed {seed} -> {cpf} should validate"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cnpj_round_trip_multiple_seeds() {
+        for seed in &["112223330001", "987654321000", "456789012345"] {
+            let cnpj = make_valid_cnpj(seed);
+            assert!(
+                validate_brazil_cnpj_with_checksum(&cnpj).is_ok(),
+                "CNPJ from seed {seed} -> {cnpj} should validate"
+            );
+        }
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/validation/mexico.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mexico.rs
@@ -1,0 +1,317 @@
+//! Mexico CURP (Clave Única de Registro de Población) validation
+//!
+//! Format (18 characters):
+//! - Positions 1-4: name letters (initials of paternal surname, maternal
+//!   surname, given name)
+//! - Positions 5-10: date of birth `YYMMDD`
+//! - Position 11: gender (`H` male, `M` female)
+//! - Positions 12-13: state/entity code (one of 33 — 32 states plus `NE` for
+//!   foreign-born)
+//! - Positions 14-16: three consonants from the names
+//! - Position 17: disambiguator (digit for pre-2000 births, letter A-Z for
+//!   post-2000 births)
+//! - Position 18: check digit (mod-10 over weighted character values)
+
+use crate::primitives::types::Problem;
+
+/// Valid Mexican state/entity codes used in positions 12-13.
+const VALID_STATE_CODES: &[&str] = &[
+    "AS", "BC", "BS", "CC", "CL", "CM", "CS", "CH", "DF", "DG", "GT", "GR", "HG", "JC", "MC", "MN",
+    "MS", "NT", "NL", "OC", "PL", "QT", "QR", "SP", "SL", "SR", "TC", "TS", "TL", "VZ", "YN", "ZS",
+    "NE", // foreign-born
+];
+
+/// Validate Mexico CURP format (without checksum)
+///
+/// Checks: 18 chars, structural composition (letters, digits, gender, state).
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format is invalid.
+pub fn validate_mexico_curp(value: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation("CURP cannot be empty".to_string()));
+    }
+
+    let upper = trimmed.to_uppercase();
+    let chars: Vec<char> = upper.chars().collect();
+
+    if chars.len() != 18 {
+        return Err(Problem::Validation(format!(
+            "CURP must be 18 characters, got {}",
+            chars.len()
+        )));
+    }
+
+    // Positions 1-4 (0..4): letters
+    for (idx, &ch) in chars.iter().take(4).enumerate() {
+        if !ch.is_ascii_uppercase() {
+            return Err(Problem::Validation(format!(
+                "CURP position {} must be a letter, got '{}'",
+                idx.saturating_add(1),
+                ch
+            )));
+        }
+    }
+
+    // Positions 5-10 (4..10): YYMMDD digits
+    for (idx, &ch) in chars.iter().skip(4).take(6).enumerate() {
+        if !ch.is_ascii_digit() {
+            return Err(Problem::Validation(format!(
+                "CURP position {} (date) must be a digit, got '{}'",
+                idx.saturating_add(5),
+                ch
+            )));
+        }
+    }
+
+    // Position 11 (index 10): gender
+    let gender = chars.get(10).copied().unwrap_or(' ');
+    if gender != 'H' && gender != 'M' {
+        return Err(Problem::Validation(format!(
+            "CURP position 11 (gender) must be 'H' or 'M', got '{gender}'"
+        )));
+    }
+
+    // Positions 12-13 (indices 11..13): state code
+    let state: String = chars.iter().skip(11).take(2).collect();
+    if !VALID_STATE_CODES.contains(&state.as_str()) {
+        return Err(Problem::Validation(format!(
+            "CURP state code '{state}' is not a valid Mexican entity code"
+        )));
+    }
+
+    // Positions 14-16 (indices 13..16): consonants
+    for (i, &ch) in chars.iter().skip(13).take(3).enumerate() {
+        if !ch.is_ascii_uppercase() {
+            return Err(Problem::Validation(format!(
+                "CURP position {} must be a letter, got '{}'",
+                i.saturating_add(14),
+                ch
+            )));
+        }
+    }
+
+    // Position 17 (index 16): disambiguator (digit OR letter)
+    let disamb = chars.get(16).copied().unwrap_or(' ');
+    if !disamb.is_ascii_digit() && !disamb.is_ascii_uppercase() {
+        return Err(Problem::Validation(format!(
+            "CURP position 17 must be a digit or uppercase letter, got '{disamb}'"
+        )));
+    }
+
+    // Position 18 (index 17): check digit (single digit 0-9)
+    let check = chars.get(17).copied().unwrap_or(' ');
+    if !check.is_ascii_digit() {
+        return Err(Problem::Validation(format!(
+            "CURP position 18 (check digit) must be a digit, got '{check}'"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate Mexico CURP with check digit verification
+///
+/// Algorithm: each of positions 1-17 maps to a character value (0-9 for
+/// digits, 10..35 for A..Z), multiplied by weight `19 - position`. Sum,
+/// take mod 10, then check digit = `(10 - remainder) % 10`.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format or check digit is invalid.
+pub fn validate_mexico_curp_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_mexico_curp(value)?;
+
+    let upper = value.trim().to_uppercase();
+    let chars: Vec<char> = upper.chars().collect();
+
+    let computed = compute_curp_check_digit(chars.get(..17).unwrap_or(&[]));
+    let actual = chars.get(17).and_then(|c| c.to_digit(10)).unwrap_or(99);
+
+    if computed != actual {
+        return Err(Problem::Validation(format!(
+            "CURP check digit mismatch: expected {computed}, got {actual}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Check if a CURP is a test/dummy pattern
+///
+/// Currently detects all-same-character inputs (e.g. `AAAAAAAAAAAAAAAAAA`).
+#[must_use]
+pub fn is_test_mexico_curp(value: &str) -> bool {
+    let upper = value.trim().to_uppercase();
+    let chars: Vec<char> = upper.chars().collect();
+    if chars.len() != 18 {
+        return false;
+    }
+    chars
+        .first()
+        .is_some_and(|&first| chars.iter().all(|&c| c == first))
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Map a CURP character to its numeric value:
+/// - `'0'..='9'` → 0..9
+/// - `'A'..='Z'` → 10..35
+/// - Anything else → 0
+fn char_value(ch: char) -> u32 {
+    if let Some(d) = ch.to_digit(10) {
+        d
+    } else if ch.is_ascii_uppercase() {
+        u32::from(ch)
+            .saturating_sub(u32::from('A'))
+            .saturating_add(10)
+    } else {
+        0
+    }
+}
+
+/// Compute the CURP check digit given the first 17 characters.
+fn compute_curp_check_digit(first_17: &[char]) -> u32 {
+    let mut sum: u32 = 0;
+    for (i, &ch) in first_17.iter().enumerate() {
+        let weight = 18_u32.saturating_sub(i as u32);
+        sum = sum.saturating_add(char_value(ch).saturating_mul(weight));
+    }
+    let r = sum.checked_rem(10).unwrap_or(0);
+    10_u32.saturating_sub(r).checked_rem(10).unwrap_or(0)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn make_valid_curp(first_17: &str) -> String {
+        let chars: Vec<char> = first_17.to_uppercase().chars().collect();
+        assert_eq!(chars.len(), 17, "make_valid_curp needs 17 chars");
+        let check = compute_curp_check_digit(&chars);
+        let mut out: String = chars.iter().collect();
+        out.push(char::from_digit(check, 10).unwrap_or('0'));
+        out
+    }
+
+    // ===== Format Tests =====
+
+    #[test]
+    fn test_validate_curp_well_formed() {
+        // Generated CURP that satisfies all structural rules
+        let curp = make_valid_curp("BADD110313HCMLNS0");
+        assert!(validate_mexico_curp(&curp).is_ok());
+    }
+
+    #[test]
+    fn test_validate_curp_lowercase_normalized() {
+        let curp = make_valid_curp("BADD110313HCMLNS0");
+        let lower = curp.to_lowercase();
+        assert!(validate_mexico_curp(&lower).is_ok());
+    }
+
+    #[test]
+    fn test_validate_curp_rejects_wrong_length() {
+        assert!(validate_mexico_curp("BADD110313HDFLNS").is_err()); // 16
+        assert!(validate_mexico_curp("BADD110313HDFLNS099").is_err()); // 19
+    }
+
+    #[test]
+    fn test_validate_curp_rejects_empty() {
+        assert!(validate_mexico_curp("").is_err());
+    }
+
+    #[test]
+    fn test_validate_curp_rejects_bad_gender() {
+        // Position 11 must be H or M
+        let bad = "BADD110313XDFLNS09";
+        assert!(validate_mexico_curp(bad).is_err());
+    }
+
+    #[test]
+    fn test_validate_curp_rejects_bad_state() {
+        // ZZ is not a valid Mexican state code
+        let bad = "BADD110313HZZLNS09";
+        assert!(validate_mexico_curp(bad).is_err());
+    }
+
+    #[test]
+    fn test_validate_curp_accepts_foreign_born_ne() {
+        let curp = make_valid_curp("BADD110313HNELNS0");
+        assert!(validate_mexico_curp(&curp).is_ok());
+    }
+
+    #[test]
+    fn test_validate_curp_rejects_digits_in_name() {
+        let bad = "BAD0110313HDFLNS09";
+        assert!(validate_mexico_curp(bad).is_err());
+    }
+
+    #[test]
+    fn test_validate_curp_rejects_letters_in_date() {
+        let bad = "BADDA10313HDFLNS09";
+        assert!(validate_mexico_curp(bad).is_err());
+    }
+
+    // ===== Checksum Tests =====
+
+    #[test]
+    fn test_validate_curp_with_checksum_generated() {
+        let curp = make_valid_curp("BADD110313HCMLNS0");
+        assert!(validate_mexico_curp_with_checksum(&curp).is_ok());
+    }
+
+    #[test]
+    fn test_validate_curp_with_checksum_tampered_last_digit() {
+        let curp = make_valid_curp("BADD110313HCMLNS0");
+        let mut chars: Vec<char> = curp.chars().collect();
+        if let Some(c) = chars.last_mut() {
+            *c = if *c == '0' { '1' } else { '0' };
+        }
+        let tampered: String = chars.into_iter().collect();
+        assert!(validate_mexico_curp_with_checksum(&tampered).is_err());
+    }
+
+    #[test]
+    fn test_validate_curp_with_checksum_multiple_seeds() {
+        for seed in &[
+            "BADD110313HCMLNS0",
+            "MEFR000123MJCLNS5",
+            "PEAR700515HVZRLN8",
+        ] {
+            let curp = make_valid_curp(seed);
+            assert!(
+                validate_mexico_curp_with_checksum(&curp).is_ok(),
+                "Generated CURP {curp} from seed {seed} should validate"
+            );
+        }
+    }
+
+    // ===== Test Pattern Tests =====
+
+    #[test]
+    fn test_is_test_mexico_curp_all_same() {
+        assert!(is_test_mexico_curp("AAAAAAAAAAAAAAAAAA"));
+        assert!(is_test_mexico_curp("000000000000000000"));
+    }
+
+    #[test]
+    fn test_is_test_mexico_curp_rejects_real() {
+        let curp = make_valid_curp("BADD110313HCMLNS0");
+        assert!(!is_test_mexico_curp(&curp));
+    }
+
+    #[test]
+    fn test_is_test_mexico_curp_rejects_wrong_length() {
+        assert!(!is_test_mexico_curp("AAA"));
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
@@ -37,6 +37,7 @@
 //! | EIN | Input Validation | Best Practice | N/A |
 
 mod australia;
+mod brazil;
 mod cache;
 mod driver_license;
 mod ein;
@@ -44,12 +45,15 @@ mod finland;
 mod india;
 mod italy;
 mod korea_rrn;
+mod mexico;
 mod national_id;
+mod nigeria;
 mod passport;
 mod poland;
 mod singapore;
 mod spain;
 mod ssn;
+mod thailand;
 mod vin;
 
 // Re-export cache utilities
@@ -116,6 +120,23 @@ pub use singapore::{
 
 // Re-export Korea RRN functions
 pub use korea_rrn::{is_test_korea_rrn, validate_korea_rrn, validate_korea_rrn_with_checksum};
+
+// Re-export Brazil functions
+pub use brazil::{
+    is_test_brazil_cnpj, is_test_brazil_cpf, validate_brazil_cnpj,
+    validate_brazil_cnpj_with_checksum, validate_brazil_cpf, validate_brazil_cpf_with_checksum,
+};
+
+// Re-export Mexico functions
+pub use mexico::{is_test_mexico_curp, validate_mexico_curp, validate_mexico_curp_with_checksum};
+
+// Re-export Nigeria functions
+pub use nigeria::{is_test_nigeria_nin, validate_nigeria_nin};
+
+// Re-export Thailand functions
+pub use thailand::{
+    is_test_thailand_tnin, validate_thailand_tnin, validate_thailand_tnin_with_checksum,
+};
 
 // Re-export VIN functions
 pub use vin::{is_test_vin, validate_vin, validate_vin_with_checksum};

--- a/crates/octarine/src/primitives/identifiers/government/validation/nigeria.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/nigeria.rs
@@ -1,0 +1,128 @@
+//! Nigeria NIN (National Identification Number) validation
+//!
+//! Format: 11 digits. No public checksum algorithm — format validation only.
+//! NIMC (National Identity Management Commission) issues these via the
+//! National Identity Database.
+
+use crate::primitives::types::Problem;
+
+/// Validate Nigeria NIN format
+///
+/// Checks: 11 digits, not all the same digit.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format is invalid.
+pub fn validate_nigeria_nin(value: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation("NIN cannot be empty".to_string()));
+    }
+
+    // NIN is plain digits; tolerate hyphens/spaces but reject letters.
+    for ch in trimmed.chars() {
+        if !ch.is_ascii_digit() && !matches!(ch, '-' | ' ' | '\t') {
+            return Err(Problem::Validation(format!(
+                "invalid character '{ch}' in NIN"
+            )));
+        }
+    }
+
+    let digits: Vec<u8> = trimmed
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+
+    if digits.len() != 11 {
+        return Err(Problem::Validation(format!(
+            "NIN must be 11 digits, got {}",
+            digits.len()
+        )));
+    }
+
+    if all_same_digit(&digits) {
+        return Err(Problem::Validation(
+            "NIN cannot have all identical digits".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check if a NIN is a test/dummy pattern (all-same-digit)
+#[must_use]
+pub fn is_test_nigeria_nin(value: &str) -> bool {
+    let digits: Vec<u8> = value
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+    digits.len() == 11 && all_same_digit(&digits)
+}
+
+fn all_same_digit(digits: &[u8]) -> bool {
+    digits
+        .first()
+        .is_some_and(|&first| digits.iter().all(|&d| d == first))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_nin_valid() {
+        assert!(validate_nigeria_nin("12345678901").is_ok());
+    }
+
+    #[test]
+    fn test_validate_nin_with_separators() {
+        assert!(validate_nigeria_nin("123-456-789-01").is_ok());
+    }
+
+    #[test]
+    fn test_validate_nin_rejects_too_short() {
+        assert!(validate_nigeria_nin("1234567890").is_err());
+    }
+
+    #[test]
+    fn test_validate_nin_rejects_too_long() {
+        assert!(validate_nigeria_nin("123456789012").is_err());
+    }
+
+    #[test]
+    fn test_validate_nin_rejects_empty() {
+        assert!(validate_nigeria_nin("").is_err());
+    }
+
+    #[test]
+    fn test_validate_nin_rejects_letters() {
+        assert!(validate_nigeria_nin("12345abc901").is_err());
+    }
+
+    #[test]
+    fn test_validate_nin_rejects_all_same() {
+        assert!(validate_nigeria_nin("11111111111").is_err());
+        assert!(validate_nigeria_nin("00000000000").is_err());
+    }
+
+    #[test]
+    fn test_is_test_nigeria_nin_detects_all_same() {
+        assert!(is_test_nigeria_nin("11111111111"));
+        assert!(is_test_nigeria_nin("00000000000"));
+    }
+
+    #[test]
+    fn test_is_test_nigeria_nin_rejects_real() {
+        assert!(!is_test_nigeria_nin("12345678901"));
+    }
+
+    #[test]
+    fn test_is_test_nigeria_nin_rejects_wrong_length() {
+        assert!(!is_test_nigeria_nin("111"));
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/validation/thailand.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/thailand.rs
@@ -1,0 +1,227 @@
+//! Thailand TNIN (National Identification Number) validation
+//!
+//! Format: 13 digits. Display form `N-NNNN-NNNNN-NN-N`.
+//!
+//! Check digit algorithm: sum `d[i] * (13 - i)` for `i` in 0..12 (weights
+//! 13, 12, …, 2), then `check = (11 - sum % 11) % 10`.
+
+use crate::primitives::types::Problem;
+
+/// Validate Thailand TNIN format (without checksum)
+///
+/// Checks: 13 digits, not all the same digit.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format is invalid.
+pub fn validate_thailand_tnin(value: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation("TNIN cannot be empty".to_string()));
+    }
+
+    for ch in trimmed.chars() {
+        if !ch.is_ascii_digit() && !matches!(ch, '-' | ' ' | '\t') {
+            return Err(Problem::Validation(format!(
+                "invalid character '{ch}' in TNIN"
+            )));
+        }
+    }
+
+    let digits: Vec<u8> = trimmed
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+
+    if digits.len() != 13 {
+        return Err(Problem::Validation(format!(
+            "TNIN must be 13 digits, got {}",
+            digits.len()
+        )));
+    }
+
+    if all_same_digit(&digits) {
+        return Err(Problem::Validation(
+            "TNIN cannot have all identical digits".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate Thailand TNIN with mod-11 weighted-sum check digit
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format or checksum is invalid.
+pub fn validate_thailand_tnin_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_thailand_tnin(value)?;
+
+    let digits: Vec<u8> = value
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+
+    let computed = compute_tnin_check_digit(digits.get(..12).unwrap_or(&[]));
+    let actual = digits.get(12).copied().unwrap_or(99);
+
+    if computed != actual {
+        return Err(Problem::Validation(format!(
+            "TNIN check digit mismatch: expected {computed}, got {actual}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Check if a TNIN is a test/dummy pattern (all-same-digit)
+#[must_use]
+pub fn is_test_thailand_tnin(value: &str) -> bool {
+    let digits: Vec<u8> = value
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+    digits.len() == 13 && all_same_digit(&digits)
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn all_same_digit(digits: &[u8]) -> bool {
+    digits
+        .first()
+        .is_some_and(|&first| digits.iter().all(|&d| d == first))
+}
+
+/// Compute the TNIN check digit from the first 12 digits.
+fn compute_tnin_check_digit(first_12: &[u8]) -> u8 {
+    let mut sum: u32 = 0;
+    for (i, &d) in first_12.iter().enumerate() {
+        let weight = 13_u32.saturating_sub(i as u32);
+        sum = sum.saturating_add(u32::from(d).saturating_mul(weight));
+    }
+    let r = sum.checked_rem(11).unwrap_or(0);
+    let check = 11_u32.saturating_sub(r).checked_rem(10).unwrap_or(0);
+    u8::try_from(check).unwrap_or(0)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn make_valid_tnin(first_12: &str) -> String {
+        let digits: Vec<u8> = first_12
+            .chars()
+            .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+            .collect();
+        assert_eq!(digits.len(), 12, "make_valid_tnin needs 12 digits");
+        let check = compute_tnin_check_digit(&digits);
+        let mut all = digits.clone();
+        all.push(check);
+        all.iter()
+            .map(|d| char::from_digit(u32::from(*d), 10).unwrap_or('0'))
+            .collect()
+    }
+
+    // ===== Format Tests =====
+
+    #[test]
+    fn test_validate_tnin_valid_unformatted() {
+        let tnin = make_valid_tnin("123456789012");
+        assert!(validate_thailand_tnin(&tnin).is_ok());
+    }
+
+    #[test]
+    fn test_validate_tnin_valid_with_dashes() {
+        let tnin = make_valid_tnin("123456789012");
+        // Insert dashes in display form: N-NNNN-NNNNN-NN-N
+        let formatted = format!(
+            "{}-{}-{}-{}-{}",
+            &tnin[..1],
+            &tnin[1..5],
+            &tnin[5..10],
+            &tnin[10..12],
+            &tnin[12..]
+        );
+        assert!(validate_thailand_tnin(&formatted).is_ok());
+    }
+
+    #[test]
+    fn test_validate_tnin_rejects_wrong_length() {
+        assert!(validate_thailand_tnin("1234567890").is_err());
+        assert!(validate_thailand_tnin("12345678901234").is_err());
+    }
+
+    #[test]
+    fn test_validate_tnin_rejects_empty() {
+        assert!(validate_thailand_tnin("").is_err());
+    }
+
+    #[test]
+    fn test_validate_tnin_rejects_letters() {
+        assert!(validate_thailand_tnin("123456789abcd").is_err());
+    }
+
+    #[test]
+    fn test_validate_tnin_rejects_all_same() {
+        assert!(validate_thailand_tnin("1111111111111").is_err());
+    }
+
+    // ===== Checksum Tests =====
+
+    #[test]
+    fn test_validate_tnin_with_checksum_generated() {
+        let tnin = make_valid_tnin("123456789012");
+        assert!(
+            validate_thailand_tnin_with_checksum(&tnin).is_ok(),
+            "Generated TNIN {tnin} should validate"
+        );
+    }
+
+    #[test]
+    fn test_validate_tnin_with_checksum_tampered() {
+        let tnin = make_valid_tnin("123456789012");
+        let mut chars: Vec<char> = tnin.chars().collect();
+        if let Some(c) = chars.last_mut() {
+            *c = if *c == '0' { '1' } else { '0' };
+        }
+        let tampered: String = chars.into_iter().collect();
+        assert!(validate_thailand_tnin_with_checksum(&tampered).is_err());
+    }
+
+    #[test]
+    fn test_validate_tnin_with_checksum_multiple_seeds() {
+        for seed in &["123456789012", "987654321098", "111222333444"] {
+            let tnin = make_valid_tnin(seed);
+            assert!(
+                validate_thailand_tnin_with_checksum(&tnin).is_ok(),
+                "Generated TNIN {tnin} from seed {seed} should validate"
+            );
+        }
+    }
+
+    // ===== Test Pattern Tests =====
+
+    #[test]
+    fn test_is_test_thailand_tnin_all_same() {
+        assert!(is_test_thailand_tnin("1111111111111"));
+        assert!(is_test_thailand_tnin("0000000000000"));
+    }
+
+    #[test]
+    fn test_is_test_thailand_tnin_rejects_real() {
+        let tnin = make_valid_tnin("123456789012");
+        assert!(!is_test_thailand_tnin(&tnin));
+    }
+
+    #[test]
+    fn test_is_test_thailand_tnin_rejects_wrong_length() {
+        assert!(!is_test_thailand_tnin("111"));
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -468,6 +468,41 @@ impl StreamingScanner {
                         total = total.saturating_add(1);
                     }
                 }
+                IdentifierType::BrazilCpf => {
+                    let government = GovernmentIdentifierBuilder::new();
+                    for m in government.find_brazil_cpfs_in_text(text) {
+                        let _ = self.buffer.push(m);
+                        total = total.saturating_add(1);
+                    }
+                }
+                IdentifierType::BrazilCnpj => {
+                    let government = GovernmentIdentifierBuilder::new();
+                    for m in government.find_brazil_cnpjs_in_text(text) {
+                        let _ = self.buffer.push(m);
+                        total = total.saturating_add(1);
+                    }
+                }
+                IdentifierType::MexicoCurp => {
+                    let government = GovernmentIdentifierBuilder::new();
+                    for m in government.find_mexico_curps_in_text(text) {
+                        let _ = self.buffer.push(m);
+                        total = total.saturating_add(1);
+                    }
+                }
+                IdentifierType::NigeriaNin => {
+                    let government = GovernmentIdentifierBuilder::new();
+                    for m in government.find_nigeria_nins_in_text(text) {
+                        let _ = self.buffer.push(m);
+                        total = total.saturating_add(1);
+                    }
+                }
+                IdentifierType::ThailandTnin => {
+                    let government = GovernmentIdentifierBuilder::new();
+                    for m in government.find_thailand_tnins_in_text(text) {
+                        let _ = self.buffer.push(m);
+                        total = total.saturating_add(1);
+                    }
+                }
                 IdentifierType::FinlandHetu => {
                     let government = GovernmentIdentifierBuilder::new();
                     for m in government.find_finland_hetus_in_text(text) {

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -73,6 +73,11 @@ pub enum IdentifierType {
     IndiaVehicleReg, // Indian vehicle registration (license plate)
     IndiaVoterId,    // Indian Voter ID (EPIC - Electors Photo Identity Card)
     IndiaPassport,   // Indian passport (P/S/D type indicator + 7 digits)
+    BrazilCpf,       // Brazilian Cadastro de Pessoas Físicas (mod-11 dual check digits)
+    BrazilCnpj,      // Brazilian Cadastro Nacional da Pessoa Jurídica (mod-11 dual check digits)
+    MexicoCurp,      // Mexican Clave Única de Registro de Población (18 chars + check)
+    NigeriaNin,      // Nigerian National Identification Number (11 digits)
+    ThailandTnin,    // Thai National Identification Number (13 digits, mod-11 check)
     SingaporeNric,   // Singapore NRIC/FIN
     FinlandHetu,     // Finnish personal identity code
     PolandPesel,     // Polish personal identity number (PESEL)


### PR DESCRIPTION
## Summary

Adds five government identifier types covering Latin America and Africa, following the established 12-step `octarine-identifier-checklist` and mirroring PR #305 (India extended IDs):

- **Brazil CPF** — 11-digit personal taxpayer ID with mod-11 dual check digits (weights 10..2 then 11..2). All-same-digit inputs rejected per spec.
- **Brazil CNPJ** — 14-digit corporate ID with mod-11 dual check digits.
- **Mexico CURP** — 18-character national ID with position-weighted mod-10 check digit; validates 32 state codes (+ `NE` for foreign-born) and gender (`H`/`M`).
- **Nigeria NIN** — 11-digit national ID (no public checksum). Text scanning is **label-gated** to avoid false positives on phone numbers (same approach as India passport).
- **Thailand TNIN** — 13-digit national ID with mod-11 weighted check digit.

## Files changed

16 files, +2,183 / -9 LOC. Pipeline coverage matches PR #305:

| Layer | File | What |
|---|---|---|
| Types | `primitives/identifiers/types/core.rs` | 5 new `IdentifierType` variants |
| Validation | `government/validation/{brazil,mexico,nigeria,thailand}.rs` | New (484/317/128/227 LOC) |
| Validation | `government/validation/mod.rs` | Module wiring + re-exports |
| Patterns | `common/patterns/personal.rs`, `patterns/mod.rs` | 5 regex modules |
| Detection | `government/detection.rs` | `is_*` + `find_*_in_text` + chain wiring |
| Primitives builder | `government/builder.rs` | Delegation methods |
| Primitives mod | `government/mod.rs` | Public re-exports |
| Streaming | `primitives/identifiers/streaming.rs` | 5 dispatcher arms |
| Layer 3 builder | `identifiers/builder/government.rs` | Observe-instrumented wrappers |
| PII bridge | `observe/pii/types.rs` | 5 `PiiType` variants + `name()` + `domain()` + `is_high_risk()` + `From<IdentifierType>` |
| PII scanner | `observe/pii/scanner/domains.rs` | 5 scanner arms |
| PII redactor | `observe/pii/redactor/mod.rs` | Routing through `redact_government_ids` |

## Test plan

- [x] 64 new unit tests across the four new validation modules (Brazil 27, Mexico 15, Nigeria 10, Thailand 12)
- [x] CPF canonical sample (`111.444.777-35`) validates against checksum
- [x] CNPJ canonical sample (`11.222.333/0001-81`) validates against checksum
- [x] All-same-digit CPF/CNPJ rejected even when mod-11 math would otherwise pass
- [x] Tampered last digit detected for all checksum-capable IDs
- [x] Generated round-trip helpers (`make_valid_*`) cover multiple seed values
- [x] Mexico CURP rejects bad state codes (`ZZ`) and bad gender letters
- [x] Lowercase CURP normalized via `to_uppercase` before validation
- [x] `just fmt` clean
- [x] `just clippy` clean (all denied lints satisfied — no `unwrap`, indexing, or unchecked arithmetic)
- [x] `just arch-check` clean
- [x] `just test-octarine` passes (6,644 passed; one pre-existing flaky timing test `cache::lru::test_cache_cleanup` unrelated to this work — known issue from PR #299)

## Compliance context

These identifiers are protected under:

- LGPD (Brazil)
- POPIA (South Africa) — applicable to NIN-style IDs more broadly
- NDPR (Nigeria)
- PDPA (Thailand)
- Mexican Federal Law on the Protection of Personal Data

Not registered as GDPR-protected (non-EU regimes apply), matching the India identifier precedent.

Closes #34