### PR TITLE
refactor(naming): rename internal prohibited-prefix functions (slice of #193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ All notable changes to octarine will be documented in this file.
   - `find_postal_codes_in_text` now gates short-numeric matches (DE/FR/AU/IN) on a ±50-char address-context keyword window (`zip`, `postal code`, `PLZ`, `CEP`, `PIN code`, `code postal`) to suppress false positives on phone numbers, prices, and years
   - `normalize_postal_code` accepts bare-digit Japanese (NNNNNNN) and Brazilian (NNNNNNNN) forms and inserts canonical hyphens; Dutch codes are normalized to a single space between digits and letters
 
+### Changed
+
+- refactor(naming): rename internal `pub fn` violations of prohibited-prefix naming convention (slice of #193)
+  - `primitives/crypto/auth/hmac`: `verify_hmac{,_strict,_hex,_with_domain,_multipart}` → `is_hmac_valid` / `validate_hmac_strict` / `is_hmac_hex_valid` / `is_hmac_with_domain_valid` / `is_hmac_multipart_valid`
+  - `primitives/crypto/builder::HmacBuilder`: `verify_strict` / `verify_hex` / `verify_with_domain` / `verify_multipart` → `validate_strict` / `is_hex_valid` / `is_with_domain_valid` / `is_multipart_valid`
+  - `primitives/crypto/keys/password`: `verify_password{,_sync}` → `validate_password{,_sync}`
+  - `primitives/io/file/permissions::ensure_directory_mode` → `with_directory_mode`
+  - `primitives/data/paths` (4 sites): `ensure_trailing_separator` → `with_trailing_separator`
+  - `primitives/security/paths/sanitization::remove_traversal_sequences` → `strip_traversal_sequences`
+  - `observe/metrics/thresholds::check_threshold` → `evaluate_threshold`
+  - `observe/writers::ensure_registry` → `init_registry_if_missing`
+  - Layer 3 public surface (`crypto::auth::hmac::verify_*`, `crypto::keys::password::verify_*`, `data::paths::FormatBuilder::ensure_trailing_separator`, `SeparatorStyle::has_separators`, `primitives::io::net::HealthCheck::check_health`) is unchanged in this PR — those require a deprecation cycle and will be done with the next minor bump (#314)
+  - `scripts/arch_check/checks/naming_prefix.py` scope extended to cover `primitives/crypto`, `primitives/data`, `primitives/io`, and `observe`
+
 ## [0.3.0-beta.3] - 2026-04-28
 
 ### Fixed

--- a/crates/octarine/src/crypto/auth/hmac.rs
+++ b/crates/octarine/src/crypto/auth/hmac.rs
@@ -73,7 +73,7 @@ pub fn compute_hex(key: &[u8], message: &[u8]) -> String {
 /// - Returns `false` for incorrect length MACs (timing-safe)
 #[must_use]
 pub fn verify(key: &[u8], message: &[u8], expected_mac: &[u8]) -> bool {
-    let valid = prim::verify_hmac(key, message, expected_mac);
+    let valid = prim::is_hmac_valid(key, message, expected_mac);
 
     if valid {
         observe::info(
@@ -98,7 +98,7 @@ pub fn verify(key: &[u8], message: &[u8], expected_mac: &[u8]) -> bool {
 ///
 /// Returns `CryptoError::MacVerification` if verification fails.
 pub fn verify_strict(key: &[u8], message: &[u8], expected_mac: &[u8]) -> Result<(), CryptoError> {
-    let result = prim::verify_hmac_strict(key, message, expected_mac);
+    let result = prim::validate_hmac_strict(key, message, expected_mac);
 
     match &result {
         Ok(()) => {
@@ -121,7 +121,7 @@ pub fn verify_strict(key: &[u8], message: &[u8], expected_mac: &[u8]) -> Result<
 /// Verify an HMAC from a hex-encoded string with audit trail.
 #[must_use]
 pub fn verify_hex(key: &[u8], message: &[u8], hex_mac: &str) -> bool {
-    let valid = prim::verify_hmac_hex(key, message, hex_mac);
+    let valid = prim::is_hmac_hex_valid(key, message, hex_mac);
 
     if valid {
         observe::info(
@@ -179,7 +179,7 @@ pub fn with_domain(key: &[u8], domain: &str, message: &[u8]) -> [u8; 32] {
 /// Verify an HMAC created with domain separation with audit trail.
 #[must_use]
 pub fn verify_with_domain(key: &[u8], domain: &str, message: &[u8], mac: &[u8]) -> bool {
-    let valid = prim::verify_hmac_with_domain(key, domain, message, mac);
+    let valid = prim::is_hmac_with_domain_valid(key, domain, message, mac);
 
     if valid {
         observe::info(
@@ -241,7 +241,7 @@ pub fn multipart(key: &[u8], parts: &[&[u8]]) -> [u8; 32] {
 /// Verify a multipart HMAC with audit trail.
 #[must_use]
 pub fn verify_multipart(key: &[u8], parts: &[&[u8]], mac: &[u8]) -> bool {
-    let valid = prim::verify_hmac_multipart(key, parts, mac);
+    let valid = prim::is_hmac_multipart_valid(key, parts, mac);
 
     let total_len: usize = parts.iter().map(|p| p.len()).sum();
     if valid {

--- a/crates/octarine/src/crypto/keys/password.rs
+++ b/crates/octarine/src/crypto/keys/password.rs
@@ -127,7 +127,7 @@ pub async fn verify(password: &str, hash: &str) -> Result<bool, PasswordError> {
     let start = Instant::now();
     observe::debug("password_verify", "Starting password verification");
 
-    let result = prim::verify_password(password, hash).await;
+    let result = prim::validate_password(password, hash).await;
 
     let elapsed = start.elapsed();
     match &result {
@@ -298,7 +298,7 @@ pub fn hash_with_profile_sync(
 ///
 /// **Warning**: Blocks the current thread. Use `verify()` in async contexts.
 pub fn verify_sync(password: &str, hash: &str) -> Result<bool, CryptoError> {
-    let result = prim::verify_password_sync(password, hash);
+    let result = prim::validate_password_sync(password, hash);
 
     match &result {
         Ok(true) => observe::info("password_verify", "Password verification succeeded"),

--- a/crates/octarine/src/data/paths/builder/format.rs
+++ b/crates/octarine/src/data/paths/builder/format.rs
@@ -232,7 +232,7 @@ impl FormatBuilder {
     /// Ensure path has trailing separator
     #[must_use]
     pub fn ensure_trailing_separator<'a>(&self, path: &'a str) -> Cow<'a, str> {
-        PrimitiveFormatBuilder::new().ensure_trailing_separator(path)
+        PrimitiveFormatBuilder::new().with_trailing_separator(path)
     }
 
     /// Strip leading dot-slash (./) from path

--- a/crates/octarine/src/observe/metrics/counters/mod.rs
+++ b/crates/octarine/src/observe/metrics/counters/mod.rs
@@ -40,7 +40,7 @@ impl Counter {
     /// Increment the counter by 1
     pub(crate) fn increment(&self) {
         let new_value = self.value.fetch_add(1, Ordering::Relaxed).saturating_add(1);
-        super::thresholds::check_threshold(&self.name, new_value as f64);
+        super::thresholds::evaluate_threshold(&self.name, new_value as f64);
     }
 
     /// Increment the counter by a specific amount
@@ -49,7 +49,7 @@ impl Counter {
             .value
             .fetch_add(amount, Ordering::Relaxed)
             .saturating_add(amount);
-        super::thresholds::check_threshold(&self.name, new_value as f64);
+        super::thresholds::evaluate_threshold(&self.name, new_value as f64);
     }
 
     /// Get the current value

--- a/crates/octarine/src/observe/metrics/gauges/mod.rs
+++ b/crates/octarine/src/observe/metrics/gauges/mod.rs
@@ -61,7 +61,7 @@ impl Gauge {
         watermarks.last_updated = Instant::now();
 
         // Check thresholds
-        super::thresholds::check_threshold(&self.name, value as f64);
+        super::thresholds::evaluate_threshold(&self.name, value as f64);
     }
 
     /// Increment the gauge

--- a/crates/octarine/src/observe/metrics/histograms/mod.rs
+++ b/crates/octarine/src/observe/metrics/histograms/mod.rs
@@ -39,7 +39,7 @@ impl Histogram {
         let _ = self.values.push(value);
 
         // Check thresholds (e.g., for response time SLOs)
-        super::thresholds::check_threshold(&self.name, value);
+        super::thresholds::evaluate_threshold(&self.name, value);
     }
 
     /// Get a snapshot of the histogram

--- a/crates/octarine/src/observe/metrics/thresholds.rs
+++ b/crates/octarine/src/observe/metrics/thresholds.rs
@@ -461,10 +461,10 @@ pub fn list_thresholds() -> Vec<String> {
     global_monitor().list()
 }
 
-/// Check a metric value against its threshold (internal use)
+/// Evaluate a metric value against its threshold (internal use)
 ///
 /// Called automatically by metric operations when thresholds are registered.
-pub(crate) fn check_threshold(metric_name: &str, value: f64) {
+pub(crate) fn evaluate_threshold(metric_name: &str, value: f64) {
     global_monitor().check(metric_name, value);
 }
 

--- a/crates/octarine/src/observe/writers/file/core.rs
+++ b/crates/octarine/src/observe/writers/file/core.rs
@@ -9,9 +9,9 @@ use crate::observe::types::{Event, Severity};
 use crate::observe::writers::builder::FileWriterBuilder;
 use crate::observe::writers::sanitize_for_writing;
 use crate::observe::writers::types::LogFormat;
-use crate::primitives::io::file::ensure_directory_mode;
 #[cfg(unix)]
 use crate::primitives::io::file::set_mode;
+use crate::primitives::io::file::with_directory_mode;
 use crate::primitives::runtime::r#async::{
     CircuitBreaker, CircuitBreakerConfig, RetryPolicy, sleep_ms,
 };
@@ -34,7 +34,7 @@ pub(super) async fn from_builder(builder: FileWriterBuilder) -> Result<FileWrite
     // Type system guarantees log_dir is valid and absolute
     let dir_path = log_dir.as_path().to_path_buf();
     crate::primitives::runtime::r#async::spawn_blocking(move || {
-        ensure_directory_mode(&dir_path, dir_mode)
+        with_directory_mode(&dir_path, dir_mode)
     })
     .await
     .map_err(|e| Problem::operation_failed(format!("Directory setup task failed: {}", e)))?

--- a/crates/octarine/src/observe/writers/mod.rs
+++ b/crates/octarine/src/observe/writers/mod.rs
@@ -216,7 +216,7 @@ struct RegisteredWriter {
 static WRITER_REGISTRY: RwLock<Option<HashMap<&'static str, RegisteredWriter>>> = RwLock::new(None);
 
 /// Initialize the registry if needed
-fn ensure_registry() {
+fn init_registry_if_missing() {
     let mut registry = WRITER_REGISTRY.write().unwrap_or_else(|e| e.into_inner());
     if registry.is_none() {
         *registry = Some(HashMap::new());
@@ -247,7 +247,7 @@ fn ensure_registry() {
 /// register_writer(Box::new(MyWriter));
 /// ```
 pub fn register_writer(writer: Box<dyn Writer>) {
-    ensure_registry();
+    init_registry_if_missing();
     let name = writer.name();
     // Store as Arc so we can clone handles out of the registry and drop the
     // lock guard before awaiting `Writer::write` in `dispatch_to_writers`.

--- a/crates/octarine/src/primitives/auth/password/policy.rs
+++ b/crates/octarine/src/primitives/auth/password/policy.rs
@@ -424,7 +424,7 @@ pub fn validate_password(
         let history_to_check = password_history.iter().take(policy.history_count);
 
         for (index, &old_hash) in history_to_check.enumerate() {
-            // Note: In production, this would use verify_password from crypto module
+            // Note: In production, this would use validate_password from crypto module
             // For now, we do a simple comparison (caller should pass hashes)
             if password == old_hash {
                 return Err(Problem::Validation(

--- a/crates/octarine/src/primitives/crypto/auth/hmac/helpers.rs
+++ b/crates/octarine/src/primitives/crypto/auth/hmac/helpers.rs
@@ -39,7 +39,7 @@ pub fn hmac_with_domain(key: &[u8], domain: &str, message: &[u8]) -> [u8; MAC_LE
 
 /// Verify a MAC that was created with domain separation.
 #[must_use]
-pub fn verify_hmac_with_domain(
+pub fn is_hmac_with_domain_valid(
     key: &[u8],
     domain: &str,
     message: &[u8],
@@ -88,7 +88,7 @@ pub fn hmac_multipart(key: &[u8], parts: &[&[u8]]) -> [u8; MAC_LENGTH] {
 
 /// Verify a multipart MAC.
 #[must_use]
-pub fn verify_hmac_multipart(key: &[u8], parts: &[&[u8]], expected_mac: &[u8]) -> bool {
+pub fn is_hmac_multipart_valid(key: &[u8], parts: &[&[u8]], expected_mac: &[u8]) -> bool {
     let computed = hmac_multipart(key, parts);
     super::super::ct_eq(&computed, expected_mac)
 }
@@ -118,16 +118,16 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_hmac_with_domain() {
+    fn test_is_hmac_with_domain_valid() {
         let key = b"key";
         let domain = "my-domain";
         let message = b"data";
 
         let mac = hmac_with_domain(key, domain, message);
 
-        assert!(verify_hmac_with_domain(key, domain, message, &mac));
-        assert!(!verify_hmac_with_domain(key, "other", message, &mac));
-        assert!(!verify_hmac_with_domain(key, domain, b"wrong", &mac));
+        assert!(is_hmac_with_domain_valid(key, domain, message, &mac));
+        assert!(!is_hmac_with_domain_valid(key, "other", message, &mac));
+        assert!(!is_hmac_with_domain_valid(key, domain, b"wrong", &mac));
     }
 
     // =========================================================================
@@ -181,13 +181,13 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_hmac_multipart() {
+    fn test_is_hmac_multipart_valid() {
         let key = b"key";
         let parts: &[&[u8]] = &[b"header", b"body"];
 
         let mac = hmac_multipart(key, parts);
 
-        assert!(verify_hmac_multipart(key, parts, &mac));
-        assert!(!verify_hmac_multipart(key, &[b"wrong"], &mac));
+        assert!(is_hmac_multipart_valid(key, parts, &mac));
+        assert!(!is_hmac_multipart_valid(key, &[b"wrong"], &mac));
     }
 }

--- a/crates/octarine/src/primitives/crypto/auth/hmac/mod.rs
+++ b/crates/octarine/src/primitives/crypto/auth/hmac/mod.rs
@@ -26,7 +26,7 @@
 //! ## Example
 //!
 //! ```ignore
-//! use crate::primitives::crypto::hmac::{hmac_sha3_256, verify_hmac};
+//! use crate::primitives::crypto::hmac::{hmac_sha3_256, is_hmac_valid};
 //!
 //! let key = b"shared-secret-key";
 //! let message = b"important data to authenticate";
@@ -35,7 +35,7 @@
 //! let mac = hmac_sha3_256(key, message);
 //!
 //! // Verify MAC (constant-time comparison)
-//! assert!(verify_hmac(key, message, &mac));
+//! assert!(is_hmac_valid(key, message, &mac));
 //! ```
 
 // Allow dead_code: Layer 1 primitives used by Layer 2/3 modules
@@ -45,7 +45,7 @@ mod helpers;
 mod streaming;
 
 pub use helpers::{
-    hmac_multipart, hmac_with_domain, verify_hmac_multipart, verify_hmac_with_domain,
+    hmac_multipart, hmac_with_domain, is_hmac_multipart_valid, is_hmac_with_domain_valid,
 };
 pub use streaming::HmacSha3_256;
 
@@ -143,17 +143,17 @@ pub fn hmac_sha3_256_hex(key: &[u8], message: &[u8]) -> String {
 /// # Example
 ///
 /// ```ignore
-/// use crate::primitives::crypto::hmac::{hmac_sha3_256, verify_hmac};
+/// use crate::primitives::crypto::hmac::{hmac_sha3_256, is_hmac_valid};
 ///
 /// let key = b"secret";
 /// let message = b"data";
 /// let valid_mac = hmac_sha3_256(key, message);
 ///
-/// assert!(verify_hmac(key, message, &valid_mac));
-/// assert!(!verify_hmac(key, b"wrong", &valid_mac));
+/// assert!(is_hmac_valid(key, message, &valid_mac));
+/// assert!(!is_hmac_valid(key, b"wrong", &valid_mac));
 /// ```
 #[must_use]
-pub fn verify_hmac(key: &[u8], message: &[u8], expected_mac: &[u8]) -> bool {
+pub fn is_hmac_valid(key: &[u8], message: &[u8], expected_mac: &[u8]) -> bool {
     // Constant-time length check
     if expected_mac.len() != MAC_LENGTH {
         return false;
@@ -165,7 +165,7 @@ pub fn verify_hmac(key: &[u8], message: &[u8], expected_mac: &[u8]) -> bool {
 
 /// Verify an HMAC-SHA3-256 tag, returning a Result.
 ///
-/// Like [`verify_hmac`] but returns a `Result` for use in error handling
+/// Like [`is_hmac_valid`] but returns a `Result` for use in error handling
 /// chains. Useful when MAC verification failure should propagate as an error.
 ///
 /// # Errors
@@ -175,21 +175,21 @@ pub fn verify_hmac(key: &[u8], message: &[u8], expected_mac: &[u8]) -> bool {
 /// # Example
 ///
 /// ```ignore
-/// use crate::primitives::crypto::hmac::{hmac_sha3_256, verify_hmac_strict};
+/// use crate::primitives::crypto::hmac::{hmac_sha3_256, validate_hmac_strict};
 ///
 /// let key = b"secret";
 /// let message = b"data";
 /// let mac = hmac_sha3_256(key, message);
 ///
-/// verify_hmac_strict(key, message, &mac)?;
+/// validate_hmac_strict(key, message, &mac)?;
 /// // Continues if valid, returns error if invalid
 /// ```
-pub fn verify_hmac_strict(
+pub fn validate_hmac_strict(
     key: &[u8],
     message: &[u8],
     expected_mac: &[u8],
 ) -> Result<(), CryptoError> {
-    if verify_hmac(key, message, expected_mac) {
+    if is_hmac_valid(key, message, expected_mac) {
         Ok(())
     } else {
         Err(CryptoError::mac_verification("HMAC verification failed"))
@@ -211,9 +211,9 @@ pub fn verify_hmac_strict(
 ///
 /// `true` if valid, `false` if invalid or malformed hex.
 #[must_use]
-pub fn verify_hmac_hex(key: &[u8], message: &[u8], hex_mac: &str) -> bool {
+pub fn is_hmac_hex_valid(key: &[u8], message: &[u8], hex_mac: &str) -> bool {
     match hex_decode(hex_mac) {
-        Some(mac_bytes) => verify_hmac(key, message, &mac_bytes),
+        Some(mac_bytes) => is_hmac_valid(key, message, &mac_bytes),
         None => false,
     }
 }
@@ -422,71 +422,71 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_verify_hmac_valid() {
+    fn test_is_hmac_valid() {
         let key = b"secret";
         let message = b"data";
         let mac = hmac_sha3_256(key, message);
 
-        assert!(verify_hmac(key, message, &mac));
+        assert!(is_hmac_valid(key, message, &mac));
     }
 
     #[test]
-    fn test_verify_hmac_wrong_message() {
+    fn test_is_hmac_valid_wrong_message() {
         let key = b"secret";
         let mac = hmac_sha3_256(key, b"original");
 
-        assert!(!verify_hmac(key, b"modified", &mac));
+        assert!(!is_hmac_valid(key, b"modified", &mac));
     }
 
     #[test]
-    fn test_verify_hmac_wrong_key() {
+    fn test_is_hmac_valid_wrong_key() {
         let message = b"data";
         let mac = hmac_sha3_256(b"key1", message);
 
-        assert!(!verify_hmac(b"key2", message, &mac));
+        assert!(!is_hmac_valid(b"key2", message, &mac));
     }
 
     #[test]
-    fn test_verify_hmac_wrong_length() {
+    fn test_is_hmac_valid_wrong_length() {
         let key = b"secret";
         let message = b"data";
 
         // Too short
-        assert!(!verify_hmac(key, message, &[0u8; 16]));
+        assert!(!is_hmac_valid(key, message, &[0u8; 16]));
         // Too long
-        assert!(!verify_hmac(key, message, &[0u8; 64]));
+        assert!(!is_hmac_valid(key, message, &[0u8; 64]));
     }
 
     #[test]
-    fn test_verify_hmac_modified_mac() {
+    fn test_is_hmac_valid_modified_mac() {
         let key = b"secret";
         let message = b"data";
         let mut mac = hmac_sha3_256(key, message);
 
         // Flip one bit
         mac[0] ^= 1;
-        assert!(!verify_hmac(key, message, &mac));
+        assert!(!is_hmac_valid(key, message, &mac));
     }
 
     #[test]
-    fn test_verify_hmac_strict() {
+    fn test_validate_hmac_strict() {
         let key = b"secret";
         let message = b"data";
         let mac = hmac_sha3_256(key, message);
 
-        assert!(verify_hmac_strict(key, message, &mac).is_ok());
-        assert!(verify_hmac_strict(key, b"wrong", &mac).is_err());
+        assert!(validate_hmac_strict(key, message, &mac).is_ok());
+        assert!(validate_hmac_strict(key, b"wrong", &mac).is_err());
     }
 
     #[test]
-    fn test_verify_hmac_hex() {
+    fn test_is_hmac_hex_valid() {
         let key = b"secret";
         let message = b"data";
         let mac_hex = hmac_sha3_256_hex(key, message);
 
-        assert!(verify_hmac_hex(key, message, &mac_hex));
-        assert!(!verify_hmac_hex(key, b"wrong", &mac_hex));
-        assert!(!verify_hmac_hex(key, message, "invalid-hex"));
+        assert!(is_hmac_hex_valid(key, message, &mac_hex));
+        assert!(!is_hmac_hex_valid(key, b"wrong", &mac_hex));
+        assert!(!is_hmac_hex_valid(key, message, "invalid-hex"));
     }
 
     // =========================================================================

--- a/crates/octarine/src/primitives/crypto/auth/mod.rs
+++ b/crates/octarine/src/primitives/crypto/auth/mod.rs
@@ -12,19 +12,19 @@
 //! | Function | Use Case |
 //! |----------|----------|
 //! | `hmac_sha3_256` | Generate authentication tag for data |
-//! | `verify_hmac` | Verify data hasn't been tampered with |
+//! | `is_hmac_valid` | Verify data hasn't been tampered with |
 //! | `ct_eq` | Compare secrets without timing leaks |
 //!
 //! ## Example
 //!
 //! ```ignore
-//! use crate::primitives::crypto::auth::{hmac_sha3_256, verify_hmac, ct_eq};
+//! use crate::primitives::crypto::auth::{hmac_sha3_256, is_hmac_valid, ct_eq};
 //!
 //! // Generate HMAC for data
 //! let mac = hmac_sha3_256(&key, b"message");
 //!
 //! // Verify HMAC (constant-time)
-//! let valid = verify_hmac(&key, b"message", &mac);
+//! let valid = is_hmac_valid(&key, b"message", &mac);
 //!
 //! // Compare two secrets (constant-time)
 //! let equal = ct_eq(&secret1, &secret2);
@@ -39,8 +39,8 @@ mod timing;
 // Re-export HMAC functions
 pub use hmac::{
     HmacSha3_256, MAC_LENGTH, hmac_multipart, hmac_sha3_256, hmac_sha3_256_hex, hmac_with_domain,
-    verify_hmac, verify_hmac_hex, verify_hmac_multipart, verify_hmac_strict,
-    verify_hmac_with_domain,
+    is_hmac_hex_valid, is_hmac_multipart_valid, is_hmac_valid, is_hmac_with_domain_valid,
+    validate_hmac_strict,
 };
 
 // Re-export timing functions

--- a/crates/octarine/src/primitives/crypto/builder/hmac.rs
+++ b/crates/octarine/src/primitives/crypto/builder/hmac.rs
@@ -2,8 +2,9 @@
 
 use crate::primitives::crypto::CryptoError;
 use crate::primitives::crypto::auth::{
-    HmacSha3_256, hmac_multipart, hmac_sha3_256, hmac_sha3_256_hex, hmac_with_domain, verify_hmac,
-    verify_hmac_hex, verify_hmac_multipart, verify_hmac_strict, verify_hmac_with_domain,
+    HmacSha3_256, hmac_multipart, hmac_sha3_256, hmac_sha3_256_hex, hmac_with_domain,
+    is_hmac_hex_valid, is_hmac_multipart_valid, is_hmac_valid, is_hmac_with_domain_valid,
+    validate_hmac_strict,
 };
 
 /// Builder for HMAC-SHA3-256 message authentication operations
@@ -56,20 +57,25 @@ impl HmacBuilder {
     /// Returns `true` if the MAC is valid.
     #[must_use]
     pub fn verify(&self, key: &[u8], message: &[u8], mac: &[u8]) -> bool {
-        verify_hmac(key, message, mac)
+        is_hmac_valid(key, message, mac)
     }
 
     /// Verify an HMAC tag, returning a Result
     ///
     /// Useful for error handling chains.
-    pub fn verify_strict(&self, key: &[u8], message: &[u8], mac: &[u8]) -> Result<(), CryptoError> {
-        verify_hmac_strict(key, message, mac)
+    pub fn validate_strict(
+        &self,
+        key: &[u8],
+        message: &[u8],
+        mac: &[u8],
+    ) -> Result<(), CryptoError> {
+        validate_hmac_strict(key, message, mac)
     }
 
     /// Verify an HMAC from a hex string
     #[must_use]
-    pub fn verify_hex(&self, key: &[u8], message: &[u8], hex_mac: &str) -> bool {
-        verify_hmac_hex(key, message, hex_mac)
+    pub fn is_hex_valid(&self, key: &[u8], message: &[u8], hex_mac: &str) -> bool {
+        is_hmac_hex_valid(key, message, hex_mac)
     }
 
     /// Create an incremental HMAC for streaming data
@@ -100,8 +106,14 @@ impl HmacBuilder {
 
     /// Verify an HMAC created with domain separation
     #[must_use]
-    pub fn verify_with_domain(&self, key: &[u8], domain: &str, message: &[u8], mac: &[u8]) -> bool {
-        verify_hmac_with_domain(key, domain, message, mac)
+    pub fn is_with_domain_valid(
+        &self,
+        key: &[u8],
+        domain: &str,
+        message: &[u8],
+        mac: &[u8],
+    ) -> bool {
+        is_hmac_with_domain_valid(key, domain, message, mac)
     }
 
     /// Compute HMAC for multiple message parts
@@ -115,8 +127,8 @@ impl HmacBuilder {
 
     /// Verify a multipart HMAC
     #[must_use]
-    pub fn verify_multipart(&self, key: &[u8], parts: &[&[u8]], mac: &[u8]) -> bool {
-        verify_hmac_multipart(key, parts, mac)
+    pub fn is_multipart_valid(&self, key: &[u8], parts: &[&[u8]], mac: &[u8]) -> bool {
+        is_hmac_multipart_valid(key, parts, mac)
     }
 }
 

--- a/crates/octarine/src/primitives/crypto/builder/password.rs
+++ b/crates/octarine/src/primitives/crypto/builder/password.rs
@@ -5,7 +5,7 @@ use crate::primitives::crypto::keys::{
     PasswordCharset, PasswordProfile, PasswordStrength, derive_key_from_password_sync,
     derive_key_from_password_with_profile_sync, derive_multiple_keys_from_password_sync,
     estimate_password_strength, generate_password, hash_password_sync,
-    hash_password_with_profile_sync, verify_password_sync,
+    hash_password_with_profile_sync, validate_password_sync,
 };
 
 /// Builder for password operations
@@ -76,7 +76,7 @@ impl PasswordBuilder {
     /// assert!(!crypto.password().verify("wrong", &hash)?);
     /// ```
     pub fn verify(&self, password: &str, hash: &str) -> Result<bool, CryptoError> {
-        verify_password_sync(password, hash)
+        validate_password_sync(password, hash)
     }
 
     /// Derive an encryption key from a password

--- a/crates/octarine/src/primitives/crypto/keys/mod.rs
+++ b/crates/octarine/src/primitives/crypto/keys/mod.rs
@@ -51,13 +51,13 @@ pub use password::{
     PasswordCharset, PasswordError, PasswordProfile, PasswordStrength, derive_key_from_password,
     derive_key_from_password_with_profile, derive_multiple_keys_from_password,
     derive_multiple_keys_with_profile, estimate_password_strength, generate_password,
-    hash_password, hash_password_with_profile, verify_password,
+    hash_password, hash_password_with_profile, validate_password,
 };
 // Sync functions (legacy/blocking contexts)
 pub use password::{
     derive_key_from_password_sync, derive_key_from_password_with_profile_sync,
     derive_multiple_keys_from_password_sync, derive_multiple_keys_with_profile_sync,
-    hash_password_sync, hash_password_with_profile_sync, verify_password_sync,
+    hash_password_sync, hash_password_with_profile_sync, validate_password_sync,
 };
 
 // Re-export random functions

--- a/crates/octarine/src/primitives/crypto/keys/password.rs
+++ b/crates/octarine/src/primitives/crypto/keys/password.rs
@@ -10,7 +10,7 @@
 //! attacks. This module provides async-first APIs that offload CPU-intensive
 //! work to a blocking thread pool:
 //!
-//! - Primary API is async (`hash_password()`, `verify_password()`, etc.)
+//! - Primary API is async (`hash_password()`, `validate_password()`, etc.)
 //! - Sync variants available with `*_sync()` suffix
 //!
 //! ## Why Argon2id?
@@ -32,21 +32,21 @@
 //! ## Example (Async)
 //!
 //! ```ignore
-//! use crate::primitives::crypto::keys::password::{hash_password, verify_password};
+//! use crate::primitives::crypto::keys::password::{hash_password, validate_password};
 //!
 //! // Hash a password for storage (runs on blocking thread pool)
 //! let hash = hash_password("user_password").await?;
-//! assert!(verify_password("user_password", &hash).await?);
+//! assert!(validate_password("user_password", &hash).await?);
 //! ```
 //!
 //! ## Example (Sync)
 //!
 //! ```ignore
-//! use crate::primitives::crypto::keys::password::{hash_password_sync, verify_password_sync};
+//! use crate::primitives::crypto::keys::password::{hash_password_sync, validate_password_sync};
 //!
 //! // Hash synchronously (blocks current thread)
 //! let hash = hash_password_sync("user_password")?;
-//! assert!(verify_password_sync("user_password", &hash)?);
+//! assert!(validate_password_sync("user_password", &hash)?);
 //! ```
 //!
 //! ## IMPORTANT: HKDF vs Argon2
@@ -209,14 +209,14 @@ pub async fn hash_password_with_profile(
 /// # Example
 ///
 /// ```ignore
-/// if verify_password("user_input", &stored_hash).await? {
+/// if validate_password("user_input", &stored_hash).await? {
 ///     // Login successful
 /// }
 /// ```
-pub async fn verify_password(password: &str, hash: &str) -> Result<bool, PasswordError> {
+pub async fn validate_password(password: &str, hash: &str) -> Result<bool, PasswordError> {
     let password = password.to_owned();
     let hash = hash.to_owned();
-    let result = spawn_blocking(move || verify_password_sync(&password, &hash)).await?;
+    let result = spawn_blocking(move || validate_password_sync(&password, &hash)).await?;
     Ok(result?)
 }
 
@@ -255,10 +255,10 @@ pub fn hash_password_with_profile_sync(
 
 /// Verify a password against a stored hash (sync).
 ///
-/// **Warning**: Blocks the current thread. In async contexts, use `verify_password()`.
+/// **Warning**: Blocks the current thread. In async contexts, use `validate_password()`.
 ///
 /// Performs constant-time comparison to prevent timing attacks.
-pub fn verify_password_sync(password: &str, hash: &str) -> Result<bool, CryptoError> {
+pub fn validate_password_sync(password: &str, hash: &str) -> Result<bool, CryptoError> {
     let parsed_hash = PasswordHash::new(hash)
         .map_err(|e| CryptoError::key_derivation(format!("Invalid hash format: {e}")))?;
 
@@ -685,8 +685,8 @@ mod tests {
         let hash = hash_password_sync("test_password").expect("Failed to hash");
         assert!(hash.starts_with("$argon2id$"));
 
-        assert!(verify_password_sync("test_password", &hash).expect("Verify failed"));
-        assert!(!verify_password_sync("wrong_password", &hash).expect("Verify failed"));
+        assert!(validate_password_sync("test_password", &hash).expect("Verify failed"));
+        assert!(!validate_password_sync("wrong_password", &hash).expect("Verify failed"));
     }
 
     #[test]
@@ -698,8 +698,8 @@ mod tests {
             hash_password_with_profile_sync("test", PasswordProfile::Moderate).expect("Failed");
 
         // Both should verify correctly
-        assert!(verify_password_sync("test", &hash_interactive).expect("Verify failed"));
-        assert!(verify_password_sync("test", &hash_moderate).expect("Verify failed"));
+        assert!(validate_password_sync("test", &hash_interactive).expect("Verify failed"));
+        assert!(validate_password_sync("test", &hash_moderate).expect("Verify failed"));
 
         // Different parameters produce different hashes
         assert_ne!(hash_interactive, hash_moderate);
@@ -833,7 +833,7 @@ mod tests {
         };
 
         let hash = hash_password_with_profile_sync("test", profile).expect("Failed");
-        assert!(verify_password_sync("test", &hash).expect("Verify failed"));
+        assert!(validate_password_sync("test", &hash).expect("Verify failed"));
     }
 
     #[test]
@@ -847,16 +847,16 @@ mod tests {
     fn test_empty_password() {
         // Empty password should still work (though not recommended)
         let hash = hash_password_sync("").expect("Failed to hash");
-        assert!(verify_password_sync("", &hash).expect("Verify failed"));
-        assert!(!verify_password_sync("x", &hash).expect("Verify failed"));
+        assert!(validate_password_sync("", &hash).expect("Verify failed"));
+        assert!(!validate_password_sync("x", &hash).expect("Verify failed"));
     }
 
     #[test]
     fn test_unicode_password() {
         let password = "пароль密码🔐";
         let hash = hash_password_sync(password).expect("Failed to hash");
-        assert!(verify_password_sync(password, &hash).expect("Verify failed"));
-        assert!(!verify_password_sync("wrong", &hash).expect("Verify failed"));
+        assert!(validate_password_sync(password, &hash).expect("Verify failed"));
+        assert!(!validate_password_sync("wrong", &hash).expect("Verify failed"));
     }
 
     // ========================================================================
@@ -871,12 +871,12 @@ mod tests {
         assert!(hash.starts_with("$argon2id$"));
 
         assert!(
-            verify_password("test_password", &hash)
+            validate_password("test_password", &hash)
                 .await
                 .expect("Verify failed")
         );
         assert!(
-            !verify_password("wrong_password", &hash)
+            !validate_password("wrong_password", &hash)
                 .await
                 .expect("Verify failed")
         );

--- a/crates/octarine/src/primitives/crypto/prelude.rs
+++ b/crates/octarine/src/primitives/crypto/prelude.rs
@@ -94,8 +94,8 @@ pub use super::auth::{
 // HMAC-SHA3-256 functions
 pub use super::auth::{
     HmacSha3_256, MAC_LENGTH, hmac_multipart, hmac_sha3_256, hmac_sha3_256_hex, hmac_with_domain,
-    verify_hmac, verify_hmac_hex, verify_hmac_multipart, verify_hmac_strict,
-    verify_hmac_with_domain,
+    is_hmac_hex_valid, is_hmac_multipart_valid, is_hmac_valid, is_hmac_with_domain_valid,
+    validate_hmac_strict,
 };
 
 // ============================================================================
@@ -112,7 +112,7 @@ pub use super::keys::{
     PasswordCharset, PasswordProfile, PasswordStrength, derive_key_from_password,
     derive_key_from_password_with_profile, derive_multiple_keys_from_password,
     derive_multiple_keys_with_profile, estimate_password_strength, generate_password,
-    hash_password, hash_password_with_profile, verify_password,
+    hash_password, hash_password_with_profile, validate_password,
 };
 
 // Random generation

--- a/crates/octarine/src/primitives/data/paths/builder/format_detection.rs
+++ b/crates/octarine/src/primitives/data/paths/builder/format_detection.rs
@@ -129,10 +129,10 @@ impl PathBuilder {
 
     /// Ensure path has trailing separator
     ///
-    /// Delegates to [`format::ensure_trailing_separator`].
+    /// Delegates to [`format::with_trailing_separator`].
     #[must_use]
-    pub fn ensure_trailing_separator<'a>(&self, path: &'a str) -> Cow<'a, str> {
-        format::ensure_trailing_separator(path)
+    pub fn with_trailing_separator<'a>(&self, path: &'a str) -> Cow<'a, str> {
+        format::with_trailing_separator(path)
     }
 
     /// Strip leading dot-slash from path
@@ -263,7 +263,7 @@ mod tests {
             "path/to/dir"
         );
         assert_eq!(
-            builder.ensure_trailing_separator("path/to/dir").as_ref(),
+            builder.with_trailing_separator("path/to/dir").as_ref(),
             "path/to/dir/"
         );
 

--- a/crates/octarine/src/primitives/data/paths/common/normalization.rs
+++ b/crates/octarine/src/primitives/data/paths/common/normalization.rs
@@ -317,12 +317,12 @@ pub fn strip_trailing_separator(path: &str) -> &str {
 /// ```ignore
 /// use octarine::primitives::paths::common::normalization;
 ///
-/// assert_eq!(normalization::ensure_trailing_separator("path/to/dir"), "path/to/dir/");
-/// assert_eq!(normalization::ensure_trailing_separator("path\\to\\dir"), "path\\to\\dir\\");
-/// assert_eq!(normalization::ensure_trailing_separator("path/to/dir/"), "path/to/dir/"); // Unchanged
+/// assert_eq!(normalization::with_trailing_separator("path/to/dir"), "path/to/dir/");
+/// assert_eq!(normalization::with_trailing_separator("path\\to\\dir"), "path\\to\\dir\\");
+/// assert_eq!(normalization::with_trailing_separator("path/to/dir/"), "path/to/dir/"); // Unchanged
 /// ```
 #[must_use]
-pub fn ensure_trailing_separator(path: &str) -> Cow<'_, str> {
+pub fn with_trailing_separator(path: &str) -> Cow<'_, str> {
     if path.ends_with('/') || path.ends_with('\\') {
         Cow::Borrowed(path)
     } else if path.contains('\\') && !path.contains('/') {
@@ -519,17 +519,17 @@ mod tests {
     }
 
     #[test]
-    fn test_ensure_trailing_separator() {
+    fn test_with_trailing_separator() {
         assert_eq!(
-            ensure_trailing_separator("path/to/dir").as_ref(),
+            with_trailing_separator("path/to/dir").as_ref(),
             "path/to/dir/"
         );
         assert_eq!(
-            ensure_trailing_separator("path\\to\\dir").as_ref(),
+            with_trailing_separator("path\\to\\dir").as_ref(),
             "path\\to\\dir\\"
         );
         // Already has trailing
-        let result = ensure_trailing_separator("path/to/dir/");
+        let result = with_trailing_separator("path/to/dir/");
         assert!(matches!(result, Cow::Borrowed(_)));
     }
 

--- a/crates/octarine/src/primitives/data/paths/format/builder.rs
+++ b/crates/octarine/src/primitives/data/paths/format/builder.rs
@@ -215,8 +215,8 @@ impl FormatBuilder {
 
     /// Ensure path has trailing separator
     #[must_use]
-    pub fn ensure_trailing_separator<'a>(&self, path: &'a str) -> Cow<'a, str> {
-        conversion::ensure_trailing_separator(path)
+    pub fn with_trailing_separator<'a>(&self, path: &'a str) -> Cow<'a, str> {
+        conversion::with_trailing_separator(path)
     }
 
     /// Strip leading dot-slash from path
@@ -420,7 +420,7 @@ mod tests {
             "path/to/dir"
         );
         assert_eq!(
-            builder.ensure_trailing_separator("path/to/dir").as_ref(),
+            builder.with_trailing_separator("path/to/dir").as_ref(),
             "path/to/dir/"
         );
         assert_eq!(

--- a/crates/octarine/src/primitives/data/paths/format/conversion.rs
+++ b/crates/octarine/src/primitives/data/paths/format/conversion.rs
@@ -233,11 +233,11 @@ pub fn strip_trailing_separator(path: &str) -> &str {
 /// ```ignore
 /// use octarine::primitives::paths::format::conversion;
 ///
-/// assert_eq!(conversion::ensure_trailing_separator("path/to/dir"), "path/to/dir/");
-/// assert_eq!(conversion::ensure_trailing_separator("path\\to\\dir"), "path\\to\\dir\\");
+/// assert_eq!(conversion::with_trailing_separator("path/to/dir"), "path/to/dir/");
+/// assert_eq!(conversion::with_trailing_separator("path\\to\\dir"), "path\\to\\dir\\");
 /// ```
 #[must_use]
-pub fn ensure_trailing_separator(path: &str) -> Cow<'_, str> {
+pub fn with_trailing_separator(path: &str) -> Cow<'_, str> {
     if path.ends_with('/') || path.ends_with('\\') {
         Cow::Borrowed(path)
     } else if path.contains('\\') && !path.contains('/') {
@@ -627,17 +627,17 @@ mod tests {
     }
 
     #[test]
-    fn test_ensure_trailing_separator() {
+    fn test_with_trailing_separator() {
         assert_eq!(
-            ensure_trailing_separator("path/to/dir").as_ref(),
+            with_trailing_separator("path/to/dir").as_ref(),
             "path/to/dir/"
         );
         assert_eq!(
-            ensure_trailing_separator("path\\to\\dir").as_ref(),
+            with_trailing_separator("path\\to\\dir").as_ref(),
             "path\\to\\dir\\"
         );
         // Already has trailing
-        let result = ensure_trailing_separator("path/to/dir/");
+        let result = with_trailing_separator("path/to/dir/");
         assert!(matches!(result, Cow::Borrowed(_)));
     }
 

--- a/crates/octarine/src/primitives/data/paths/format/mod.rs
+++ b/crates/octarine/src/primitives/data/paths/format/mod.rs
@@ -134,7 +134,6 @@ pub use detection::{
 // Re-export conversion functions
 pub use conversion::{
     convert_to_format,
-    ensure_trailing_separator,
     normalize_separators,
     // Separator cleanup
     strip_leading_dot_slash,
@@ -149,5 +148,6 @@ pub use conversion::{
     windows_drive_to_unix,
     // Cross-platform conversion
     windows_drive_to_wsl,
+    with_trailing_separator,
     wsl_to_windows_drive,
 };

--- a/crates/octarine/src/primitives/identifiers/confidence/context.rs
+++ b/crates/octarine/src/primitives/identifiers/confidence/context.rs
@@ -96,7 +96,7 @@ impl ContextAnalyzer {
         match_end: usize,
         entity_type: &IdentifierType,
     ) -> f64 {
-        if self.has_keyword_in_window(text, match_start, match_end, entity_type) {
+        if self.is_keyword_in_window_present(text, match_start, match_end, entity_type) {
             // Boost and cap
             let boosted = BASE_CONFIDENCE + self.config.boost_factor;
             if boosted > self.config.max_confidence {
@@ -121,11 +121,11 @@ impl ContextAnalyzer {
         match_end: usize,
         entity_type: &IdentifierType,
     ) -> bool {
-        self.has_keyword_in_window(text, match_start, match_end, entity_type)
+        self.is_keyword_in_window_present(text, match_start, match_end, entity_type)
     }
 
     /// Internal: check if any keyword appears in the window around the match.
-    fn has_keyword_in_window(
+    fn is_keyword_in_window_present(
         &self,
         text: &str,
         match_start: usize,

--- a/crates/octarine/src/primitives/identifiers/location/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/location/detection.rs
@@ -446,7 +446,7 @@ pub fn find_postal_codes_in_text(text: &str) -> Vec<IdentifierMatch> {
         for capture in pattern.captures_iter(text) {
             let full_match = capture.get(0).expect("BUG: capture group 0 always exists");
             let matched = full_match.as_str();
-            if !has_address_context(text, full_match.start(), full_match.end()) {
+            if !is_address_context_present(text, full_match.start(), full_match.end()) {
                 continue;
             }
             // Range re-validation for short numerics. Regex already enforces
@@ -480,7 +480,7 @@ const POSTAL_CONTEXT_WINDOW: usize = 50;
 ///
 /// Slicing uses [`str::get`] (saturating bounds), so non-ASCII boundary
 /// failures degrade to "no context found" rather than panic.
-fn has_address_context(text: &str, match_start: usize, match_end: usize) -> bool {
+fn is_address_context_present(text: &str, match_start: usize, match_end: usize) -> bool {
     let before_start = match_start.saturating_sub(POSTAL_CONTEXT_WINDOW);
     let after_end = match_end
         .saturating_add(POSTAL_CONTEXT_WINDOW)

--- a/crates/octarine/src/primitives/io/file/mod.rs
+++ b/crates/octarine/src/primitives/io/file/mod.rs
@@ -124,7 +124,7 @@ pub use locking::{
 #[allow(unused_imports)]
 pub use options::{SyncMode, TempStrategy, WriteOptions};
 #[allow(unused_imports)]
-pub use permissions::{FileMode, ensure_directory_mode, set_file_mode, set_mode};
+pub use permissions::{FileMode, set_file_mode, set_mode, with_directory_mode};
 
 // Magic byte detection
 #[allow(unused_imports)]

--- a/crates/octarine/src/primitives/io/file/permissions.rs
+++ b/crates/octarine/src/primitives/io/file/permissions.rs
@@ -363,13 +363,13 @@ pub fn set_file_mode(_file: &std::fs::File, _mode: FileMode) -> Result<(), Probl
 /// # Examples
 ///
 /// ```rust,ignore
-/// use crate::primitives::io::{ensure_directory_mode, FileMode};
+/// use crate::primitives::io::{with_directory_mode, FileMode};
 ///
 /// // Creates /var/log/myapp with 0750 if it doesn't exist
 /// // If it exists, attempts to set permissions (may silently skip if not owned)
-/// ensure_directory_mode("/var/log/myapp", FileMode::LOG_DIR)?;
+/// with_directory_mode("/var/log/myapp", FileMode::LOG_DIR)?;
 /// ```
-pub fn ensure_directory_mode(path: impl AsRef<Path>, mode: FileMode) -> Result<(), Problem> {
+pub fn with_directory_mode(path: impl AsRef<Path>, mode: FileMode) -> Result<(), Problem> {
     let path = path.as_ref();
 
     // Create directory if needed
@@ -590,7 +590,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_ensure_directory_mode() {
+    fn test_with_directory_mode() {
         use std::os::unix::fs::PermissionsExt;
         use tempfile::tempdir;
 
@@ -598,7 +598,7 @@ mod tests {
         let new_dir = dir.path().join("subdir");
 
         // Create and set mode
-        ensure_directory_mode(&new_dir, FileMode::LOG_DIR).expect("ensure dir");
+        with_directory_mode(&new_dir, FileMode::LOG_DIR).expect("ensure dir");
 
         // Verify
         assert!(new_dir.is_dir());
@@ -609,7 +609,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_ensure_directory_mode_creates_nested_dirs() {
+    fn test_with_directory_mode_creates_nested_dirs() {
         use std::os::unix::fs::PermissionsExt;
         use tempfile::tempdir;
 
@@ -617,7 +617,7 @@ mod tests {
         let nested_dir = dir.path().join("a").join("b").join("c");
 
         // Create nested directories
-        ensure_directory_mode(&nested_dir, FileMode::LOG_DIR).expect("ensure nested dir");
+        with_directory_mode(&nested_dir, FileMode::LOG_DIR).expect("ensure nested dir");
 
         // Verify leaf directory exists with correct permissions
         assert!(nested_dir.is_dir());
@@ -628,7 +628,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_ensure_directory_mode_updates_owned_existing_dir() {
+    fn test_with_directory_mode_updates_owned_existing_dir() {
         use std::os::unix::fs::PermissionsExt;
         use tempfile::tempdir;
 
@@ -640,8 +640,8 @@ mod tests {
         std::fs::set_permissions(&subdir, std::fs::Permissions::from_mode(0o777))
             .expect("set initial permissions");
 
-        // Now ensure_directory_mode should update it (we own it)
-        ensure_directory_mode(&subdir, FileMode::LOG_DIR).expect("ensure dir");
+        // Now with_directory_mode should update it (we own it)
+        with_directory_mode(&subdir, FileMode::LOG_DIR).expect("ensure dir");
 
         // Verify permissions were updated
         let metadata = std::fs::metadata(&subdir).expect("get metadata");
@@ -651,10 +651,10 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_ensure_directory_mode_on_tmp_succeeds() {
+    fn test_with_directory_mode_on_tmp_succeeds() {
         // /tmp exists and is owned by root, but we should NOT fail
         // This tests the "don't fail on directories we don't own" behavior
-        let result = ensure_directory_mode("/tmp", FileMode::LOG_DIR);
+        let result = with_directory_mode("/tmp", FileMode::LOG_DIR);
 
         // Should succeed (not try to change permissions on /tmp)
         assert!(result.is_ok(), "Should not fail on /tmp: {:?}", result);
@@ -662,17 +662,17 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_ensure_directory_mode_on_var_tmp_succeeds() {
+    fn test_with_directory_mode_on_var_tmp_succeeds() {
         // /var/tmp is another common shared directory
         if std::path::Path::new("/var/tmp").exists() {
-            let result = ensure_directory_mode("/var/tmp", FileMode::LOG_DIR);
+            let result = with_directory_mode("/var/tmp", FileMode::LOG_DIR);
             assert!(result.is_ok(), "Should not fail on /var/tmp: {:?}", result);
         }
     }
 
     #[cfg(unix)]
     #[test]
-    fn test_ensure_directory_mode_creates_subdir_in_tmp() {
+    fn test_with_directory_mode_creates_subdir_in_tmp() {
         use std::time::{SystemTime, UNIX_EPOCH};
 
         // Create a unique subdirectory in /tmp
@@ -684,7 +684,7 @@ mod tests {
         let path = std::path::PathBuf::from(&subdir);
 
         // Should create the subdirectory with correct permissions
-        let result = ensure_directory_mode(&path, FileMode::LOG_DIR);
+        let result = with_directory_mode(&path, FileMode::LOG_DIR);
 
         // Cleanup before assertions (so cleanup happens even if assertions fail)
         #[allow(clippy::disallowed_methods)]
@@ -701,7 +701,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_ensure_directory_mode_creates_subdir_with_correct_perms() {
+    fn test_with_directory_mode_creates_subdir_with_correct_perms() {
         use std::os::unix::fs::PermissionsExt;
         use tempfile::tempdir;
 
@@ -710,7 +710,7 @@ mod tests {
         let subdir = parent.path().join("myapp_logs");
 
         // Should create the subdirectory with correct permissions
-        ensure_directory_mode(&subdir, FileMode::LOG_DIR).expect("ensure subdir");
+        with_directory_mode(&subdir, FileMode::LOG_DIR).expect("ensure subdir");
 
         assert!(subdir.is_dir());
         let metadata = std::fs::metadata(&subdir).expect("get metadata");

--- a/crates/octarine/src/primitives/security/paths/sanitization.rs
+++ b/crates/octarine/src/primitives/security/paths/sanitization.rs
@@ -180,8 +180,8 @@ pub fn sanitize_clean(path: &str) -> SanitizationResult {
     // Remove control characters (except keeping spaces)
     result = result.chars().filter(|c| !c.is_control()).collect();
 
-    // Remove traversal sequences
-    result = remove_traversal_sequences(&result);
+    // Strip traversal sequences
+    result = strip_traversal_sequences(&result);
 
     // Normalize separators
     result = normalize_separators(&result);
@@ -273,7 +273,7 @@ pub fn sanitize_escape(path: &str) -> SanitizationResult {
 /// ```
 #[must_use]
 pub fn strip_traversal(path: &str) -> String {
-    remove_traversal_sequences(path)
+    strip_traversal_sequences(path)
 }
 
 /// Strip null bytes from path
@@ -328,8 +328,8 @@ pub fn normalize_path_separators(path: &str) -> String {
 // Helper Functions (Internal)
 // ============================================================================
 
-/// Remove `..` path components
-fn remove_traversal_sequences(path: &str) -> String {
+/// Strip `..` path components
+fn strip_traversal_sequences(path: &str) -> String {
     // Split by separators, filter out .., rejoin
     let parts: Vec<&str> = path
         .split(['/', '\\'])
@@ -393,7 +393,7 @@ fn normalize_separators(path: &str) -> String {
 #[must_use]
 pub fn strip_traversal_cow(path: &str) -> Cow<'_, str> {
     if detection::is_traversal_present(path) {
-        Cow::Owned(remove_traversal_sequences(path))
+        Cow::Owned(strip_traversal_sequences(path))
     } else {
         Cow::Borrowed(path)
     }

--- a/scripts/arch_check/checks/naming_prefix.py
+++ b/scripts/arch_check/checks/naming_prefix.py
@@ -11,10 +11,23 @@ from scripts.arch_check.core import Finding, iter_files, rel
 _TRIGGER = re.compile(r"pub fn (has_|contains_|check_|verify_|ensure_|remove_)")
 _EXTRACT = re.compile(r"(has_|contains_|check_|verify_|ensure_|remove_)[a-z_]*")
 
+# Subdirs to scan. Order matches the historical bash recipe: identifier
+# subdirs first, then the broader primitives/observe domains added in #193.
+# Layer 3 paths (`crypto/`, `data/`) are deliberately excluded — their few
+# remaining violations are `pub fn` public-API renames that require a
+# deprecation cycle paired with the next minor bump.
+_SUBDIRS: tuple[str, ...] = (
+    "primitives/identifiers",
+    "identifiers",
+    "primitives/crypto",
+    "primitives/data",
+    "primitives/io",
+    "observe",
+)
+
 
 def run(*, staged_only: bool, root: Path) -> Iterator[Finding]:
-    # Subdir order matches bash: primitives/identifiers first, then identifiers.
-    for subdir in ("primitives/identifiers", "identifiers"):
+    for subdir in _SUBDIRS:
         for path in iter_files(subdir=subdir, staged_only=staged_only, root=root):
             try:
                 text = path.read_text(encoding="utf-8", errors="replace")

--- a/tests/arch_check/test_naming_prefix.py
+++ b/tests/arch_check/test_naming_prefix.py
@@ -55,3 +55,28 @@ def test_subdir_order_primitives_first(write_rs, tmp_repo: Path):
     paths = [f.rel_path for f in findings]
     assert paths[0].startswith("crates/octarine/src/primitives/")
     assert paths[1].startswith("crates/octarine/src/identifiers/")
+
+
+def test_extended_scope_covers_primitives_crypto_data_io_and_observe(
+    write_rs, tmp_repo: Path
+):
+    write_rs("primitives/crypto/x.rs", "pub fn verify_x() {}\n")
+    write_rs("primitives/data/y.rs", "pub fn ensure_y() {}\n")
+    write_rs("primitives/io/z.rs", "pub fn check_z() {}\n")
+    write_rs("observe/w.rs", "pub fn has_w() {}\n")
+    findings = list(naming_prefix.run(staged_only=False, root=tmp_repo))
+    assert {f.rel_path for f in findings} == {
+        "crates/octarine/src/primitives/crypto/x.rs",
+        "crates/octarine/src/primitives/data/y.rs",
+        "crates/octarine/src/primitives/io/z.rs",
+        "crates/octarine/src/observe/w.rs",
+    }
+
+
+def test_layer3_crypto_and_data_not_in_scope(write_rs, tmp_repo: Path):
+    # Layer 3 `crypto/` and `data/` retain deprecated public-surface names
+    # pending a SemVer-bumped follow-up; the scanner deliberately skips them.
+    write_rs("crypto/auth/legacy.rs", "pub fn verify_legacy() {}\n")
+    write_rs("data/paths/legacy.rs", "pub fn ensure_legacy() {}\n")
+    findings = list(naming_prefix.run(staged_only=False, root=tmp_repo))
+    assert findings == []


### PR DESCRIPTION
## Summary

Slices the **naming-drift** category from umbrella #193: renames ~22 internal `pub fn` violations of `has_*` / `verify_*` / `ensure_*` / `check_*` / `remove_*` prefixes to the canonical names from `docs/api/naming-conventions.md` (lines 230-249). Internal-only — no Layer 3 public surface changes — so this PR doesn't trigger a SemVer bump.

**Layer 3 public surface (5 sites) is deferred** to #314, which will pair the deprecation cycle with the next minor bump:
- `crypto::auth::hmac::verify` / `_strict` / `_hex` / `_with_domain` / `_multipart`
- `crypto::keys::password::verify` / `verify_sync`
- `data::paths::FormatBuilder::ensure_trailing_separator`
- `data::paths::SeparatorStyle::has_separators`
- `primitives::io::net::HealthCheck::check_health`

## Rename map

| Old | New | Location |
| --- | --- | --- |
| `verify_hmac` | `is_hmac_valid` | `primitives/crypto/auth/hmac` |
| `verify_hmac_strict` | `validate_hmac_strict` | same |
| `verify_hmac_hex` | `is_hmac_hex_valid` | same |
| `verify_hmac_with_domain` | `is_hmac_with_domain_valid` | same |
| `verify_hmac_multipart` | `is_hmac_multipart_valid` | same |
| `HmacBuilder::verify_strict` | `validate_strict` | `primitives/crypto/builder` |
| `HmacBuilder::verify_hex` | `is_hex_valid` | same |
| `HmacBuilder::verify_with_domain` | `is_with_domain_valid` | same |
| `HmacBuilder::verify_multipart` | `is_multipart_valid` | same |
| `verify_password` (async) | `validate_password` | `primitives/crypto/keys/password` |
| `verify_password_sync` | `validate_password_sync` | same |
| `ensure_directory_mode` | `with_directory_mode` | `primitives/io/file/permissions` |
| `ensure_trailing_separator` (×4) | `with_trailing_separator` | `primitives/data/paths/{common,format,builder}` |
| `remove_traversal_sequences` | `strip_traversal_sequences` | `primitives/security/paths/sanitization` |
| `check_threshold` | `evaluate_threshold` | `observe/metrics/thresholds` |
| `ensure_registry` | `init_registry_if_missing` | `observe/writers` |
| `has_keyword_in_window` | `is_keyword_in_window_present` | `primitives/identifiers/confidence` |
| `has_address_context` | `is_address_context_present` | `primitives/identifiers/location` |

**Intentionally NOT renamed**: `primitives/io/file/async_fs::remove_file` mirrors `std::fs::remove_file` and keeps the stdlib idiom recognizable.

## Lockdown

`scripts/arch_check/checks/naming_prefix.py` previously scanned only `primitives/identifiers/` and `identifiers/`. Extended scope to also cover `primitives/crypto`, `primitives/data`, `primitives/io`, and `observe/` — preventing regressions. Two new pytest cases assert the expanded coverage and the deliberate Layer 3 exclusion.

## Test plan

- `just preflight` — fmt, clippy (`-D warnings`), arch-check, full workspace test suite — **green**
- `just arch-check-test` (62 pytest cases including 2 new ones) — **green**
- Layer 3 public API surface verified unchanged via final `grep -rEn "pub fn (has_|verify_|ensure_|check_|remove_)" crates/octarine/src/` — only the 5 deferred sites + `remove_file` stdlib mirror remain

## Scope

Refs #193 (umbrella stays open — other categories: file-length, complexity, dup, magic numbers, tech-debt markers)
Follow-up: #314 (Layer 3 deprecation cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)