### PR TITLE
chore(ci): wire osv-scanner for broader vulnerability coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,17 @@ jobs:
       - uses: taiki-e/install-action@just
       - run: just deps-deny
 
+  osv:
+    name: OSV Scanner
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google/osv-scanner-action@v2.3.8
+        with:
+          scan-args: |-
+            --config=osv-scanner.toml
+            --lockfile=Cargo.lock
+
   semver:
     name: SemVer
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,7 +2357,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -2682,7 +2682,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -3520,9 +3520,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4454,7 +4454,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1 0.10.6",
@@ -4494,7 +4494,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -37,7 +37,8 @@ just arch-check                  # Architecture enforcement
 
 # Dependencies
 just deps-check                  # Full dependency health check
-just deps-audit                  # Security vulnerability audit
+just deps-audit                  # Security vulnerability audit (cargo audit / RustSec)
+just deps-osv                    # Security vulnerability audit (osv-scanner / OSV.dev)
 just deps-outdated               # Show outdated dependencies
 ```
 

--- a/justfile
+++ b/justfile
@@ -125,8 +125,12 @@ deps-audit:
 deps-deny:
     cargo deny check
 
-# Full dependency health check: audit + deny + outdated
-deps-check: deps-audit deps-deny deps-outdated
+# Check workspace lockfile against OSV.dev (RustSec + GHSA + cross-ecosystem)
+deps-osv:
+    osv-scanner scan source --lockfile=Cargo.lock
+
+# Full dependency health check: audit + deny + osv + outdated
+deps-check: deps-audit deps-deny deps-osv deps-outdated
 
 # ─── Utilities ───────────────────────────────────────────────────────────────
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,10 @@
+# osv-scanner allowlist
+#
+# Findings ignored here must also be reflected in `cargo audit` invocations
+# (currently `just deps-audit` via `--ignore`) so the two scanners stay in
+# sync. See justfile and docs/security/.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0071"
+# Marvin attack on the rsa crate. No fix is available upstream yet. The same
+# ignore is applied in `just deps-audit`; revisit when rsa publishes a fix.


### PR DESCRIPTION
## Summary

- Adds `osv-scanner` alongside `cargo audit` / `cargo deny` so we cross-check the RustSec DB (cargo audit) against OSV.dev (RustSec + GitHub Advisory DB + cross-ecosystem). Catches advisories that land in one DB but not the other.
- `justfile`: new `deps-osv` recipe; threaded into the `deps-check` chain.
- `osv-scanner.toml`: ignores `RUSTSEC-2023-0071` (rsa Marvin, no upstream fix) — mirrors the existing `--ignore` in `just deps-audit` so the two scanners agree on what's intentionally accepted.
- `.github/workflows/ci.yml`: new `osv` job parallel to `audit` / `deny`, running on push, PR, and the daily `17 6 * * *` cron. Uses pinned `google/osv-scanner-action@v2.3.8`.
- `docs/development/index.md`: lists `just deps-osv` next to `deps-audit`.
- `Cargo.lock`: bumps `rand 0.8.5 → 0.8.6` (RUSTSEC-2026-0097). One-line lockfile patch, no transitive cascade.

## Naming

Recipe name is `deps-osv` (not the issue's literal `osv-scan`) for parity with sibling recipes `deps-audit` / `deps-deny` / `deps-check`. All dependency-health recipes live under the `deps-*` namespace.

## Why the rand bump is in this PR

`cargo audit` treats RUSTSEC-2026-0097 as `unsound` and exits 0 (it's an "allowed warning"), but `osv-scanner` treats it as a finding and exits 1. Wiring osv-scanner without the bump would land CI permanently red. The bump itself is a one-line patch — `cargo update -p rand@0.8.5` updates just the `rand` entry in the workspace lockfile, no other crates affected. Folding it in here was the smallest change that lets this PR be merged cleanly.

## Container support

`osv-scanner v2.3.5` is pre-installed in the dev container via `containers/lib/features/dev-tools.sh` (pinned in `containers/lib/checksums.json`). No Dockerfile or container rebuild required.

## Test plan

- [x] `just deps-osv` — runs cleanly (exit 0) with the `RUSTSEC-2023-0071` allowlist applied
- [x] `just deps-check` — full chain (`deps-audit + deps-deny + deps-osv + deps-outdated`) passes
- [x] `just fmt-check` — passes
- [x] `just arch-check` — passes
- [x] `actionlint .github/workflows/ci.yml` — passes
- [ ] CI: `osv` job appears in the checks list and runs alongside `audit` / `deny`
- [ ] CI: existing `fmt` / `clippy` / `test` / `doc` / `semver` / `arch` still skip on the daily cron (their `if: github.event_name != 'schedule'` guards untouched)

Closes #265