### PR TITLE
chore(deps): bump assert_cmd, jsonwebtoken, nix to latest patch/minor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -2345,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2364,6 +2364,7 @@ dependencies = [
  "sha2 0.10.9",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -2614,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2771,7 +2772,7 @@ dependencies = [
  "libc",
  "local-ip-address",
  "ml-kem",
- "nix 0.31.2",
+ "nix 0.31.3",
  "octarine-derive",
  "once_cell",
  "opentelemetry",
@@ -3731,7 +3732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a0ac16ec311879f32b8b1963eb6b81792f30c6bede86d8ce83ad5adfca4698d"
 dependencies = [
  "comma",
- "nix 0.31.2",
+ "nix 0.31.3",
  "regex",
  "tempfile",
  "thiserror 2.0.18",


### PR DESCRIPTION
## Summary

Lockfile-only updates of three semver-compatible dependencies. No Cargo.toml manifest changes needed.

- `assert_cmd` 2.2.1 → 2.2.2 (patch, test infra)
- `jsonwebtoken` 10.3.0 → 10.4.0 (minor): adds **partial zeroization of `EncodingKey` / `DecodingKey` on drop** and fixes Ed25519 JWK thumbprint encoding. [Changelog](https://github.com/Keats/jsonwebtoken/blob/master/CHANGELOG.md). No breaking changes.
- `nix` 0.31.2 → 0.31.3 (patch, unix-only)

## Why now

Surfaced by `just deps-outdated` while reviewing post #321 state. These are the three lockfile-safe bumps in the set of five outdated deps — the remaining two (`quick-xml 0.39 → 0.40` and `rexpect 0.6 → 0.7`) involve breaking changes and will be filed as separate issues.

## Test plan

- [x] `just preflight` (fmt + clippy + shellcheck + arch-check + test) passes
- [x] `just deps-check` (audit + deny + osv + outdated) passes
- [x] `cargo update` dry-run confirmed lockfile-only patch (no transitive cascade beyond `zeroize` being added as a `jsonwebtoken` dep, already in tree)