### PR TITLE
fix(ci): harden macOS Check against rustup-init shim flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,23 @@ jobs:
     if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
+      - name: Reset pre-installed Rust toolchain
+        # macOS runner images sometimes ship a stub cargo that is actually
+        # rustup-init; the dtolnay/rust-toolchain action then short-circuits
+        # past its curl install (rustup-init reports "rustup is present") and
+        # never registers $CARGO_HOME/bin on PATH. cargo check then resolves
+        # to rustup-init and fails with "unexpected argument 'check' found".
+        # Wiping forces dtolnay's clean-install path.
+        run: rm -rf "$HOME/.cargo" "$HOME/.rustup"
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.94"
+      - name: Verify cargo resolves to toolchain
+        # Fail fast (and visibly) if the rustup-init flake recurs, instead of
+        # letting cargo check emit a confusing usage error 30 lines later.
+        run: |
+          which cargo
+          cargo --version
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: macos


### PR DESCRIPTION
## Summary

Hardens the `Check (macOS)` job against a transient runner-image flake observed once on the post-merge CI for #331.

**Root cause**: macOS runner images sometimes ship `/opt/homebrew/bin/cargo` as the unbootstrapped `rustup-init` binary. `dtolnay/rust-toolchain`'s "install rustup if needed" guard then short-circuits past the curl install (`command -v rustup` returns truthy for rustup-init), but the resulting setup never registers `$CARGO_HOME/bin` on PATH. `cargo check` then resolves to rustup-init and fails with:

```
error: unexpected argument 'check' found
Usage: rustup-init[EXE] [OPTIONS]
```

A `gh run rerun --failed` on the same SHA passed cleanly, confirming the flake is transient and tied to the runner image, not our code.

## Fix

Two defensive steps added to `check-macos` only:

1. **Reset pre-installed Rust toolchain** before `dtolnay/rust-toolchain` — `rm -rf "$HOME/.cargo" "$HOME/.rustup"` so the action takes the clean curl-install path that registers PATH correctly.
2. **Verify cargo resolves to toolchain** after install — `which cargo && cargo --version` so a recurrence fails at the verification step with a clear signal instead of producing a confusing usage error mid-build 30 lines later.

Linux and Windows jobs are unaffected.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `yq . .github/workflows/ci.yml` — YAML valid
- [ ] PR CI run — `Check (macOS)` should now show the two new steps in its log
- Monitor the next ~10 main CI runs for recurrence; if it reproduces despite the wipe, swap the toolchain action

Refs the post-merge flake on #331.