### PR TITLE
feat(arch-check): enforce 800 production-LOC file-length limit

### DIFF
--- a/scripts/arch_check/checks/__init__.py
+++ b/scripts/arch_check/checks/__init__.py
@@ -8,6 +8,7 @@ from typing import Callable, Iterator
 from scripts.arch_check.core import Finding, iter_files
 from scripts.arch_check.checks import (
     builder_visibility,
+    file_length,
     layer_boundary,
     naming_prefix,
     naming_return_type,
@@ -51,6 +52,10 @@ def _run_builder_visibility(*, staged_only: bool, root: Path) -> Iterator[Findin
     yield from builder_visibility.run(root=root)
 
 
+def _run_file_length(*, staged_only: bool, root: Path) -> Iterator[Finding]:
+    yield from file_length.run(staged_only=staged_only, root=root)
+
+
 # Order matters: bash executes checks in this exact sequence.
 CHECK_ORDER: list[str] = [
     "layer-boundary",
@@ -60,6 +65,7 @@ CHECK_ORDER: list[str] = [
     "test-lint",
     "type-visibility",
     "builder-visibility",
+    "file-length",
 ]
 
 CHECKS: dict[str, CheckRunner] = {
@@ -70,4 +76,5 @@ CHECKS: dict[str, CheckRunner] = {
     "test-lint": _run_test_lint,
     "type-visibility": _run_type_visibility,
     "builder-visibility": _run_builder_visibility,
+    "file-length": _run_file_length,
 }

--- a/scripts/arch_check/checks/file_length.py
+++ b/scripts/arch_check/checks/file_length.py
@@ -1,0 +1,70 @@
+"""Check 8: File length — production LOC must not exceed 800.
+
+Production LOC is total file LOC minus everything from the first
+`#[cfg(test)]` module onward. Files may opt out with an explicit
+`// arch-check: allow file-length` waiver comment within the first 20 lines.
+
+Mirrors the size-limit policy in `CLAUDE.md`:
+
+    Preferred: <300 LOC per file
+    Warning:   >500 LOC
+    Split at:  >800 LOC
+
+Only the >800 split threshold is enforced here. The other thresholds are
+advisory guidance that may be revisited as the codebase evolves.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+from scripts.arch_check.core import Finding, iter_files, rel
+
+_PROD_LOC_LIMIT = 800
+_WAIVER_WINDOW = 20
+_WAIVER_MARKER = "arch-check: allow file-length"
+_TEST_MODULE_MARKER = "#[cfg(test)]"
+
+
+def _production_loc(text: str) -> int:
+    """Return production LOC = total lines minus inline test module.
+
+    The first ``#[cfg(test)]`` line and everything after it is excluded.
+    If no test module is present, the whole file is production.
+    """
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        if line.lstrip().startswith(_TEST_MODULE_MARKER):
+            return idx
+    return len(lines)
+
+
+def _has_waiver(text: str) -> bool:
+    """Detect the inline waiver comment in the first 20 lines."""
+    for line in text.splitlines()[:_WAIVER_WINDOW]:
+        if _WAIVER_MARKER in line:
+            return True
+    return False
+
+
+def run(*, staged_only: bool, root: Path) -> Iterator[Finding]:
+    for path in iter_files(subdir=None, staged_only=staged_only, root=root):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if _has_waiver(text):
+            continue
+        prod = _production_loc(text)
+        if prod > _PROD_LOC_LIMIT:
+            yield Finding(
+                severity="ERROR",
+                check="file-length",
+                rel_path=rel(path, root),
+                line=None,
+                message=(
+                    f"file has {prod} production LOC; split at >{_PROD_LOC_LIMIT} "
+                    f"(or add `// {_WAIVER_MARKER}` near the top with justification)"
+                ),
+            )


### PR DESCRIPTION
## Summary

Adds `scripts/arch_check/checks/file_length.py` — the load-bearing piece that locks in the file splits from PRs #341 / #342 / #343 / #344 / #345 / #346 by making the 800 production-LOC limit pre-push enforceable instead of audit-only.

**Production LOC** = total lines minus everything from the first `#[cfg(test)]` module onward. Files may opt out with an explicit `// arch-check: allow file-length` waiver comment within the first 20 lines (no current files require this).

Mirrors the policy in `CLAUDE.md`:

```
Preferred: <300 LOC per file
Warning:   >500 LOC
Split at:  >800 LOC
```

Only the >800 split threshold is enforced — the lower thresholds remain advisory.

Wired into `scripts/arch_check/checks/__init__.py` `CHECK_ORDER` so it runs in `just arch-check`, `just preflight` (pre-push hook), and the CI check workflow. Output format mirrors `naming_prefix` and other existing checks.

## Test plan

- [x] `python3 -m scripts.arch_check file-length` exits 0 on `main` (no files exceed)
- [x] `just preflight` passes
- [x] An 901-line fixture produces an `ERROR` finding
- [x] The same fixture with a `// arch-check: allow file-length` waiver produces zero findings

## Context

Closes #338 (file-length umbrella). Final PR (7 of 7) in the series:

- #341 — split `personal.rs`
- #342 — split `network.rs`
- #343 — split Layer 1 `token/builder.rs`
- #344 — split `io/ops.rs`
- #345 — split `crypto/secrets/storage.rs`
- #346 — split `observe/pii/types.rs`
- #347 (this) — add the enforcement rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)