### PR TITLE
fix(ci): unbreak macOS Check — PATH + cache invalidation + no bin caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,23 +164,28 @@ jobs:
     if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
-      - name: Reset pre-installed Rust toolchain
-        # macOS runner images sometimes ship a stub cargo that is actually
-        # rustup-init; the dtolnay/rust-toolchain action then short-circuits
-        # past its curl install (rustup-init reports "rustup is present") and
-        # never registers $CARGO_HOME/bin on PATH. cargo check then resolves
-        # to rustup-init and fails with "unexpected argument 'check' found".
-        # Wiping forces dtolnay's clean-install path.
-        run: rm -rf "$HOME/.cargo" "$HOME/.rustup"
+      - name: Ensure $CARGO_HOME/bin on PATH
+        # macOS runner images come with rustup pre-installed at a system path
+        # (e.g. /opt/homebrew/bin/rustup). dtolnay/rust-toolchain's
+        # "install rustup if needed" guard sees that rustup is present and
+        # short-circuits past `echo "$CARGO_HOME/bin" >> $GITHUB_PATH`, so
+        # rustup's shim dir (where cargo/rustc actually live) never lands on
+        # PATH. Subsequent steps then hit "rustc: command not found" or
+        # cargo resolves to a stub rustup-init binary. Putting CARGO_HOME/bin
+        # on PATH here covers the short-circuit case; if dtolnay does run
+        # the curl install, the duplicate entry is harmless.
+        run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.94"
       - name: Verify cargo resolves to toolchain
-        # Fail fast (and visibly) if the rustup-init flake recurs, instead of
-        # letting cargo check emit a confusing usage error 30 lines later.
+        # Fail fast (and visibly) if cargo/rustc still aren't reachable,
+        # instead of letting later steps emit a confusing error.
         run: |
           which cargo
+          which rustc
           cargo --version
+          rustc --version
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,13 +167,11 @@ jobs:
       - name: Ensure $CARGO_HOME/bin on PATH
         # macOS runner images come with rustup pre-installed at a system path
         # (e.g. /opt/homebrew/bin/rustup). dtolnay/rust-toolchain's
-        # "install rustup if needed" guard sees that rustup is present and
-        # short-circuits past `echo "$CARGO_HOME/bin" >> $GITHUB_PATH`, so
-        # rustup's shim dir (where cargo/rustc actually live) never lands on
-        # PATH. Subsequent steps then hit "rustc: command not found" or
-        # cargo resolves to a stub rustup-init binary. Putting CARGO_HOME/bin
-        # on PATH here covers the short-circuit case; if dtolnay does run
-        # the curl install, the duplicate entry is harmless.
+        # "install rustup if needed" guard sees rustup is present and
+        # short-circuits past "echo $CARGO_HOME/bin >> $GITHUB_PATH". The
+        # toolchain installs fine, but the shim dir never lands on PATH,
+        # which breaks cargo invocations after the cache step swaps in its
+        # own .cargo/bin contents.
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -188,7 +186,16 @@ jobs:
           rustc --version
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: macos
+          # `macos-v2` invalidates a cache poisoned by the original
+          # rustup-init flake (an earlier run cached a stub `cargo` that
+          # was actually rustup-init; every subsequent run restored it
+          # and then `cargo check` resolved to rustup-init).
+          shared-key: macos-v2
+          # Do not cache ~/.cargo/bin on this job — we don't `cargo
+          # install` anything here, and caching the toolchain shims has
+          # only caused breakage on macOS. The toolchain itself lives in
+          # ~/.rustup/toolchains and is reinstalled by dtolnay each run.
+          cache-bin: false
       - run: cargo check --workspace --all-features
 
   test-nightly:


### PR DESCRIPTION
## Summary

The macOS Check job has been failing intermittently with a confusing `cargo` -> `rustup-init` resolution error. After three iterations of investigation, the actual root cause turned out to be **cache poisoning**, not a transient runner issue.

## What I learned from each attempt

### Attempt 1 (#332): wipe ~/.cargo, ~/.rustup before dtolnay

Hypothesis: macOS runner ships `cargo` as a rustup-init stub; force dtolnay's curl-install path.

Result: failed with exit 127 at the `create cachekey` step (`rustc: command not found`).

Why it failed: the runner actually has real `rustup` at `/opt/homebrew/bin/rustup` (not in `$HOME`), so the wipe was incomplete. dtolnay's `command -v rustup` short-circuited, the toolchain installed via the system rustup, but `$CARGO_HOME/bin` was never added to PATH.

### Attempt 2 (this PR, initial commit): prepend $CARGO_HOME/bin to PATH

Hypothesis: cover the PATH gap from dtolnay's short-circuit.

Result: `Verify cargo resolves to toolchain` printed `/Users/runner/.cargo/bin/cargo` and a valid `cargo --version` — but `cargo check` then still failed with the rustup-init usage error.

That made no sense until I looked at the timeline:

| Time | Step |
|---|---|
| 16:27:02.31 | `which cargo` → `~/.cargo/bin/cargo` ✓ |
| 16:27:02.31 | `cargo --version` → `cargo 1.94.1` ✓ |
| 16:27:04.67 | Swatinem/rust-cache: `Cache Paths: /Users/runner/.cargo/bin` (among others) |
| 16:27:13.67 | `Cache restored successfully` |
| 16:27:13.83 | `cargo check` → `error: unexpected argument 'check' found / Usage: rustup-init[EXE]` |

The cache was poisoned. An earlier run hit the original rustup-init flake (probably the original failure on #331's post-merge run), and that broken `cargo` binary was stored in `~/.cargo/bin` and uploaded to the macOS cache. Every subsequent macOS Check run then:

1. Installed a fresh toolchain (the verify step proved this worked).
2. Restored the cache, which overwrote `~/.cargo/bin` with the poisoned stub.
3. `cargo check` resolved to the stub and produced the misleading rustup-init error.

### Attempt 3 (this PR, current commit): bust the cache + stop caching .cargo/bin

Two changes:

1. **`shared-key: macos` → `shared-key: macos-v2`** — invalidates the poisoned cache. GitHub abandons unused caches after 7 days, so the old entry will GC.

2. **`cache-bin: false`** — we don't `cargo install` any tools on this job (deps tools use `taiki-e/install-action`). Caching `~/.cargo/bin` only stores toolchain shims that `dtolnay/rust-toolchain` reinstalls every run anyway. The valuable parts of the cache (`~/.cargo/registry`, `~/.cargo/git`, `target/`) are unaffected.

The diagnostic + PATH steps from the previous attempt are kept — they're cheap and they made the failure mode debuggable.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [ ] PR CI run — `Check (macOS)` should now pass; verify step prints toolchain paths, cache misses on the new key (first run), cargo check completes
- [ ] Subsequent main runs should hit the new cache cleanly

Linux and Windows jobs are unchanged.

Supersedes #332 (which was reverted by this PR's first commit on the macOS job — the rm-rf is removed entirely).