### PR TITLE
refactor(naming): rename Layer 3 public verify_*/has_*/ensure_*/check_* (closes #314, breaking)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -6,3 +6,4 @@
 - [LOC excludes docs and tests](feedback_loc_excludes_docs_tests.md) — size limits (300/500/800) measure production code only, not doc comments or test modules
 - [PR auto-merge on green](feedback_pr_auto_merge.md) — for /next-issue-ship PRs, squash-merge + delete-branch + prune as soon as CI is green; don't ask
 - [Dependabot coordinated bumps](project_dependabot_coordinated_bumps.md) — opentelemetry/tonic/tracing families need ONE unified PR; close individual Dependabot PRs as superseded
+- [Pre-1.0 prefer breaking](feedback_pre_1_0_breaking_changes.md) — while on 0.x beta, do breaking renames directly; skip `#[deprecated]` aliases

--- a/.claude/memory/feedback_pre_1_0_breaking_changes.md
+++ b/.claude/memory/feedback_pre_1_0_breaking_changes.md
@@ -1,0 +1,20 @@
+---
+name: pre-1-0-prefer-breaking-over-deprecation
+description: "While pre-1.0, prefer direct breaking renames over `#[deprecated]` alias dances. Beta is for making changes."
+metadata:
+  node_type: memory
+  type: feedback
+  originSessionId: 2b6e3b9e-2ae9-4601-9fcd-e69d0373b101
+---
+
+While pre-1.0 (`0.x` line), do breaking renames directly — drop the old name in the same PR — rather than maintaining `#[deprecated]` aliases through a deprecation cycle.
+
+**Why:** Octarine is at `0.3.0-beta.x`, not published to crates.io, and the SemVer policy explicitly says `0.X.0` minor bumps may include breaking changes. The whole point of the beta line is to absorb breakage cheaply. Carrying parallel old+new names doubles the public surface, splits documentation, and forces the cleanup to happen *twice* (rename, then later remove). Downstream callers in this state are few and updating callsites in one go is straightforward.
+
+**How to apply:**
+- When a naming/API change qualifies as "breaking" per the breaking-change catalog in [[octarine-release]] AND the project is on `0.x`: rename in place, delete the old symbol, and document the break under `### Changed` in CHANGELOG `[Unreleased]`.
+- The version bump remains `minor` (which finalizes a beta to stable per `octarine-release` SKILL.md) — don't add a synthetic `#[deprecated]` step just because the change is breaking.
+- After 1.0 ships, the calculus flips — deprecation cycles become the right tool. Reassess this guidance when crossing 1.0.
+- This guidance doesn't apply when the rename targets a trait method that external implementers might rely on without us being able to update them — that's still a hard break worth flagging in the PR description, but the action is the same (just rename), not "add a deprecation alias."
+
+Concrete example: instead of #314's original "add `#[deprecated]` aliases pointing at new names" plan, the follow-up should just rename `crypto::auth::hmac::verify_*` → `validate_*` / `is_*_valid`, delete the old names, bump minor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ All notable changes to octarine will be documented in this file.
 
 ### Changed
 
+- **BREAKING refactor(naming):** rename Layer 3 public verify_*/has_*/ensure_*/check_* to canonical names (#314, completes #193 naming-drift)
+  - `crypto::auth::hmac`: `verify` / `verify_strict` / `verify_hex` / `verify_with_domain` / `verify_multipart` → `is_valid` / `validate_strict` / `is_hex_valid` / `is_with_domain_valid` / `is_multipart_valid` (old names deleted, no aliases)
+  - `crypto::auth::hmac`: misnamed `validate_hex` / `validate_with_domain` / `validate_multipart` bool-returning aliases removed (the convention reserves `validate_*` for `Result`-returning functions)
+  - `crypto::keys::password`: `verify` (async) / `verify_sync` → `validate` / `validate_sync` (the prior `validate_sync` alias is now the only name)
+  - `data::paths::FormatBuilder::ensure_trailing_separator` → `with_trailing_separator`
+  - `data::paths::SeparatorStyle::is_separators_present` (was `has_separators`) on both Layer 1 and Layer 3 enums
+  - `primitives::io::net::HealthCheck::evaluate_health` trait method (was `check_health`) — external implementers must update
+  - `primitives::crypto::builder::HmacBuilder::is_valid` / `PasswordBuilder::validate` (were `.verify`)
+  - `scripts/arch_check/checks/naming_prefix.py` scope extended to all Layer 3 modules (`crypto/`, `data/`, `security/`, `auth/`, `http/`, `runtime/`, `io/`) — completes the prefix-rule lockdown crate-wide
+
 - refactor(naming): rename internal `pub fn` violations of prohibited-prefix naming convention (slice of #193)
   - `primitives/crypto/auth/hmac`: `verify_hmac{,_strict,_hex,_with_domain,_multipart}` → `is_hmac_valid` / `validate_hmac_strict` / `is_hmac_hex_valid` / `is_hmac_with_domain_valid` / `is_hmac_multipart_valid`
   - `primitives/crypto/builder::HmacBuilder`: `verify_strict` / `verify_hex` / `verify_with_domain` / `verify_multipart` → `validate_strict` / `is_hex_valid` / `is_with_domain_valid` / `is_multipart_valid`

--- a/crates/octarine/src/crypto/auth/hmac.rs
+++ b/crates/octarine/src/crypto/auth/hmac.rs
@@ -18,7 +18,7 @@
 //! let mac = auth::compute(&key, b"message");
 //!
 //! // Verify HMAC (generates security event with result)
-//! let valid = auth::verify(&key, b"message", &mac);
+//! let valid = auth::is_valid(&key, b"message", &mac);
 //! ```
 
 use crate::observe;
@@ -37,7 +37,7 @@ use crate::primitives::crypto::auth as prim;
 ///
 /// - Key should be at least 32 bytes of cryptographically random data
 /// - Never reuse keys across different protocols
-/// - Use constant-time comparison when verifying (use `verify` function)
+/// - Use constant-time comparison when verifying (use `is_valid` function)
 #[must_use]
 pub fn compute(key: &[u8], message: &[u8]) -> [u8; 32] {
     let mac = prim::hmac_sha3_256(key, message);
@@ -72,7 +72,7 @@ pub fn compute_hex(key: &[u8], message: &[u8]) -> String {
 /// - Uses constant-time comparison to prevent timing attacks
 /// - Returns `false` for incorrect length MACs (timing-safe)
 #[must_use]
-pub fn verify(key: &[u8], message: &[u8], expected_mac: &[u8]) -> bool {
+pub fn is_valid(key: &[u8], message: &[u8], expected_mac: &[u8]) -> bool {
     let valid = prim::is_hmac_valid(key, message, expected_mac);
 
     if valid {
@@ -97,7 +97,7 @@ pub fn verify(key: &[u8], message: &[u8], expected_mac: &[u8]) -> bool {
 /// # Errors
 ///
 /// Returns `CryptoError::MacVerification` if verification fails.
-pub fn verify_strict(key: &[u8], message: &[u8], expected_mac: &[u8]) -> Result<(), CryptoError> {
+pub fn validate_strict(key: &[u8], message: &[u8], expected_mac: &[u8]) -> Result<(), CryptoError> {
     let result = prim::validate_hmac_strict(key, message, expected_mac);
 
     match &result {
@@ -120,7 +120,7 @@ pub fn verify_strict(key: &[u8], message: &[u8], expected_mac: &[u8]) -> Result<
 
 /// Verify an HMAC from a hex-encoded string with audit trail.
 #[must_use]
-pub fn verify_hex(key: &[u8], message: &[u8], hex_mac: &str) -> bool {
+pub fn is_hex_valid(key: &[u8], message: &[u8], hex_mac: &str) -> bool {
     let valid = prim::is_hmac_hex_valid(key, message, hex_mac);
 
     if valid {
@@ -178,7 +178,7 @@ pub fn with_domain(key: &[u8], domain: &str, message: &[u8]) -> [u8; 32] {
 
 /// Verify an HMAC created with domain separation with audit trail.
 #[must_use]
-pub fn verify_with_domain(key: &[u8], domain: &str, message: &[u8], mac: &[u8]) -> bool {
+pub fn is_with_domain_valid(key: &[u8], domain: &str, message: &[u8], mac: &[u8]) -> bool {
     let valid = prim::is_hmac_with_domain_valid(key, domain, message, mac);
 
     if valid {
@@ -240,7 +240,7 @@ pub fn multipart(key: &[u8], parts: &[&[u8]]) -> [u8; 32] {
 
 /// Verify a multipart HMAC with audit trail.
 #[must_use]
-pub fn verify_multipart(key: &[u8], parts: &[&[u8]], mac: &[u8]) -> bool {
+pub fn is_multipart_valid(key: &[u8], parts: &[&[u8]], mac: &[u8]) -> bool {
     let valid = prim::is_hmac_multipart_valid(key, parts, mac);
 
     let total_len: usize = parts.iter().map(|p| p.len()).sum();
@@ -265,37 +265,6 @@ pub fn verify_multipart(key: &[u8], parts: &[&[u8]], mac: &[u8]) -> bool {
     }
 
     valid
-}
-
-// ============================================================================
-// Validate Aliases (Standard Naming Convention)
-// ============================================================================
-
-/// Alias for `verify_strict` following naming conventions.
-///
-/// # Errors
-///
-/// Returns `CryptoError::MacVerification` if verification fails.
-pub fn validate_strict(key: &[u8], message: &[u8], expected_mac: &[u8]) -> Result<(), CryptoError> {
-    verify_strict(key, message, expected_mac)
-}
-
-/// Alias for `verify_hex` following naming conventions.
-#[must_use]
-pub fn validate_hex(key: &[u8], message: &[u8], hex_mac: &str) -> bool {
-    verify_hex(key, message, hex_mac)
-}
-
-/// Alias for `verify_with_domain` following naming conventions.
-#[must_use]
-pub fn validate_with_domain(key: &[u8], domain: &str, message: &[u8], mac: &[u8]) -> bool {
-    verify_with_domain(key, domain, message, mac)
-}
-
-/// Alias for `verify_multipart` following naming conventions.
-#[must_use]
-pub fn validate_multipart(key: &[u8], parts: &[&[u8]], mac: &[u8]) -> bool {
-    verify_multipart(key, parts, mac)
 }
 
 // ============================================================================
@@ -326,33 +295,33 @@ mod tests {
     }
 
     #[test]
-    fn test_verify() {
+    fn test_is_valid() {
         let key = b"secret-key";
         let message = b"test message";
         let mac = compute(key, message);
 
-        assert!(verify(key, message, &mac));
-        assert!(!verify(key, b"wrong message", &mac));
+        assert!(is_valid(key, message, &mac));
+        assert!(!is_valid(key, b"wrong message", &mac));
     }
 
     #[test]
-    fn test_verify_strict() {
+    fn test_validate_strict() {
         let key = b"secret-key";
         let message = b"test message";
         let mac = compute(key, message);
 
-        assert!(verify_strict(key, message, &mac).is_ok());
-        assert!(verify_strict(key, b"wrong", &mac).is_err());
+        assert!(validate_strict(key, message, &mac).is_ok());
+        assert!(validate_strict(key, b"wrong", &mac).is_err());
     }
 
     #[test]
-    fn test_verify_hex() {
+    fn test_is_hex_valid() {
         let key = b"secret-key";
         let message = b"test message";
         let mac = compute_hex(key, message);
 
-        assert!(verify_hex(key, message, &mac));
-        assert!(!verify_hex(key, b"wrong", &mac));
+        assert!(is_hex_valid(key, message, &mac));
+        assert!(!is_hex_valid(key, b"wrong", &mac));
     }
 
     #[test]
@@ -368,14 +337,14 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_with_domain() {
+    fn test_is_with_domain_valid() {
         let key = b"secret-key";
         let message = b"data";
 
         let mac = with_domain(key, "api:v1", message);
 
-        assert!(verify_with_domain(key, "api:v1", message, &mac));
-        assert!(!verify_with_domain(key, "api:v2", message, &mac));
+        assert!(is_with_domain_valid(key, "api:v1", message, &mac));
+        assert!(!is_with_domain_valid(key, "api:v2", message, &mac));
     }
 
     #[test]
@@ -388,14 +357,14 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_multipart() {
+    fn test_is_multipart_valid() {
         let key = b"secret-key";
         let parts: &[&[u8]] = &[b"header", b"body"];
 
         let mac = multipart(key, parts);
 
-        assert!(verify_multipart(key, parts, &mac));
-        assert!(!verify_multipart(key, &[b"wrong", b"parts"], &mac));
+        assert!(is_multipart_valid(key, parts, &mac));
+        assert!(!is_multipart_valid(key, &[b"wrong", b"parts"], &mac));
     }
 
     #[test]
@@ -411,15 +380,15 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_wrong_length_mac() {
+    fn test_is_valid_wrong_length_mac() {
         let key = b"secret-key";
         let message = b"test message";
 
         // Too short (16 bytes)
-        assert!(!verify(key, message, &[0u8; 16]));
+        assert!(!is_valid(key, message, &[0u8; 16]));
         // Too long (64 bytes)
-        assert!(!verify(key, message, &[0u8; 64]));
+        assert!(!is_valid(key, message, &[0u8; 64]));
         // Empty
-        assert!(!verify(key, message, &[]));
+        assert!(!is_valid(key, message, &[]));
     }
 }

--- a/crates/octarine/src/crypto/keys/mod.rs
+++ b/crates/octarine/src/crypto/keys/mod.rs
@@ -37,7 +37,7 @@
 //! let hash = password::hash("user_password").await?;
 //!
 //! // Verify password
-//! if password::verify("user_password", &hash).await? {
+//! if password::validate("user_password", &hash).await? {
 //!     // Login successful
 //! }
 //! ```
@@ -51,7 +51,7 @@
 //! let hash = password::hash_sync("user_password")?;
 //!
 //! // Verify synchronously
-//! if password::verify_sync("user_password", &hash)? {
+//! if password::validate_sync("user_password", &hash)? {
 //!     // Login successful
 //! }
 //! ```

--- a/crates/octarine/src/crypto/keys/password.rs
+++ b/crates/octarine/src/crypto/keys/password.rs
@@ -9,7 +9,7 @@
 //! attacks. This module provides async-first APIs that offload CPU-intensive
 //! work to a blocking thread pool:
 //!
-//! - Primary API is async (`hash()`, `verify()`, etc.)
+//! - Primary API is async (`hash()`, `validate()`, etc.)
 //! - Sync variants available with `*_sync()` suffix
 //!
 //! # Security Events
@@ -29,7 +29,7 @@
 //! let hash = password::hash("user_password").await?;
 //!
 //! // Verify password
-//! if password::verify("user_password", &hash).await? {
+//! if password::validate("user_password", &hash).await? {
 //!     // Success
 //! }
 //!
@@ -46,7 +46,7 @@
 //! let hash = password::hash_sync("user_password")?;
 //!
 //! // Verify synchronously
-//! if password::verify_sync("user_password", &hash)? {
+//! if password::validate_sync("user_password", &hash)? {
 //!     // Success
 //! }
 //! ```
@@ -119,11 +119,11 @@ pub async fn hash_with_profile(
 /// # Example
 ///
 /// ```ignore
-/// if password::verify("user_input", &stored_hash).await? {
+/// if password::validate("user_input", &stored_hash).await? {
 ///     // Login successful
 /// }
 /// ```
-pub async fn verify(password: &str, hash: &str) -> Result<bool, PasswordError> {
+pub async fn validate(password: &str, hash: &str) -> Result<bool, PasswordError> {
     let start = Instant::now();
     observe::debug("password_verify", "Starting password verification");
 
@@ -296,8 +296,8 @@ pub fn hash_with_profile_sync(
 
 /// Verify a password synchronously.
 ///
-/// **Warning**: Blocks the current thread. Use `verify()` in async contexts.
-pub fn verify_sync(password: &str, hash: &str) -> Result<bool, CryptoError> {
+/// **Warning**: Blocks the current thread. Use `validate()` in async contexts.
+pub fn validate_sync(password: &str, hash: &str) -> Result<bool, CryptoError> {
     let result = prim::validate_password_sync(password, hash);
 
     match &result {
@@ -313,13 +313,6 @@ pub fn verify_sync(password: &str, hash: &str) -> Result<bool, CryptoError> {
     }
 
     result
-}
-
-/// Alias for `verify_sync` following naming conventions.
-///
-/// **Warning**: Blocks the current thread. Use `verify()` in async contexts.
-pub fn validate_sync(password: &str, hash: &str) -> Result<bool, CryptoError> {
-    verify_sync(password, hash)
 }
 
 /// Derive a key from password synchronously.
@@ -431,12 +424,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_hash_and_verify_sync() {
+    fn test_hash_and_validate_sync() {
         let hash = hash_sync("test_password").expect("Hash failed");
         assert!(hash.starts_with("$argon2id$"));
 
-        assert!(verify_sync("test_password", &hash).expect("Verify failed"));
-        assert!(!verify_sync("wrong_password", &hash).expect("Verify failed"));
+        assert!(validate_sync("test_password", &hash).expect("Verify failed"));
+        assert!(!validate_sync("wrong_password", &hash).expect("Verify failed"));
     }
 
     #[test]
@@ -459,13 +452,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_hash_and_verify_async() {
+    async fn test_hash_and_validate_async() {
         let hash = hash("test_password").await.expect("Hash failed");
         assert!(hash.starts_with("$argon2id$"));
 
-        assert!(verify("test_password", &hash).await.expect("Verify failed"));
         assert!(
-            !verify("wrong_password", &hash)
+            validate("test_password", &hash)
+                .await
+                .expect("Verify failed")
+        );
+        assert!(
+            !validate("wrong_password", &hash)
                 .await
                 .expect("Verify failed")
         );

--- a/crates/octarine/src/crypto/mod.rs
+++ b/crates/octarine/src/crypto/mod.rs
@@ -59,7 +59,7 @@
 //! let hash = password::hash("user_password")?;
 //!
 //! // Verify password (generates auth event)
-//! if password::verify("user_password", &hash)? {
+//! if password::validate("user_password", &hash).await? {
 //!     // Login successful
 //! }
 //! ```

--- a/crates/octarine/src/data/paths/builder/format.rs
+++ b/crates/octarine/src/data/paths/builder/format.rs
@@ -229,9 +229,9 @@ impl FormatBuilder {
         PrimitiveFormatBuilder::new().strip_trailing_separator(path)
     }
 
-    /// Ensure path has trailing separator
+    /// Add a trailing separator if not already present
     #[must_use]
-    pub fn ensure_trailing_separator<'a>(&self, path: &'a str) -> Cow<'a, str> {
+    pub fn with_trailing_separator<'a>(&self, path: &'a str) -> Cow<'a, str> {
         PrimitiveFormatBuilder::new().with_trailing_separator(path)
     }
 

--- a/crates/octarine/src/data/paths/types.rs
+++ b/crates/octarine/src/data/paths/types.rs
@@ -624,7 +624,7 @@ pub enum SeparatorStyle {
 impl SeparatorStyle {
     /// Check if this style has any separators
     #[must_use]
-    pub const fn has_separators(&self) -> bool {
+    pub const fn is_separators_present(&self) -> bool {
         !matches!(self, Self::None)
     }
 

--- a/crates/octarine/src/primitives/crypto/builder/hmac.rs
+++ b/crates/octarine/src/primitives/crypto/builder/hmac.rs
@@ -56,7 +56,7 @@ impl HmacBuilder {
     ///
     /// Returns `true` if the MAC is valid.
     #[must_use]
-    pub fn verify(&self, key: &[u8], message: &[u8], mac: &[u8]) -> bool {
+    pub fn is_valid(&self, key: &[u8], message: &[u8], mac: &[u8]) -> bool {
         is_hmac_valid(key, message, mac)
     }
 

--- a/crates/octarine/src/primitives/crypto/builder/password.rs
+++ b/crates/octarine/src/primitives/crypto/builder/password.rs
@@ -72,10 +72,10 @@ impl PasswordBuilder {
     /// ```ignore
     /// let crypto = CryptoBuilder::new();
     /// let hash = crypto.password().hash("secret")?;
-    /// assert!(crypto.password().verify("secret", &hash)?);
-    /// assert!(!crypto.password().verify("wrong", &hash)?);
+    /// assert!(crypto.password().validate("secret", &hash)?);
+    /// assert!(!crypto.password().validate("wrong", &hash)?);
     /// ```
-    pub fn verify(&self, password: &str, hash: &str) -> Result<bool, CryptoError> {
+    pub fn validate(&self, password: &str, hash: &str) -> Result<bool, CryptoError> {
         validate_password_sync(password, hash)
     }
 
@@ -178,13 +178,13 @@ mod tests {
         assert!(
             crypto
                 .password()
-                .verify("test_password", &hash)
+                .validate("test_password", &hash)
                 .expect("Verify failed")
         );
         assert!(
             !crypto
                 .password()
-                .verify("wrong", &hash)
+                .validate("wrong", &hash)
                 .expect("Verify failed")
         );
     }

--- a/crates/octarine/src/primitives/data/paths/format/detection.rs
+++ b/crates/octarine/src/primitives/data/paths/format/detection.rs
@@ -103,7 +103,7 @@ pub enum SeparatorStyle {
 impl SeparatorStyle {
     /// Check if this style has any separators
     #[must_use]
-    pub const fn has_separators(&self) -> bool {
+    pub const fn is_separators_present(&self) -> bool {
         !matches!(self, Self::None)
     }
 
@@ -512,10 +512,10 @@ mod tests {
     // SeparatorStyle tests
     #[test]
     fn test_separator_style() {
-        assert!(SeparatorStyle::Forward.has_separators());
-        assert!(SeparatorStyle::Back.has_separators());
-        assert!(SeparatorStyle::Mixed.has_separators());
-        assert!(!SeparatorStyle::None.has_separators());
+        assert!(SeparatorStyle::Forward.is_separators_present());
+        assert!(SeparatorStyle::Back.is_separators_present());
+        assert!(SeparatorStyle::Mixed.is_separators_present());
+        assert!(!SeparatorStyle::None.is_separators_present());
 
         assert!(SeparatorStyle::Forward.is_consistent());
         assert!(SeparatorStyle::Back.is_consistent());

--- a/crates/octarine/src/primitives/io/net/health.rs
+++ b/crates/octarine/src/primitives/io/net/health.rs
@@ -68,7 +68,7 @@ impl std::fmt::Display for NetworkHealthStatus {
 /// struct DatabaseClient { /* ... */ }
 ///
 /// impl HealthCheck for DatabaseClient {
-///     fn check_health(&self) -> Pin<Box<dyn Future<Output = NetworkHealthStatus> + Send + '_>> {
+///     fn evaluate_health(&self) -> Pin<Box<dyn Future<Output = NetworkHealthStatus> + Send + '_>> {
 ///         Box::pin(async move {
 ///             // Perform health check
 ///             match self.ping().await {
@@ -87,7 +87,7 @@ pub trait HealthCheck: Send + Sync {
     /// Perform a health check
     ///
     /// Returns the current health status of the service.
-    fn check_health(&self) -> Pin<Box<dyn Future<Output = NetworkHealthStatus> + Send + '_>>;
+    fn evaluate_health(&self) -> Pin<Box<dyn Future<Output = NetworkHealthStatus> + Send + '_>>;
 
     /// Get the service name for logging/metrics
     fn service_name(&self) -> &str;

--- a/crates/octarine/tests/crypto/kdf_hmac.rs
+++ b/crates/octarine/tests/crypto/kdf_hmac.rs
@@ -20,7 +20,7 @@ fn test_kdf_derived_key_hmac_round_trip() {
     let mac = auth::compute(&derived_key, message);
 
     assert!(
-        auth::verify(&derived_key, message, &mac),
+        auth::is_valid(&derived_key, message, &mac),
         "HMAC should verify with same derived key"
     );
 }
@@ -61,7 +61,7 @@ fn test_domain_separation_produces_different_macs() {
 
     // Cross-verification should fail
     assert!(
-        !auth::verify(&key_enc, message, &mac_auth),
+        !auth::is_valid(&key_enc, message, &mac_auth),
         "MAC from auth key should not verify with enc key"
     );
 }
@@ -102,7 +102,7 @@ fn test_versioned_key_rotation() {
 
     // v1 MAC should not verify with v2 key
     assert!(
-        !auth::verify(&key_v2, message, &mac_v1),
+        !auth::is_valid(&key_v2, message, &mac_v1),
         "v1 MAC should not verify with v2 key"
     );
 }
@@ -115,9 +115,14 @@ fn test_domain_separated_hmac() {
 
     let mac = auth::with_domain(key, "api-signing", message);
 
-    assert!(auth::verify_with_domain(key, "api-signing", message, &mac));
+    assert!(auth::is_with_domain_valid(
+        key,
+        "api-signing",
+        message,
+        &mac
+    ));
     assert!(
-        !auth::verify_with_domain(key, "different-domain", message, &mac),
+        !auth::is_with_domain_valid(key, "different-domain", message, &mac),
         "Different domain should not verify"
     );
 }
@@ -137,12 +142,12 @@ fn test_multipart_hmac_with_derived_key() {
     let parts: &[&[u8]] = &[b"header", b"payload", b"footer"];
     let mac = auth::multipart(&derived, parts);
 
-    assert!(auth::verify_multipart(&derived, parts, &mac));
+    assert!(auth::is_multipart_valid(&derived, parts, &mac));
 
     // Tampered parts should not verify
     let tampered: &[&[u8]] = &[b"header", b"TAMPERED", b"footer"];
     assert!(
-        !auth::verify_multipart(&derived, tampered, &mac),
+        !auth::is_multipart_valid(&derived, tampered, &mac),
         "Tampered data should not verify"
     );
 }

--- a/crates/octarine/tests/crypto/password_hashing.rs
+++ b/crates/octarine/tests/crypto/password_hashing.rs
@@ -4,22 +4,22 @@ use octarine::crypto::keys::password;
 use octarine::crypto::keys::{PasswordCharset, PasswordStrength};
 
 // =========================================================================
-// Hash + Verify (sync)
+// Hash + Validate (sync)
 // =========================================================================
 
-/// hash_sync → verify_sync with correct password succeeds.
+/// hash_sync → validate_sync with correct password succeeds.
 #[test]
-fn test_hash_verify_sync_correct() {
+fn test_hash_validate_sync_correct() {
     let hash = password::hash_sync("correct-horse-battery-staple").expect("hash");
-    let valid = password::verify_sync("correct-horse-battery-staple", &hash).expect("verify");
+    let valid = password::validate_sync("correct-horse-battery-staple", &hash).expect("verify");
     assert!(valid, "Correct password should verify");
 }
 
-/// hash_sync → verify_sync with wrong password fails.
+/// hash_sync → validate_sync with wrong password fails.
 #[test]
-fn test_hash_verify_sync_wrong_password() {
+fn test_hash_validate_sync_wrong_password() {
     let hash = password::hash_sync("correct-password").expect("hash");
-    let valid = password::verify_sync("wrong-password", &hash).expect("verify");
+    let valid = password::validate_sync("wrong-password", &hash).expect("verify");
     assert!(!valid, "Wrong password should not verify");
 }
 
@@ -31,19 +31,19 @@ fn test_hash_produces_unique_outputs() {
     assert_ne!(h1, h2, "Different salts should produce different hashes");
 
     // But both should verify
-    assert!(password::verify_sync("same-password", &h1).expect("verify 1"));
-    assert!(password::verify_sync("same-password", &h2).expect("verify 2"));
+    assert!(password::validate_sync("same-password", &h1).expect("verify 1"));
+    assert!(password::validate_sync("same-password", &h2).expect("verify 2"));
 }
 
 // =========================================================================
-// Hash + Verify (async)
+// Hash + Validate (async)
 // =========================================================================
 
-/// Async hash → verify round-trip.
+/// Async hash → validate round-trip.
 #[tokio::test]
-async fn test_hash_verify_async() {
+async fn test_hash_validate_async() {
     let hash = password::hash("async-password-test").await.expect("hash");
-    let valid = password::verify("async-password-test", &hash)
+    let valid = password::validate("async-password-test", &hash)
         .await
         .expect("verify");
     assert!(valid, "Async verification should succeed");

--- a/scripts/arch_check/checks/naming_prefix.py
+++ b/scripts/arch_check/checks/naming_prefix.py
@@ -12,10 +12,8 @@ _TRIGGER = re.compile(r"pub fn (has_|contains_|check_|verify_|ensure_|remove_)")
 _EXTRACT = re.compile(r"(has_|contains_|check_|verify_|ensure_|remove_)[a-z_]*")
 
 # Subdirs to scan. Order matches the historical bash recipe: identifier
-# subdirs first, then the broader primitives/observe domains added in #193.
-# Layer 3 paths (`crypto/`, `data/`) are deliberately excluded — their few
-# remaining violations are `pub fn` public-API renames that require a
-# deprecation cycle paired with the next minor bump.
+# subdirs first, then the broader primitives/observe domains added in #193,
+# then Layer 3 modules added in #314.
 _SUBDIRS: tuple[str, ...] = (
     "primitives/identifiers",
     "identifiers",
@@ -23,6 +21,13 @@ _SUBDIRS: tuple[str, ...] = (
     "primitives/data",
     "primitives/io",
     "observe",
+    "crypto",
+    "data",
+    "security",
+    "auth",
+    "http",
+    "runtime",
+    "io",
 )
 
 

--- a/tests/arch_check/test_naming_prefix.py
+++ b/tests/arch_check/test_naming_prefix.py
@@ -73,10 +73,13 @@ def test_extended_scope_covers_primitives_crypto_data_io_and_observe(
     }
 
 
-def test_layer3_crypto_and_data_not_in_scope(write_rs, tmp_repo: Path):
-    # Layer 3 `crypto/` and `data/` retain deprecated public-surface names
-    # pending a SemVer-bumped follow-up; the scanner deliberately skips them.
+def test_layer3_crypto_and_data_now_in_scope(write_rs, tmp_repo: Path):
+    # As of #314, Layer 3 `crypto/` and `data/` are scanned too — the
+    # deferred public-surface renames have landed.
     write_rs("crypto/auth/legacy.rs", "pub fn verify_legacy() {}\n")
     write_rs("data/paths/legacy.rs", "pub fn ensure_legacy() {}\n")
     findings = list(naming_prefix.run(staged_only=False, root=tmp_repo))
-    assert findings == []
+    assert {f.rel_path for f in findings} == {
+        "crates/octarine/src/crypto/auth/legacy.rs",
+        "crates/octarine/src/data/paths/legacy.rs",
+    }


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**. Completes the naming-drift category from umbrella #193 by renaming the 5 deferred Layer 3 public-surface sites that were left out of #315. Old names are deleted outright — no `#[deprecated]` aliases. Per pre-1.0 policy, beta is for absorbing breakage cheaply; downstream callers in this state are few, and direct renames avoid splitting the API surface.

## Rename map

| Module | Before | After |
| --- | --- | --- |
| `crypto::auth::hmac` | `verify` | `is_valid` |
| `crypto::auth::hmac` | `verify_strict` | `validate_strict` |
| `crypto::auth::hmac` | `verify_hex` | `is_hex_valid` |
| `crypto::auth::hmac` | `verify_with_domain` | `is_with_domain_valid` |
| `crypto::auth::hmac` | `verify_multipart` | `is_multipart_valid` |
| `crypto::auth::hmac` | `validate_hex` / `validate_with_domain` / `validate_multipart` *(bool aliases)* | **deleted** — `validate_*` reserved for `Result` returns |
| `crypto::keys::password` | `verify` *(async)* | `validate` |
| `crypto::keys::password` | `verify_sync` | `validate_sync` |
| `data::paths::FormatBuilder` | `ensure_trailing_separator` | `with_trailing_separator` |
| `data::paths::SeparatorStyle` | `has_separators` | `is_separators_present` *(Layer 1 + Layer 3)* |
| `primitives::io::net::HealthCheck` *(trait method)* | `check_health` | `evaluate_health` |
| `primitives::crypto::builder::HmacBuilder` | `.verify` | `.is_valid` |
| `primitives::crypto::builder::PasswordBuilder` | `.verify` | `.validate` |

## Lockdown

`scripts/arch_check/checks/naming_prefix.py` `_SUBDIRS` is extended to cover **all** Layer 3 modules (`crypto/`, `data/`, `security/`, `auth/`, `http/`, `runtime/`, `io/`). The arch-check test that previously asserted Layer 3 was OUT of scope is inverted to assert it's now IN scope. This completes the prefix-rule lockdown crate-wide.

## Test plan

- `just preflight` — fmt, clippy (`-D warnings`), arch-check, full test suite, doctests — **green**
- `cargo check --tests --all-features` after every rename — kept clean throughout
- `tests/arch_check/test_naming_prefix.py` (8 pytest cases) — green

## Memory

Includes a short feedback memory note (`.claude/memory/feedback_pre_1_0_breaking_changes.md`) capturing the rationale: while pre-1.0, prefer direct breaking renames over deprecation aliases. Reassess after 1.0.

## Scope

Closes #314. Together with #315, fully resolves the naming-drift category from umbrella #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)