### PR TITLE
fix(ci): replace broken osv-scanner-action with install-action + just recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: google/osv-scanner-action@v2.3.8
-        with:
-          scan-args: |-
-            --config=osv-scanner.toml
-            --lockfile=Cargo.lock
+      - uses: taiki-e/install-action@osv-scanner
+      - uses: taiki-e/install-action@just
+      - run: just deps-osv
 
   semver:
     name: SemVer


### PR DESCRIPTION
## Summary

- `google/osv-scanner-action@v2.3.8` is a **reusable workflow**, not a step-level action — every CI run since #321 has failed with `##[error]Top level 'runs:' section is required for google/osv-scanner-action/v2.3.8/action.yml`
- Swap it for `taiki-e/install-action@osv-scanner` + `just deps-osv` (recipe already exists from #321)
- Matches the existing audit/deny job pattern and CLAUDE.md's "always use just recipes" invariant
- `osv-scanner.toml` is auto-discovered, so the explicit `--config` flag is dropped

## Test plan

- [x] Verified locally: \`just deps-osv\` filters RUSTSEC-2023-0071 via osv-scanner.toml and reports "No issues found"
- [ ] CI \`OSV Scanner\` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)