### PR TITLE
deps(testing): bump rexpect 0.6 → 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3727,9 +3727,9 @@ dependencies = [
 
 [[package]]
 name = "rexpect"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0ac16ec311879f32b8b1963eb6b81792f30c6bede86d8ce83ad5adfca4698d"
+checksum = "e459b12e442eb95f78b7e69bb2c3a64fc96f24d90dbc47fb028d94ffb26ce1e8"
 dependencies = [
  "comma",
  "nix 0.31.3",

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -169,7 +169,7 @@ local-ip-address = "0.6.8"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["fs", "user"] }
 libc = "0.2"
-rexpect = { version = "0.6", optional = true }
+rexpect = { version = "0.7", optional = true }
 
 [features]
 default = ["console", "full", "derive"]
@@ -226,7 +226,7 @@ test-case = "3.3"
 wiremock = "0.6"
 fake = { version = "5.1", features = ["derive"] }
 assert_cmd = "2.0"
-rexpect = "0.6"
+rexpect = "0.7"
 
 [[bench]]
 name = "pii_redaction"


### PR DESCRIPTION
## Summary

- Bumps `rexpect` 0.6 → 0.7 in both the optional `[target.cfg(unix).dependencies]` entry and the `[dev-dependencies]` entry
- Test-infra only — gated behind the `testing` feature
- Audited every rexpect call site against the 0.7 breaking changes: **no source changes required**

## 0.7 breaking-change audit

| 0.7 break | octarine usage | Impact |
|---|---|---|
| Private fields on `PtyReplSession`, `PtySession`, `StreamSession`, `Options` | `PtySession` used only as a type and `impl InteractiveTestExt` target; impl calls only public methods (`exp_string`, `send_line`, `exp_eof`, `exp_regex`, `send`). No field access. | None |
| `Options` / `Error` marked `#[non_exhaustive]` | `Options` never constructed; `Error` only appears in return signatures, never matched. | None |
| Removed `find`, `process::wait`, `process::signal` | Not used in the crate. | None |
| MSRV → 1.85 | Pinned to 1.94 in `rust-toolchain.toml`. | None |

`rexpect::spawn(&cmd, Some(timeout_ms))` signature is unchanged in 0.7 ([docs.rs/rexpect/0.7.0](https://docs.rs/rexpect/0.7.0/)).

Closes #324

## Test plan

- [x] `just test-with-fixtures` — 183 passed, 0 failed
- [x] `just clippy` — clean
- [x] `just deps-outdated` no longer flags rexpect
- [x] No callers reach into private fields of `PtySession` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)