### PR TITLE
deps(xml): bump quick-xml 0.39 → 0.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2659,7 +2659,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3397,7 +3397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3435,9 +3435,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "0b7315c86b26aaef0321fba33c9dcc160da659c6a9d278f0f6a5656d6561c03b"
 dependencies = [
  "memchr",
 ]
@@ -3846,7 +3846,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3903,7 +3903,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4651,7 +4651,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5583,7 +5583,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -142,7 +142,7 @@ sha1 = { version = "0.11", optional = true }
 graphql-parser = { version = "0.4", optional = true }
 
 # Structured data formats (optional, for formats module)
-quick-xml = { version = "0.39", optional = true }
+quick-xml = { version = "0.40", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 # Crypto input validation (optional)


### PR DESCRIPTION
## Summary

- Bumps `quick-xml` from 0.39 to 0.40 (breaking-change release per upstream changelog).
- **No source changes required.** Audit of all octarine call sites confirmed that none of the 0.40 breaking-change APIs (NsReader resolver methods, split `SyntaxError` variants, `read_text()` return type, deprecated `unescape_value()`, `Parser::eof_error()` signature) are used. Only `Reader::from_str`, event-loop pattern matching, `BytesDecl/Text/Start/End::new`, `Writer::write_event`, `e.decode()`, `e.attributes()`, and `error_position()` — all unchanged in 0.40.
- MSRV bump in `quick-xml` (1.59 → 1.79) is a non-issue; octarine is already on 1.94.

## Test plan

- [x] `just test-mod "primitives::data::formats::xml" formats` — 13/13 pass
- [x] `just test-mod "runtime::formats::xml" formats` — 5/5 pass
- [x] `cargo test -p octarine --lib --features "formats observe" -- xml` — 49/49 pass (primitives + runtime + Layer 3 builder/shortcuts)
- [x] `just clippy` — clean
- [x] `just deps-outdated` — `quick-xml` no longer flagged
- [x] `just preflight` — green on rerun (one unrelated flake on first run, did not repeat)

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)