### PR TITLE
chore(memory): record macOS CI cache-poisoning lesson

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -7,3 +7,4 @@
 - [PR auto-merge on green](feedback_pr_auto_merge.md) — for /next-issue-ship PRs, squash-merge + delete-branch + prune as soon as CI is green; don't ask
 - [Dependabot coordinated bumps](project_dependabot_coordinated_bumps.md) — opentelemetry/tonic/tracing families need ONE unified PR; close individual Dependabot PRs as superseded
 - [Pre-1.0 prefer breaking](feedback_pre_1_0_breaking_changes.md) — while on 0.x beta, do breaking renames directly; skip `#[deprecated]` aliases
+- [macOS CI cache poisoning](project_ci_macos_cache_poisoning.md) — ci.yml uses `cache-bin: false` + versioned `shared-key` to prevent a poisoned `~/.cargo/bin` cache from breaking every subsequent run. Bump the key if it happens again; don't waste time debugging.

--- a/.claude/memory/project_ci_macos_cache_poisoning.md
+++ b/.claude/memory/project_ci_macos_cache_poisoning.md
@@ -1,0 +1,45 @@
+---
+name: ci-macos-cache-poisoning
+description: macOS CI uses cache-bin=false to prevent .cargo/bin poisoning and bumps shared-key when toolchain bins get corrupted
+metadata:
+  node_type: memory
+  type: project
+  originSessionId: bfac780c-0dc5-4dfa-8e30-660c0215a5ac
+---
+
+The `Check (macOS)` job in `.github/workflows/ci.yml` uses:
+
+- explicit `echo "$CARGO_HOME/bin" >> $GITHUB_PATH` before
+  `dtolnay/rust-toolchain` (handles dtolnay's short-circuit when the
+  runner has system rustup at `/opt/homebrew/bin/rustup`)
+- `cache-bin: false` on `Swatinem/rust-cache@v2` (prevents poisoning)
+- a versioned `shared-key` (`macos-v2`) (lets us invalidate the cache
+  when poisoning happens)
+
+**Why:** A single runner-image flake stored a stub `rustup-init` as
+`~/.cargo/bin/cargo`. `Swatinem/rust-cache@v2` caches `~/.cargo/bin`
+by default, so every subsequent macOS run pulled the bad cache AFTER
+the toolchain install, replacing the working shims and reproducing the
+`error: unexpected argument 'check' found / Usage: rustup-init[EXE]`
+error indefinitely. One broken run → permanent CI breakage until the
+cache key changed.
+
+**How to apply:**
+
+- Do NOT remove `cache-bin: false` on the macOS job. We don't
+  `cargo install` anything there, so caching `~/.cargo/bin` provides
+  no benefit and creates this poisoning risk.
+- If macOS Check breaks again with a similar rustup-init or "command
+  not found" signature, bump `shared-key: macos-v2` → `macos-v3`. Don't
+  spend time debugging; the cache is poisoned.
+- The "Verify cargo resolves to toolchain" step is the canary. If it
+  fails, the PATH-prepend is the issue. If it passes but `cargo check`
+  fails, the cache is poisoned.
+- Linux and Windows jobs do not need any of this — their runner images
+  do not pre-install rustup the same way, and they have not exhibited
+  the poisoning pattern.
+
+History: original flake on #331's post-merge run; misdiagnosed as
+rustup-init shim in #332 (rm -rf approach was wrong); finally fixed
+in #333 by combining the PATH prepend with `cache-bin: false` + a
+fresh `shared-key`.


### PR DESCRIPTION
## Summary

Persists the lesson learned from the three-PR macOS CI investigation (#332, #333) into team memory so future-me (or anyone else) doesn't re-walk the same diagnostic path.

## What's in the memory file

`project_ci_macos_cache_poisoning.md`:

- The three load-bearing pieces of the fix (PATH prepend, `cache-bin: false`, versioned `shared-key`)
- The actual root cause (Swatinem caching `~/.cargo/bin` propagated a one-off bad binary indefinitely)
- The remediation if it recurs (bump `shared-key: macos-vN` and move on — don't debug)
- The canary: the "Verify cargo resolves to toolchain" step distinguishes setup issues from cache poisoning

`MEMORY.md`: one-line index entry pointing at the new file.

Both files are long-term memory (root of `.claude/memory/`), not session-tier, per the project's two-tier memory convention.

## Test plan

- [x] `head` on `project_ci_macos_cache_poisoning.md` to confirm frontmatter
- [x] precedent check — earlier `chore(memory): ...` commits (e.g. 0f6311d, 29f1575, 31dc19a) followed the same shape and were direct commits to main; this PR uses a branch out of caution since multi-PR session