### PR TITLE
test(timing): add diagnostic messages to bare timing assertions

### DIFF
--- a/crates/octarine/src/observe/metrics/timers/mod.rs
+++ b/crates/octarine/src/observe/metrics/timers/mod.rs
@@ -112,7 +112,11 @@ mod tests {
         let timer = timer("test_operation");
         thread::sleep(Duration::from_millis(10));
         let duration = timer.record();
-        assert!(duration.as_millis() >= 10);
+        assert!(
+            duration.as_millis() >= 10,
+            "Expected at least 10ms duration, got {}ms",
+            duration.as_millis()
+        );
     }
 
     #[test]

--- a/crates/octarine/src/primitives/runtime/async/async_utils.rs
+++ b/crates/octarine/src/primitives/runtime/async/async_utils.rs
@@ -351,7 +351,11 @@ mod tests {
         sleep_ms(10).await;
         let elapsed = start.elapsed();
         // Allow 20% margin for OS scheduler jitter
-        assert!(elapsed.as_millis() >= 8);
+        assert!(
+            elapsed.as_millis() >= 8,
+            "Expected at least 8ms elapsed, got {}ms",
+            elapsed.as_millis()
+        );
     }
 
     #[tokio::test]
@@ -395,7 +399,11 @@ mod tests {
         let start = now();
         timeout(Duration::from_millis(10)).await;
         let elapsed = start.elapsed();
-        assert!(elapsed.as_millis() >= 10);
+        assert!(
+            elapsed.as_millis() >= 10,
+            "Expected at least 10ms elapsed, got {}ms",
+            elapsed.as_millis()
+        );
     }
 
     #[tokio::test]

--- a/crates/octarine/src/primitives/runtime/async/batch.rs
+++ b/crates/octarine/src/primitives/runtime/async/batch.rs
@@ -202,7 +202,12 @@ mod tests {
     fn test_batch_processor_elapsed() {
         let batch = BatchProcessor::<i32>::new(10, Duration::from_secs(60));
         std::thread::sleep(Duration::from_millis(10));
-        assert!(batch.elapsed().as_millis() >= 10);
+        let elapsed = batch.elapsed();
+        assert!(
+            elapsed.as_millis() >= 10,
+            "Expected at least 10ms elapsed, got {}ms",
+            elapsed.as_millis()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Four `assert!(elapsed >= N)` calls across `observe::metrics::timers` and `primitives::runtime::async` lacked format strings — when these fail under CI coverage instrumentation, output reads `assertion failed: ...` with no observed value, blocking triage.
- Added `"Expected at least Nms ..., got {}ms"` diagnostic messages mirroring the existing convention at `async_utils.rs:386`.
- Captured `batch.elapsed()` once in `test_batch_processor_elapsed` so the predicate and the diagnostic read the same observed value.
- No assertion logic changed; only diagnostic ergonomics.

Sites touched:
- `observe/metrics/timers/mod.rs:115` — `test_timer_manual_record`
- `primitives/runtime/async/async_utils.rs:354` — `test_sleep_ms`
- `primitives/runtime/async/async_utils.rs:398` — `test_timeout`
- `primitives/runtime/async/batch.rs:205` — `test_batch_processor_elapsed`

## Test plan
- [x] `cargo test -p octarine --lib -- primitives::runtime::r#async::async_utils` — 12/12 pass
- [x] `cargo test -p octarine --lib -- primitives::runtime::r#async::batch observe::metrics::timers` — 15/15 pass
- [x] `just fmt-check`
- [x] `just clippy` — clean
- [x] Sanity check: temporarily set the batch assertion to `>= 100000` and confirmed failure output reads `Expected at least 10ms elapsed, got 11ms` (then reverted).

Closes #94