### PR TITLE
refactor(http): extract pure logic into primitives/http/

### DIFF
--- a/crates/octarine/src/http/middleware/auth.rs
+++ b/crates/octarine/src/http/middleware/auth.rs
@@ -67,6 +67,8 @@ use tower::{Layer, Service};
 use super::super::ProblemResponse;
 use crate::Problem;
 use crate::observe;
+use crate::primitives::http::headers::parse_bearer_token;
+use crate::primitives::http::routing::is_path_excluded;
 use crate::primitives::runtime as prim_runtime;
 
 /// Type alias for API key validation function.
@@ -305,7 +307,7 @@ impl AuthConfig {
 
     /// Check if a path should be excluded from authentication.
     fn is_excluded(&self, path: &str) -> bool {
-        self.exclude_paths.iter().any(|p| path.starts_with(p))
+        is_path_excluded(path, &self.exclude_paths)
     }
 }
 
@@ -411,11 +413,9 @@ impl<S> AuthService<S> {
         };
 
         // Check for Bearer prefix
-        if !auth_str.starts_with("Bearer ") {
+        let Some(token) = parse_bearer_token(auth_str) else {
             return AuthResult::NoCredentials;
-        }
-
-        let token = &auth_str[7..]; // Skip "Bearer "
+        };
 
         // Decode and validate JWT
         match decode::<Claims>(token, key, validation) {

--- a/crates/octarine/src/http/middleware/context.rs
+++ b/crates/octarine/src/http/middleware/context.rs
@@ -24,6 +24,7 @@ use axum::{
 use tower::{Layer, Service};
 
 use crate::observe;
+use crate::primitives::http::headers::{parse_forwarded_for, parse_real_ip};
 use crate::primitives::runtime as prim_runtime;
 
 /// Header name for tenant ID
@@ -129,16 +130,13 @@ impl<S> ContextService<S> {
     fn extract_source_ip(&self, request: &Request<Body>) -> Option<String> {
         // Try X-Forwarded-For first (if trusted)
         if self.trust_forwarded_for {
-            if let Some(forwarded) = request
+            if let Some(client_ip) = request
                 .headers()
                 .get(&X_FORWARDED_FOR)
                 .and_then(|v| v.to_str().ok())
+                .and_then(parse_forwarded_for)
             {
-                // X-Forwarded-For can contain multiple IPs: "client, proxy1, proxy2"
-                // The first one is the original client
-                if let Some(client_ip) = forwarded.split(',').next() {
-                    return Some(client_ip.trim().to_string());
-                }
+                return Some(client_ip.to_string());
             }
 
             // Try X-Real-IP (nginx convention)
@@ -146,6 +144,7 @@ impl<S> ContextService<S> {
                 .headers()
                 .get(&X_REAL_IP)
                 .and_then(|v| v.to_str().ok())
+                .and_then(parse_real_ip)
             {
                 return Some(real_ip.to_string());
             }

--- a/crates/octarine/src/http/middleware/metrics.rs
+++ b/crates/octarine/src/http/middleware/metrics.rs
@@ -57,6 +57,7 @@ use crate::observe::metrics::{self, MetricName};
 use crate::primitives::data::network::{
     PathPattern as PrimitivePathPattern, normalize_path_segments_with_patterns,
 };
+use crate::primitives::http::routing::is_path_excluded;
 
 // ============================================================================
 // Metrics Configuration
@@ -154,7 +155,7 @@ impl MetricsConfig {
 
     /// Check if a path should be excluded from metrics.
     fn is_excluded(&self, path: &str) -> bool {
-        self.exclude_paths.iter().any(|p| path.starts_with(p))
+        is_path_excluded(path, &self.exclude_paths)
     }
 
     /// Apply normalization to a path using configured patterns.

--- a/crates/octarine/src/http/middleware/observe.rs
+++ b/crates/octarine/src/http/middleware/observe.rs
@@ -67,6 +67,7 @@ use crate::observe::pii;
 use crate::primitives::data::network::{
     PathPattern as PrimitivePathPattern, normalize_path_segments_with_patterns,
 };
+use crate::primitives::http::routing::is_path_excluded;
 use crate::primitives::runtime::{
     correlation_id as get_correlation_id, tenant_id as get_tenant_id,
 };
@@ -258,7 +259,7 @@ impl ObserveConfig {
 
     /// Check if a path should be excluded from logging.
     fn is_excluded(&self, path: &str) -> bool {
-        self.exclude_paths.iter().any(|p| path.starts_with(p))
+        is_path_excluded(path, &self.exclude_paths)
     }
 
     /// Normalize a path using configured patterns and auto-detection.

--- a/crates/octarine/src/http/middleware/rate_limit.rs
+++ b/crates/octarine/src/http/middleware/rate_limit.rs
@@ -67,6 +67,8 @@ use governor::{
 };
 
 use crate::observe;
+use crate::primitives::http::headers::{parse_forwarded_for, parse_real_ip};
+use crate::primitives::http::routing::is_path_excluded;
 
 /// Header for forwarded IP (when behind proxy)
 static X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
@@ -210,7 +212,7 @@ impl RateLimitConfig {
 
     /// Check if a path should be excluded.
     fn is_excluded(&self, path: &str) -> bool {
-        self.exclude_paths.iter().any(|p| path.starts_with(p))
+        is_path_excluded(path, &self.exclude_paths)
     }
 
     /// Build the quota for governor.
@@ -343,8 +345,8 @@ impl<S> RateLimitService<S> {
                 .headers()
                 .get(&X_FORWARDED_FOR)
                 .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.split(',').next())
-                .and_then(|s| s.trim().parse().ok());
+                .and_then(parse_forwarded_for)
+                .and_then(|s| s.parse().ok());
 
             if let Some(ip) = forwarded_ip {
                 return Some(ip);
@@ -355,6 +357,7 @@ impl<S> RateLimitService<S> {
                 .headers()
                 .get(&X_REAL_IP)
                 .and_then(|v| v.to_str().ok())
+                .and_then(parse_real_ip)
                 .and_then(|s| s.parse().ok());
 
             if let Some(ip) = real_ip {

--- a/crates/octarine/src/http/middleware/request_id.rs
+++ b/crates/octarine/src/http/middleware/request_id.rs
@@ -21,6 +21,7 @@ use axum::{
 use tower::{Layer, Service};
 use uuid::Uuid;
 
+use crate::primitives::http::request_id::parse_or_generate_request_id;
 use crate::primitives::runtime as prim_runtime;
 
 /// Header name for request ID
@@ -99,14 +100,14 @@ where
     fn call(&mut self, mut request: Request<Body>) -> Self::Future {
         let header_name = self.header_name().clone();
 
-        // Extract existing request ID or generate new one
-        // Try to parse as UUID, generate new one if invalid or missing
-        let request_id: Uuid = request
-            .headers()
-            .get(&header_name)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| Uuid::try_parse(s).ok())
-            .unwrap_or_else(Uuid::new_v4);
+        // Extract existing request ID or generate new one (primitive parses
+        // the header string and falls back to a fresh v4).
+        let request_id: Uuid = parse_or_generate_request_id(
+            request
+                .headers()
+                .get(&header_name)
+                .and_then(|v| v.to_str().ok()),
+        );
 
         // Set in Octarine context for observability
         prim_runtime::set_correlation_id(request_id);

--- a/crates/octarine/src/http/middleware/security.rs
+++ b/crates/octarine/src/http/middleware/security.rs
@@ -58,6 +58,8 @@ use axum::{
 };
 use tower::{Layer, Service};
 
+use crate::primitives::http::security::{HstsConfig, build_hsts_value, is_production_or_staging};
+
 /// Header names for security headers
 static STRICT_TRANSPORT_SECURITY: HeaderName = HeaderName::from_static("strict-transport-security");
 static X_CONTENT_TYPE_OPTIONS: HeaderName = HeaderName::from_static("x-content-type-options");
@@ -296,29 +298,12 @@ impl SecurityConfig {
     /// Build the HSTS header value.
     fn build_hsts_value(&self) -> Option<String> {
         let max_age = self.hsts_max_age?;
-
-        let mut value = format!("max-age={max_age}");
-
-        if self.hsts_include_subdomains {
-            value.push_str("; includeSubDomains");
-        }
-
-        if self.hsts_preload {
-            value.push_str("; preload");
-        }
-
-        Some(value)
+        Some(build_hsts_value(&HstsConfig {
+            max_age,
+            include_subdomains: self.hsts_include_subdomains,
+            preload: self.hsts_preload,
+        }))
     }
-}
-
-/// Check if running in production or staging environment.
-fn is_production_or_staging() -> bool {
-    let env = std::env::var("ENVIRONMENT")
-        .or_else(|_| std::env::var("ENV"))
-        .unwrap_or_default()
-        .to_lowercase();
-
-    matches!(env.as_str(), "production" | "prod" | "staging" | "stage")
 }
 
 /// Layer that adds security headers to responses.

--- a/crates/octarine/src/primitives/http/headers.rs
+++ b/crates/octarine/src/primitives/http/headers.rs
@@ -1,0 +1,139 @@
+//! Header-parsing primitives
+//!
+//! Pure parsers for HTTP header values. Callers convert from framework types
+//! (e.g. `axum::http::HeaderValue`) to `&str` before calling in, keeping
+//! this module dependency-free.
+
+/// Parse the first client IP from an `X-Forwarded-For` header value.
+///
+/// `X-Forwarded-For` is a comma-separated chain of intermediaries:
+/// `"client, proxy1, proxy2"`. The first entry is the original client.
+///
+/// Returns `None` if the header is empty or contains only whitespace.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use octarine::primitives::http::headers::parse_forwarded_for;
+///
+/// assert_eq!(parse_forwarded_for("203.0.113.5, 10.0.0.1"), Some("203.0.113.5"));
+/// assert_eq!(parse_forwarded_for("  198.51.100.7  "), Some("198.51.100.7"));
+/// assert_eq!(parse_forwarded_for(""), None);
+/// ```
+#[must_use]
+pub fn parse_forwarded_for(header_value: &str) -> Option<&str> {
+    let first = header_value.split(',').next()?.trim();
+    if first.is_empty() { None } else { Some(first) }
+}
+
+/// Parse a single client IP from an `X-Real-IP` header value (nginx
+/// convention).
+///
+/// Returns `None` if the header is empty or whitespace.
+#[must_use]
+pub fn parse_real_ip(header_value: &str) -> Option<&str> {
+    let trimmed = header_value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+/// Strip the `"Bearer "` prefix from an Authorization header value, returning
+/// the token slice when the prefix is present.
+///
+/// Returns `None` for any value that does not start with the exact
+/// case-sensitive prefix `Bearer ` (matching RFC 6750 §2.1 syntax that
+/// upstream callers expect).
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use octarine::primitives::http::headers::parse_bearer_token;
+///
+/// assert_eq!(parse_bearer_token("Bearer abc.def.ghi"), Some("abc.def.ghi"));
+/// assert_eq!(parse_bearer_token("Basic dXNlcjpwYXNz"), None);
+/// ```
+#[must_use]
+pub fn parse_bearer_token(auth_header: &str) -> Option<&str> {
+    auth_header.strip_prefix("Bearer ")
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forwarded_for_single_ip() {
+        assert_eq!(parse_forwarded_for("203.0.113.5"), Some("203.0.113.5"));
+    }
+
+    #[test]
+    fn forwarded_for_takes_first_in_chain() {
+        assert_eq!(
+            parse_forwarded_for("203.0.113.5, 10.0.0.1, 10.0.0.2"),
+            Some("203.0.113.5"),
+        );
+    }
+
+    #[test]
+    fn forwarded_for_trims_whitespace() {
+        assert_eq!(parse_forwarded_for("  203.0.113.5  "), Some("203.0.113.5"));
+    }
+
+    #[test]
+    fn forwarded_for_returns_none_on_empty() {
+        assert_eq!(parse_forwarded_for(""), None);
+        assert_eq!(parse_forwarded_for("   "), None);
+        assert_eq!(parse_forwarded_for(","), None);
+    }
+
+    #[test]
+    fn real_ip_trims_whitespace() {
+        assert_eq!(parse_real_ip("  198.51.100.7  "), Some("198.51.100.7"));
+    }
+
+    #[test]
+    fn real_ip_returns_none_on_empty() {
+        assert_eq!(parse_real_ip(""), None);
+        assert_eq!(parse_real_ip("   "), None);
+    }
+
+    #[test]
+    fn bearer_token_strips_prefix() {
+        assert_eq!(
+            parse_bearer_token("Bearer abc.def.ghi"),
+            Some("abc.def.ghi")
+        );
+    }
+
+    #[test]
+    fn bearer_token_rejects_other_schemes() {
+        assert_eq!(parse_bearer_token("Basic dXNlcjpwYXNz"), None);
+        assert_eq!(parse_bearer_token("Digest realm=test"), None);
+    }
+
+    #[test]
+    fn bearer_token_is_case_sensitive() {
+        // Per RFC 6750, the scheme is case-insensitive in HTTP, but upstream
+        // callers historically matched the exact "Bearer " prefix; preserve
+        // that behavior here. Documented in function-level docs.
+        assert_eq!(parse_bearer_token("bearer abc"), None);
+        assert_eq!(parse_bearer_token("BEARER abc"), None);
+    }
+
+    #[test]
+    fn bearer_token_requires_space_separator() {
+        assert_eq!(parse_bearer_token("Bearer"), None);
+        assert_eq!(parse_bearer_token("Bearer:abc"), None);
+    }
+
+    #[test]
+    fn bearer_token_empty_after_prefix() {
+        // Caller is responsible for rejecting empty tokens; this returns Some("")
+        // to keep the primitive a pure prefix-strip.
+        assert_eq!(parse_bearer_token("Bearer "), Some(""));
+    }
+}

--- a/crates/octarine/src/primitives/http/mod.rs
+++ b/crates/octarine/src/primitives/http/mod.rs
@@ -1,0 +1,25 @@
+//! HTTP primitives (Layer 1)
+//!
+//! Pure HTTP-related utilities with no observe dependencies. Each function
+//! takes string slices and returns plain values, keeping the module
+//! framework-agnostic — callers in [`crate::http`] convert from
+//! `axum::http::HeaderValue` (or similar) before calling in.
+//!
+//! # Submodules
+//!
+//! - [`request_id`] — Parse or generate a request-correlation UUID.
+//! - [`headers`] — Parse forwarded-IP and Bearer-token headers.
+//! - [`security`] — Build `Strict-Transport-Security` values, detect
+//!   production/staging environments.
+//! - [`routing`] — Match request paths against exclusion lists.
+//!
+//! # Architecture
+//!
+//! This is Layer 1 (primitives) — pure functions with no observe
+//! dependencies. Layer 3 (`src/http/`) wraps these with Tower middleware,
+//! Axum extractors, and observe instrumentation.
+
+pub mod headers;
+pub mod request_id;
+pub mod routing;
+pub mod security;

--- a/crates/octarine/src/primitives/http/request_id.rs
+++ b/crates/octarine/src/primitives/http/request_id.rs
@@ -1,0 +1,67 @@
+//! Request-ID primitives
+//!
+//! Parses incoming request IDs from header strings, falling back to a freshly
+//! generated UUID v4 when the header is missing or unparseable.
+
+use uuid::Uuid;
+
+/// Parse an incoming request-ID header as a UUID, generating a new v4 when
+/// the input is `None` or not a valid UUID.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use octarine::primitives::http::request_id::parse_or_generate_request_id;
+///
+/// // Valid UUID is preserved
+/// let id = parse_or_generate_request_id(Some("550e8400-e29b-41d4-a716-446655440000"));
+/// assert_eq!(id.to_string(), "550e8400-e29b-41d4-a716-446655440000");
+///
+/// // Missing or invalid input generates a fresh v4
+/// let fresh = parse_or_generate_request_id(None);
+/// assert_eq!(fresh.get_version_num(), 4);
+/// ```
+#[must_use]
+pub fn parse_or_generate_request_id(header_value: Option<&str>) -> Uuid {
+    header_value
+        .and_then(|s| Uuid::try_parse(s).ok())
+        .unwrap_or_else(Uuid::new_v4)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_valid_uuid() {
+        let valid = "550e8400-e29b-41d4-a716-446655440000";
+        let id = parse_or_generate_request_id(Some(valid));
+        assert_eq!(id.to_string(), valid);
+    }
+
+    #[test]
+    fn generates_v4_when_missing() {
+        let id = parse_or_generate_request_id(None);
+        assert_eq!(id.get_version_num(), 4);
+    }
+
+    #[test]
+    fn generates_v4_when_malformed() {
+        let id = parse_or_generate_request_id(Some("not-a-uuid"));
+        assert_eq!(id.get_version_num(), 4);
+    }
+
+    #[test]
+    fn generates_v4_when_empty() {
+        let id = parse_or_generate_request_id(Some(""));
+        assert_eq!(id.get_version_num(), 4);
+    }
+
+    #[test]
+    fn distinct_ids_when_generated() {
+        let a = parse_or_generate_request_id(None);
+        let b = parse_or_generate_request_id(None);
+        assert_ne!(a, b);
+    }
+}

--- a/crates/octarine/src/primitives/http/routing.rs
+++ b/crates/octarine/src/primitives/http/routing.rs
@@ -1,0 +1,62 @@
+//! Routing primitives
+//!
+//! Pure helpers for matching request paths against configured rule lists.
+
+/// Return `true` when `path` begins with any prefix in `exclusions`.
+///
+/// Matches the historical Layer 3 middleware behavior: a prefix match (not
+/// a glob or regex), checked in the order the exclusions were supplied.
+/// Useful for "skip auth/metrics/rate-limit for these paths" patterns.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use octarine::primitives::http::routing::is_path_excluded;
+///
+/// let exclusions = vec!["/health".to_string(), "/public".to_string()];
+/// assert!(is_path_excluded("/health/live", &exclusions));
+/// assert!(!is_path_excluded("/api/data", &exclusions));
+/// ```
+#[must_use]
+pub fn is_path_excluded(path: &str, exclusions: &[String]) -> bool {
+    exclusions.iter().any(|p| path.starts_with(p.as_str()))
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn exclusions() -> Vec<String> {
+        vec!["/health".to_string(), "/public".to_string()]
+    }
+
+    #[test]
+    fn matches_exact_prefix() {
+        assert!(is_path_excluded("/health", &exclusions()));
+        assert!(is_path_excluded("/public", &exclusions()));
+    }
+
+    #[test]
+    fn matches_path_under_prefix() {
+        assert!(is_path_excluded("/health/live", &exclusions()));
+        assert!(is_path_excluded("/public/assets/logo.png", &exclusions()));
+    }
+
+    #[test]
+    fn does_not_match_unrelated_paths() {
+        assert!(!is_path_excluded("/api/data", &exclusions()));
+        assert!(!is_path_excluded("/admin", &exclusions()));
+    }
+
+    #[test]
+    fn empty_exclusions_never_match() {
+        assert!(!is_path_excluded("/anything", &[]));
+    }
+
+    #[test]
+    fn matches_root_prefix() {
+        let only_root = vec!["/".to_string()];
+        assert!(is_path_excluded("/anything", &only_root));
+    }
+}

--- a/crates/octarine/src/primitives/http/security.rs
+++ b/crates/octarine/src/primitives/http/security.rs
@@ -1,0 +1,112 @@
+//! HTTP security primitives
+//!
+//! Pure helpers for building security-related header values and detecting
+//! the deployment environment from process env vars.
+
+/// Configuration for building a `Strict-Transport-Security` header value.
+#[derive(Debug, Clone, Copy)]
+pub struct HstsConfig {
+    /// Max-age in seconds.
+    pub max_age: u64,
+    /// Whether to add the `includeSubDomains` directive.
+    pub include_subdomains: bool,
+    /// Whether to add the `preload` directive.
+    pub preload: bool,
+}
+
+/// Build a `Strict-Transport-Security` header value from the given config.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use octarine::primitives::http::security::{HstsConfig, build_hsts_value};
+///
+/// let value = build_hsts_value(&HstsConfig {
+///     max_age: 31_536_000,
+///     include_subdomains: true,
+///     preload: false,
+/// });
+/// assert_eq!(value, "max-age=31536000; includeSubDomains");
+/// ```
+#[must_use]
+pub fn build_hsts_value(config: &HstsConfig) -> String {
+    let mut value = format!("max-age={}", config.max_age);
+    if config.include_subdomains {
+        value.push_str("; includeSubDomains");
+    }
+    if config.preload {
+        value.push_str("; preload");
+    }
+    value
+}
+
+/// Return `true` when the current process is running in a production or
+/// staging environment.
+///
+/// Inspects the `ENVIRONMENT` and `ENV` environment variables (in that
+/// order); matches the lowercase values `production`, `prod`, `staging`,
+/// and `stage`.
+#[must_use]
+pub fn is_production_or_staging() -> bool {
+    let env = std::env::var("ENVIRONMENT")
+        .or_else(|_| std::env::var("ENV"))
+        .unwrap_or_default()
+        .to_lowercase();
+
+    matches!(env.as_str(), "production" | "prod" | "staging" | "stage")
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hsts_minimal() {
+        let value = build_hsts_value(&HstsConfig {
+            max_age: 3600,
+            include_subdomains: false,
+            preload: false,
+        });
+        assert_eq!(value, "max-age=3600");
+    }
+
+    #[test]
+    fn hsts_with_subdomains() {
+        let value = build_hsts_value(&HstsConfig {
+            max_age: 31_536_000,
+            include_subdomains: true,
+            preload: false,
+        });
+        assert_eq!(value, "max-age=31536000; includeSubDomains");
+    }
+
+    #[test]
+    fn hsts_full() {
+        let value = build_hsts_value(&HstsConfig {
+            max_age: 63_072_000,
+            include_subdomains: true,
+            preload: true,
+        });
+        assert_eq!(value, "max-age=63072000; includeSubDomains; preload");
+    }
+
+    #[test]
+    fn hsts_preload_without_subdomains() {
+        // Preload doesn't depend on includeSubDomains at this layer — the
+        // primitive is a faithful builder; policy enforcement lives in the
+        // calling middleware.
+        let value = build_hsts_value(&HstsConfig {
+            max_age: 100,
+            include_subdomains: false,
+            preload: true,
+        });
+        assert_eq!(value, "max-age=100; preload");
+    }
+
+    // is_production_or_staging() reads process env vars, so we can't test it
+    // hermetically here without serialization. The behavior is exercised by
+    // integration tests in tests/http/ and by the existing security.rs unit
+    // tests that already manipulate ENV. Keep this primitive simple and trust
+    // those upstream tests.
+}

--- a/crates/octarine/src/primitives/mod.rs
+++ b/crates/octarine/src/primitives/mod.rs
@@ -66,6 +66,7 @@ pub(crate) mod types;
 
 pub(crate) mod crypto;
 pub(crate) mod data;
+pub(crate) mod http;
 pub(crate) mod identifiers;
 pub(crate) mod io;
 pub(crate) mod runtime;


### PR DESCRIPTION
## Summary

Fills the Layer 3 architecture gap flagged in #63 — every Layer 3 module
had a corresponding `primitives/` submodule for pure logic except `http/`.
Inline UUID parsing, header parsing, HSTS construction, environment
detection, Bearer-token extraction, and excluded-path matching lived
directly inside Tower middleware, making them hard to unit-test without
booting an Axum router.

### What moved

New module `crates/octarine/src/primitives/http/` with four submodules:

| Submodule | Functions |
| --- | --- |
| `request_id` | `parse_or_generate_request_id()` |
| `headers` | `parse_forwarded_for()`, `parse_real_ip()`, `parse_bearer_token()` |
| `security` | `HstsConfig`, `build_hsts_value()`, `is_production_or_staging()` |
| `routing` | `is_path_excluded()` |

Seven Layer 3 middleware files (`auth`, `context`, `metrics`, `observe`,
`rate_limit`, `request_id`, `security`) now delegate to these primitives.
`is_path_excluded()` alone replaces four duplicated copies across the
middleware stack.

### Design notes

- Primitives take `&str` (not `axum::http::HeaderValue`) to stay
  framework-agnostic. Layer 3 callers do the `HeaderValue → &str`
  conversion before delegating.
- `parse_bearer_token` is intentionally case-sensitive on `"Bearer "` to
  preserve the historical behavior of `http/middleware/auth.rs`.
- No public API change — `primitives/` is `pub(crate)` and only reached
  from inside the crate.

## Test plan

- [x] `just fmt-check` — clean
- [x] `just clippy` — clean (`-D warnings`)
- [x] `just arch-check` — clean (verifies no `use crate::observe` under
      `primitives/` and naming conventions OK)
- [x] `just test-octarine` — 25 new unit tests pass alongside all
      existing tests (6675 unit + 770+ integration + 241 doctests,
      0 failures)
- [x] Verified no inline UUID parsing, Bearer prefix matching, or
      `starts_with` exclusion loops remain in `http/`

Closes #63