### PR TITLE
docs: explain platform-conditional logic

### DIFF
--- a/crates/octarine/src/data/paths/home/core.rs
+++ b/crates/octarine/src/data/paths/home/core.rs
@@ -101,21 +101,24 @@ fn get_home_dir() -> Result<String, Problem> {
 
 /// Fallback home directory detection
 fn home_dir_fallback() -> Option<String> {
-    // Use a simple platform-specific fallback
+    // Best-effort platform-specific guess when $HOME is unset. We do not
+    // consult /etc/passwd via getpwuid — this is intentionally conservative.
     #[cfg(unix)]
     {
-        // On Unix, try /etc/passwd via getpwuid
-        // For simplicity, we'll just check common paths
         if let Ok(user) = std::env::var("USER") {
+            // Linux convention: /home/<user>.
             let path = PathBuf::from(format!("/home/{}", user));
             if path.exists() {
                 return Some(path.to_string_lossy().to_string());
             }
-            // macOS uses /Users
+            // macOS convention: /Users/<user>.
             let path = PathBuf::from(format!("/Users/{}", user));
             if path.exists() {
                 return Some(path.to_string_lossy().to_string());
             }
+            // BSDs, NixOS, and other Unix variants may use other layouts
+            // (e.g., /usr/home, /var/empty). Fall through to None and let
+            // the caller surface a clean error.
         }
     }
 

--- a/crates/octarine/src/observe/writers/file/core.rs
+++ b/crates/octarine/src/observe/writers/file/core.rs
@@ -10,6 +10,9 @@ use crate::observe::types::{Event, Severity};
 use crate::observe::writers::builder::FileWriterBuilder;
 use crate::observe::writers::sanitize_for_writing;
 use crate::observe::writers::types::LogFormat;
+// Unix-only: POSIX file-mode bits for log-file permission enforcement.
+// On Windows the log file inherits the parent directory's default ACLs;
+// stricter access control must be configured externally.
 #[cfg(unix)]
 use crate::primitives::io::file::set_mode;
 use crate::primitives::io::file::with_directory_mode;


### PR DESCRIPTION
## Summary

- Add comments documenting the platform contract for two `cfg(unix)` sites flagged by `audit-octarine-platforms`.
- `observe/writers/file/core.rs` — clarify that the Unix-only `set_mode` import enforces POSIX file-mode bits, and that Windows log files inherit parent-directory ACLs.
- `data/paths/home/core.rs` — distinguish Linux (`/home/<user>`) from macOS (`/Users/<user>`) conventions in `home_dir_fallback`, and acknowledge that BSDs/NixOS variants may use other layouts and fall through to `None`.
- No behaviour change. Pure documentation.

## Test plan

- [x] `just preflight` (fmt + clippy + arch-check + tests) — all green
- [x] Commit-only diff: 2 files, +10/-4 lines, all comment changes
- [x] Manual review confirms no logic touched

Closes #201