### PR TITLE
refactor(lints): reduce cognitive complexity & enforce in CI

### DIFF
--- a/crates/octarine-derive/Cargo.toml
+++ b/crates/octarine-derive/Cargo.toml
@@ -41,6 +41,7 @@ panic = "deny"
 todo = "warn"
 unimplemented = "warn"
 complexity = { level = "warn", priority = -1 }
+cognitive_complexity = "deny"
 perf = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
 dbg_macro = "deny"

--- a/crates/octarine-problem/Cargo.toml
+++ b/crates/octarine-problem/Cargo.toml
@@ -33,6 +33,7 @@ unimplemented = "warn"
 indexing_slicing = "deny"
 arithmetic_side_effects = "deny"
 complexity = { level = "warn", priority = -1 }
+cognitive_complexity = "deny"
 perf = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
 dbg_macro = "deny"

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -256,6 +256,7 @@ unimplemented = "warn"
 indexing_slicing = "deny"
 arithmetic_side_effects = "deny"
 complexity = { level = "warn", priority = -1 }
+cognitive_complexity = "deny"
 perf = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
 dbg_macro = "deny"

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -8,9 +8,9 @@ use super::super::types::PiiType;
 // Import domain builders from primitives/identifiers
 use crate::primitives::identifiers::{
     BiometricIdentifierBuilder, CredentialIdentifierBuilder, FinancialIdentifierBuilder,
-    GovernmentIdentifierBuilder, LocationIdentifierBuilder, MedicalIdentifierBuilder,
-    NetworkIdentifierBuilder, OrganizationalIdentifierBuilder, PersonalIdentifierBuilder,
-    TokenIdentifierBuilder, TokenType,
+    GovernmentIdentifierBuilder, IdentifierMatch, LocationIdentifierBuilder,
+    MedicalIdentifierBuilder, NetworkIdentifierBuilder, OrganizationalIdentifierBuilder,
+    PersonalIdentifierBuilder, TokenIdentifierBuilder, TokenType,
 };
 
 /// Scan for personal PII (email, phone, name, birthdate)
@@ -62,96 +62,124 @@ pub(super) fn scan_financial(text: &str, pii_types: &mut Vec<PiiType>) {
     }
 }
 
-/// Scan for government IDs (SSN, driver license, passport, tax ID)
+/// Scan for government IDs (SSN, driver license, passport, tax ID, plus
+/// country-specific national IDs across 18 jurisdictions).
 pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
-    let government = GovernmentIdentifierBuilder::new();
+    type Finder = fn(&GovernmentIdentifierBuilder, &str) -> Vec<IdentifierMatch>;
+    const SCANNERS: &[(Finder, PiiType)] = &[
+        (GovernmentIdentifierBuilder::find_ssns_in_text, PiiType::Ssn),
+        (
+            GovernmentIdentifierBuilder::find_driver_licenses_in_text,
+            PiiType::DriverLicense,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_passports_in_text,
+            PiiType::Passport,
+        ),
+        (GovernmentIdentifierBuilder::find_eins_in_text, PiiType::Ein),
+        (
+            GovernmentIdentifierBuilder::find_tax_ids_in_text,
+            PiiType::TaxId,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_national_ids_in_text,
+            PiiType::NationalId,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_vehicle_ids_in_text,
+            PiiType::Vin,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_korea_rrns_in_text,
+            PiiType::KoreaRrn,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_australia_tfns_in_text,
+            PiiType::AustraliaTfn,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_australia_abns_in_text,
+            PiiType::AustraliaAbn,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_india_aadhaars_in_text,
+            PiiType::IndiaAadhaar,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_india_pans_in_text,
+            PiiType::IndiaPan,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_india_gstins_in_text,
+            PiiType::IndiaGstin,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_india_vehicle_registrations_in_text,
+            PiiType::IndiaVehicleReg,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_india_voter_ids_in_text,
+            PiiType::IndiaVoterId,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_india_passports_in_text,
+            PiiType::IndiaPassport,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_brazil_cpfs_in_text,
+            PiiType::BrazilCpf,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_brazil_cnpjs_in_text,
+            PiiType::BrazilCnpj,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_mexico_curps_in_text,
+            PiiType::MexicoCurp,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_nigeria_nins_in_text,
+            PiiType::NigeriaNin,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_thailand_tnins_in_text,
+            PiiType::ThailandTnin,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_singapore_nrics_in_text,
+            PiiType::SingaporeNric,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_finland_hetus_in_text,
+            PiiType::FinlandHetu,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_poland_pesels_in_text,
+            PiiType::PolandPesel,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_italy_fiscal_codes_in_text,
+            PiiType::ItalyFiscalCode,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_spain_nifs_in_text,
+            PiiType::SpainNif,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_spain_nies_in_text,
+            PiiType::SpainNie,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_uk_nis_in_text,
+            PiiType::UkNi,
+        ),
+    ];
 
-    if !government.find_ssns_in_text(text).is_empty() {
-        pii_types.push(PiiType::Ssn);
-    }
-    if !government.find_driver_licenses_in_text(text).is_empty() {
-        pii_types.push(PiiType::DriverLicense);
-    }
-    if !government.find_passports_in_text(text).is_empty() {
-        pii_types.push(PiiType::Passport);
-    }
-    if !government.find_eins_in_text(text).is_empty() {
-        pii_types.push(PiiType::Ein);
-    }
-    if !government.find_tax_ids_in_text(text).is_empty() {
-        pii_types.push(PiiType::TaxId);
-    }
-    if !government.find_national_ids_in_text(text).is_empty() {
-        pii_types.push(PiiType::NationalId);
-    }
-    if !government.find_vehicle_ids_in_text(text).is_empty() {
-        pii_types.push(PiiType::Vin);
-    }
-    if !government.find_korea_rrns_in_text(text).is_empty() {
-        pii_types.push(PiiType::KoreaRrn);
-    }
-    if !government.find_australia_tfns_in_text(text).is_empty() {
-        pii_types.push(PiiType::AustraliaTfn);
-    }
-    if !government.find_australia_abns_in_text(text).is_empty() {
-        pii_types.push(PiiType::AustraliaAbn);
-    }
-    if !government.find_india_aadhaars_in_text(text).is_empty() {
-        pii_types.push(PiiType::IndiaAadhaar);
-    }
-    if !government.find_india_pans_in_text(text).is_empty() {
-        pii_types.push(PiiType::IndiaPan);
-    }
-    if !government.find_india_gstins_in_text(text).is_empty() {
-        pii_types.push(PiiType::IndiaGstin);
-    }
-    if !government
-        .find_india_vehicle_registrations_in_text(text)
-        .is_empty()
-    {
-        pii_types.push(PiiType::IndiaVehicleReg);
-    }
-    if !government.find_india_voter_ids_in_text(text).is_empty() {
-        pii_types.push(PiiType::IndiaVoterId);
-    }
-    if !government.find_india_passports_in_text(text).is_empty() {
-        pii_types.push(PiiType::IndiaPassport);
-    }
-    if !government.find_brazil_cpfs_in_text(text).is_empty() {
-        pii_types.push(PiiType::BrazilCpf);
-    }
-    if !government.find_brazil_cnpjs_in_text(text).is_empty() {
-        pii_types.push(PiiType::BrazilCnpj);
-    }
-    if !government.find_mexico_curps_in_text(text).is_empty() {
-        pii_types.push(PiiType::MexicoCurp);
-    }
-    if !government.find_nigeria_nins_in_text(text).is_empty() {
-        pii_types.push(PiiType::NigeriaNin);
-    }
-    if !government.find_thailand_tnins_in_text(text).is_empty() {
-        pii_types.push(PiiType::ThailandTnin);
-    }
-    if !government.find_singapore_nrics_in_text(text).is_empty() {
-        pii_types.push(PiiType::SingaporeNric);
-    }
-    if !government.find_finland_hetus_in_text(text).is_empty() {
-        pii_types.push(PiiType::FinlandHetu);
-    }
-    if !government.find_poland_pesels_in_text(text).is_empty() {
-        pii_types.push(PiiType::PolandPesel);
-    }
-    if !government.find_italy_fiscal_codes_in_text(text).is_empty() {
-        pii_types.push(PiiType::ItalyFiscalCode);
-    }
-    if !government.find_spain_nifs_in_text(text).is_empty() {
-        pii_types.push(PiiType::SpainNif);
-    }
-    if !government.find_spain_nies_in_text(text).is_empty() {
-        pii_types.push(PiiType::SpainNie);
-    }
-    if !government.find_uk_nis_in_text(text).is_empty() {
-        pii_types.push(PiiType::UkNi);
+    let government = GovernmentIdentifierBuilder::new();
+    for &(finder, pii_type) in SCANNERS {
+        if !finder(&government, text).is_empty() {
+            pii_types.push(pii_type);
+        }
     }
 }
 

--- a/crates/octarine/src/observe/pii/types/tests.rs
+++ b/crates/octarine/src/observe/pii/types/tests.rs
@@ -1,6 +1,11 @@
 //! Unit tests for `PiiType` classification and `From<IdentifierType>` mapping.
 
 #![allow(clippy::panic, clippy::expect_used)]
+// `from_identifier_type_direct_mappings` is a long table of `assert_eq!`
+// calls exercising every IdentifierType -> PiiType mapping; each assert
+// counts toward cognitive complexity. Splitting into per-domain sub-tests
+// would obscure that the mapping is exhaustive without improving safety.
+#![allow(clippy::cognitive_complexity)]
 
 use super::*;
 use crate::primitives::identifiers::IdentifierType;

--- a/crates/octarine/src/primitives/data/network/url.rs
+++ b/crates/octarine/src/primitives/data/network/url.rs
@@ -113,132 +113,167 @@ pub fn normalize_url_path_with_options<'a>(
         return Cow::Borrowed("");
     }
 
+    let (mut result, mut modified) = if options.remove_dot_segments {
+        process_with_dot_segments(path, options)
+    } else {
+        process_simple(path, options)
+    };
+
+    apply_post_normalization(&mut result, &mut modified, options);
+    finalize(result, modified, path)
+}
+
+/// Process path with dot-segment removal: split into segments, drop `.` /
+/// pop on `..`, then rebuild with the original leading/trailing slash
+/// semantics and any requested case folding.
+fn process_with_dot_segments(path: &str, options: &NormalizeUrlPathOptions) -> (String, bool) {
     let mut result = String::new();
     let mut modified = false;
 
-    // Process the path
-    let mut prev_was_slash = false;
-    let mut segments: Vec<&str> = Vec::new();
-    let mut current_segment_start = 0;
-
-    // Split into segments for dot segment processing
-    if options.remove_dot_segments {
-        let mut had_consecutive_slashes = false;
-        for (i, c) in path.char_indices() {
-            if c == '/' {
-                // Detect consecutive slashes (empty segment would be skipped)
-                if i == current_segment_start && i > 0 {
-                    had_consecutive_slashes = true;
-                }
-                if i > current_segment_start {
-                    segments.push(&path[current_segment_start..i]);
-                }
-                current_segment_start = i + 1;
-            }
-        }
-        if current_segment_start < path.len() {
-            segments.push(&path[current_segment_start..]);
-        }
-        if had_consecutive_slashes && options.collapse_slashes {
-            modified = true;
-        }
-
-        // Process dot segments
-        let mut output_segments: Vec<&str> = Vec::new();
-        for segment in &segments {
-            match *segment {
-                "." => {
-                    modified = true;
-                    // Skip current directory references
-                }
-                ".." => {
-                    modified = true;
-                    // Go up one directory
-                    output_segments.pop();
-                }
-                _ => {
-                    output_segments.push(segment);
-                }
-            }
-        }
-
-        // Rebuild path from segments
-        let starts_with_slash = path.starts_with('/');
-        let ends_with_slash = path.ends_with('/') && path.len() > 1;
-
-        if starts_with_slash {
-            result.push('/');
-        }
-
-        for (i, segment) in output_segments.iter().enumerate() {
-            if i > 0 {
-                result.push('/');
-            }
-            if options.lowercase {
-                result.push_str(&segment.to_lowercase());
-                if segment.chars().any(|c| c.is_uppercase()) {
-                    modified = true;
-                }
-            } else {
-                result.push_str(segment);
-            }
-        }
-
-        // Handle trailing slash
-        if ends_with_slash && !options.remove_trailing_slash {
-            result.push('/');
-        } else if ends_with_slash {
-            modified = true;
-        }
-    } else {
-        // Simple processing without dot segment removal
-        for c in path.chars() {
-            if c == '/' {
-                if prev_was_slash && options.collapse_slashes {
-                    modified = true;
-                    continue;
-                }
-                prev_was_slash = true;
-            } else {
-                prev_was_slash = false;
-            }
-
-            if options.lowercase && c.is_uppercase() {
-                result.push(c.to_lowercase().next().unwrap_or(c));
-                modified = true;
-            } else {
-                result.push(c);
-            }
-        }
-    }
-
-    // Collapse slashes if we haven't already processed this
-    if options.collapse_slashes && !options.remove_dot_segments {
-        let collapsed = collapse_slashes(&result);
-        if collapsed.len() != result.len() {
-            result = collapsed;
-            modified = true;
-        }
-    } else if options.collapse_slashes && options.remove_dot_segments {
-        // Already built result, check for collapsed slashes
-        let collapsed = collapse_slashes(&result);
-        if collapsed != result {
-            result = collapsed;
-            modified = true;
-        }
-    }
-
-    // Remove trailing slash (but keep root path as "/")
-    if options.remove_trailing_slash && result.len() > 1 && result.ends_with('/') {
-        result.pop();
+    let (segments, had_consecutive_slashes) = split_segments(path);
+    if had_consecutive_slashes && options.collapse_slashes {
         modified = true;
     }
 
-    // Ensure we have at least "/" for empty result from root path
+    // Process dot segments
+    let mut output_segments: Vec<&str> = Vec::new();
+    for segment in &segments {
+        match *segment {
+            "." => {
+                modified = true;
+                // Skip current directory references
+            }
+            ".." => {
+                modified = true;
+                // Go up one directory
+                output_segments.pop();
+            }
+            _ => {
+                output_segments.push(segment);
+            }
+        }
+    }
+
+    // Rebuild path from segments
+    let starts_with_slash = path.starts_with('/');
+    let ends_with_slash = path.ends_with('/') && path.len() > 1;
+
+    if starts_with_slash {
+        result.push('/');
+    }
+
+    for (i, segment) in output_segments.iter().enumerate() {
+        if i > 0 {
+            result.push('/');
+        }
+        if options.lowercase {
+            result.push_str(&segment.to_lowercase());
+            if segment.chars().any(|c| c.is_uppercase()) {
+                modified = true;
+            }
+        } else {
+            result.push_str(segment);
+        }
+    }
+
+    // Handle trailing slash
+    if ends_with_slash && !options.remove_trailing_slash {
+        result.push('/');
+    } else if ends_with_slash {
+        modified = true;
+    }
+
+    (result, modified)
+}
+
+/// Split a path into slash-delimited segments. Returns the segments and a
+/// flag indicating whether consecutive slashes were observed (which the
+/// caller may need to record as `modified` when collapsing).
+fn split_segments(path: &str) -> (Vec<&str>, bool) {
+    let mut segments: Vec<&str> = Vec::new();
+    let mut current_segment_start = 0;
+    let mut had_consecutive_slashes = false;
+    for (i, c) in path.char_indices() {
+        if c == '/' {
+            if i == current_segment_start && i > 0 {
+                had_consecutive_slashes = true;
+            }
+            if i > current_segment_start {
+                segments.push(&path[current_segment_start..i]);
+            }
+            current_segment_start = i + 1;
+        }
+    }
+    if current_segment_start < path.len() {
+        segments.push(&path[current_segment_start..]);
+    }
+    (segments, had_consecutive_slashes)
+}
+
+/// Simple character-by-character pass for when dot-segment removal is
+/// disabled. Handles slash collapse and case folding inline.
+fn process_simple(path: &str, options: &NormalizeUrlPathOptions) -> (String, bool) {
+    let mut result = String::new();
+    let mut modified = false;
+    let mut prev_was_slash = false;
+
+    for c in path.chars() {
+        if c == '/' {
+            if prev_was_slash && options.collapse_slashes {
+                modified = true;
+                continue;
+            }
+            prev_was_slash = true;
+        } else {
+            prev_was_slash = false;
+        }
+
+        if options.lowercase && c.is_uppercase() {
+            result.push(c.to_lowercase().next().unwrap_or(c));
+            modified = true;
+        } else {
+            result.push(c);
+        }
+    }
+    (result, modified)
+}
+
+/// Apply post-processing slash normalization: collapse runs of `/` (if not
+/// already done during dot-segment processing) and strip a trailing slash
+/// from non-root paths when requested.
+fn apply_post_normalization(
+    result: &mut String,
+    modified: &mut bool,
+    options: &NormalizeUrlPathOptions,
+) {
+    if options.collapse_slashes {
+        let collapsed = collapse_slashes(result);
+        // First branch is the dot-segments-disabled path (length-based shortcut);
+        // second is the dot-segments-enabled path where we've already rebuilt.
+        let changed = if options.remove_dot_segments {
+            collapsed != *result
+        } else {
+            collapsed.len() != result.len()
+        };
+        if changed {
+            *result = collapsed;
+            *modified = true;
+        }
+    }
+
+    if options.remove_trailing_slash && result.len() > 1 && result.ends_with('/') {
+        result.pop();
+        *modified = true;
+    }
+}
+
+/// Convert the working buffer into the right `Cow` variant: borrow when the
+/// path was untouched, or own when changes were applied. Restores `/` for
+/// the special case of an empty result from an absolute root path.
+fn finalize<'a>(result: String, modified: bool, path: &'a str) -> Cow<'a, str> {
     if result.is_empty() && path.starts_with('/') {
         return Cow::Borrowed("/");
     }
-
     if modified {
         Cow::Owned(result)
     } else {

--- a/crates/octarine/src/primitives/data/paths/mod.rs
+++ b/crates/octarine/src/primitives/data/paths/mod.rs
@@ -218,6 +218,12 @@ pub(crate) use filename::FilenameBuilder;
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
+    // `test_security_builder` and `test_filename_builder` are wide
+    // integration tests that drive an entire builder API in a single
+    // function. Each `assert!`/`assert_eq!` counts toward cognitive
+    // complexity; splitting would scatter the integration story without
+    // improving safety.
+    #![allow(clippy::cognitive_complexity)]
     use super::*;
     use crate::primitives::security::paths::SecurityBuilder;
 

--- a/crates/octarine/src/primitives/identifiers/network/validation/hostname/tld.rs
+++ b/crates/octarine/src/primitives/identifiers/network/validation/hostname/tld.rs
@@ -491,6 +491,10 @@ pub fn validate_domain_tld(domain: &str) -> Result<(), Problem> {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
+    // `test_is_common_tld` is a long table of `assert!` calls exercising
+    // every entry in the common-TLD list. Each assert counts toward cognitive
+    // complexity; splitting per category would scatter the table.
+    #![allow(clippy::cognitive_complexity)]
     use super::*;
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -236,418 +236,305 @@ impl StreamingScanner {
     /// Number of matches found
     pub fn scan_types(&self, text: &str, types: &[IdentifierType]) -> usize {
         let mut total: usize = 0;
-
         for id_type in types {
-            match id_type {
-                // Personal identifiers
-                IdentifierType::Email => {
-                    let personal = PersonalIdentifierBuilder::new();
-                    for m in personal.detect_emails_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::PhoneNumber => {
-                    let personal = PersonalIdentifierBuilder::new();
-                    for m in personal.detect_phones_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::PersonalName => {
-                    let personal = PersonalIdentifierBuilder::new();
-                    for m in personal.detect_names_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::Birthdate => {
-                    let personal = PersonalIdentifierBuilder::new();
-                    for m in personal.detect_birthdates_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::Username => {
-                    // Not yet implemented in personal module
-                    continue;
-                }
+            total = total.saturating_add(self.scan_one_type(text, id_type));
+        }
+        total
+    }
 
-                // Network identifiers
-                IdentifierType::IpAddress => {
-                    let network = NetworkIdentifierBuilder::new();
-                    for m in network.find_ip_addresses_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::Url => {
-                    let network = NetworkIdentifierBuilder::new();
-                    for m in network.find_urls_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::Uuid => {
-                    let network = NetworkIdentifierBuilder::new();
-                    for m in network.find_uuids_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::MacAddress => {
-                    let network = NetworkIdentifierBuilder::new();
-                    for m in network.find_mac_addresses_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::Domain
-                | IdentifierType::Hostname
-                | IdentifierType::Port
-                | IdentifierType::Jwt
-                | IdentifierType::ApiKey
-                | IdentifierType::SessionId
-                | IdentifierType::OAuthToken
-                | IdentifierType::SshKey
-                | IdentifierType::OnePasswordToken
-                | IdentifierType::OnePasswordVaultRef
-                | IdentifierType::BearerToken
-                | IdentifierType::UrlWithCredentials => {
-                    // These are detected by network/token modules via
-                    // find_all_in_text / is_X predicates, but the streaming
-                    // scanner has no dedicated find_X_in_text methods for
-                    // them. Skip for now in selective scan.
-                    continue;
-                }
+    /// Dispatch a single requested identifier type to the matching per-domain
+    /// scanner. Returns the number of matches pushed to the buffer.
+    fn scan_one_type(&self, text: &str, id_type: &IdentifierType) -> usize {
+        // Each helper returns Some(count) for variants it owns, None otherwise.
+        // The fall-through covers variants that have no dedicated scanner
+        // (Unknown, unimplemented Username, etc.) and is therefore a no-op.
+        self.scan_personal_type(text, id_type)
+            .or_else(|| self.scan_network_type(text, id_type))
+            .or_else(|| self.scan_financial_type(text, id_type))
+            .or_else(|| self.scan_government_type(text, id_type))
+            .or_else(|| self.scan_grouped_type(text, id_type))
+            .or_else(|| self.scan_special_type(text, id_type))
+            .unwrap_or(0)
+    }
 
-                // Financial identifiers
-                IdentifierType::CreditCard => {
-                    let financial = FinancialIdentifierBuilder::new();
-                    for m in financial.detect_credit_cards_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::BankAccount
-                | IdentifierType::RoutingNumber
-                | IdentifierType::PaymentToken
-                | IdentifierType::CryptoAddress
-                | IdentifierType::Iban => {
-                    // Financial module covers all via detect_all_in_text
-                    let financial = FinancialIdentifierBuilder::new();
-                    for m in financial.detect_all_in_text(text) {
-                        // Only push if it matches the requested type
-                        if m.identifier_type == *id_type {
-                            let _ = self.buffer.push(m);
-                            total = total.saturating_add(1);
-                        }
-                    }
-                }
+    /// Push every match from `matches` into the buffer and return the count.
+    fn push_all(&self, matches: Vec<IdentifierMatch>) -> usize {
+        let mut count: usize = 0;
+        for m in matches {
+            let _ = self.buffer.push(m);
+            count = count.saturating_add(1);
+        }
+        count
+    }
 
-                // Token/Key identifiers (not yet implemented in modules)
-                IdentifierType::GitHubToken
-                | IdentifierType::GitLabToken
-                | IdentifierType::AwsAccessKey
-                | IdentifierType::AwsSessionToken => {
-                    // Not yet implemented in primitives
-                    continue;
-                }
-
-                // Connection string detection
-                IdentifierType::ConnectionString => {
-                    let creds = CredentialIdentifierBuilder::new();
-                    if creds.is_connection_string_with_credentials(text) {
-                        total = total.saturating_add(1);
-                    }
-                }
-
-                // Government identifiers
-                IdentifierType::Ssn => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_ssns_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::DriverLicense => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_driver_licenses_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::Passport => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_passports_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::Ein => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_eins_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::TaxId => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_tax_ids_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::NationalId => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_national_ids_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::KoreaRrn => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_korea_rrns_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::AustraliaTfn => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_australia_tfns_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::AustraliaAbn => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_australia_abns_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::IndiaAadhaar => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_india_aadhaars_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::IndiaPan => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_india_pans_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::IndiaGstin => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_india_gstins_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::IndiaVehicleReg => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_india_vehicle_registrations_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::IndiaVoterId => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_india_voter_ids_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::IndiaPassport => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_india_passports_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::BrazilCpf => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_brazil_cpfs_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::BrazilCnpj => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_brazil_cnpjs_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::MexicoCurp => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_mexico_curps_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::NigeriaNin => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_nigeria_nins_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::ThailandTnin => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_thailand_tnins_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::FinlandHetu => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_finland_hetus_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::PolandPesel => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_poland_pesels_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::ItalyFiscalCode => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_italy_fiscal_codes_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::SingaporeNric => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_singapore_nrics_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::SpainNif => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_spain_nifs_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::SpainNie => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_spain_nies_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::UkNi => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_uk_nis_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-                IdentifierType::VehicleId => {
-                    let government = GovernmentIdentifierBuilder::new();
-                    for m in government.find_vehicle_ids_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-
-                // Organizational identifiers
-                IdentifierType::EmployeeId
-                | IdentifierType::StudentId
-                | IdentifierType::BadgeNumber => {
-                    // Organizational module covers all via find_all_in_text
-                    let organizational = OrganizationalIdentifierBuilder::new();
-                    for m in organizational.find_all_in_text(text) {
-                        if m.identifier_type == *id_type {
-                            let _ = self.buffer.push(m);
-                            total = total.saturating_add(1);
-                        }
-                    }
-                }
-
-                // Location identifiers
-                IdentifierType::GPSCoordinate
-                | IdentifierType::StreetAddress
-                | IdentifierType::PostalCode => {
-                    // Location module covers all via find_all_in_text
-                    let location = LocationIdentifierBuilder::new();
-                    for m in location.find_all_in_text(text) {
-                        if m.identifier_type == *id_type {
-                            let _ = self.buffer.push(m);
-                            total = total.saturating_add(1);
-                        }
-                    }
-                }
-
-                // Medical identifiers
-                IdentifierType::MedicalRecordNumber
-                | IdentifierType::HealthInsurance
-                | IdentifierType::Prescription
-                | IdentifierType::ProviderID
-                | IdentifierType::MedicalCode
-                | IdentifierType::MedicalLicense => {
-                    // Medical module covers all via find_all_in_text
-                    let medical = MedicalIdentifierBuilder::new();
-                    for m in medical.find_all_in_text(text) {
-                        if m.identifier_type == *id_type {
-                            let _ = self.buffer.push(m);
-                            total = total.saturating_add(1);
-                        }
-                    }
-                }
-
-                // Biometric identifiers
-                IdentifierType::Fingerprint
-                | IdentifierType::FacialRecognition
-                | IdentifierType::IrisScan
-                | IdentifierType::VoicePrint
-                | IdentifierType::DNASequence
-                | IdentifierType::BiometricTemplate => {
-                    // Biometric module covers all via detect_all_in_text
-                    let biometric = BiometricIdentifierBuilder::new();
-                    for m in biometric.detect_all_in_text(text) {
-                        if m.identifier_type == *id_type {
-                            let _ = self.buffer.push(m);
-                            total = total.saturating_add(1);
-                        }
-                    }
-                }
-
-                // Credential identifiers (context-based detection)
-                IdentifierType::Password
-                | IdentifierType::Pin
-                | IdentifierType::SecurityAnswer
-                | IdentifierType::Passphrase => {
-                    // Credentials require context-based detection which works differently
-                    // from pattern-based detection. They are detected via labels like
-                    // "password:", "pin=", etc. Use CredentialIdentifierBuilder directly.
-                    continue;
-                }
-
-                IdentifierType::HighEntropyString => {
-                    for m in entropy::detect_high_entropy_strings_in_text(text) {
-                        let _ = self.buffer.push(m);
-                        total = total.saturating_add(1);
-                    }
-                }
-
-                IdentifierType::Unknown => {
-                    // Don't scan for unknown types
-                    continue;
-                }
+    /// Push every match whose type equals `wanted` and return the count.
+    fn push_matching(&self, matches: Vec<IdentifierMatch>, wanted: &IdentifierType) -> usize {
+        let mut count: usize = 0;
+        for m in matches {
+            if m.identifier_type == *wanted {
+                let _ = self.buffer.push(m);
+                count = count.saturating_add(1);
             }
         }
+        count
+    }
 
-        total
+    fn scan_personal_type(&self, text: &str, id_type: &IdentifierType) -> Option<usize> {
+        let personal = PersonalIdentifierBuilder::new();
+        let matches = match id_type {
+            IdentifierType::Email => personal.detect_emails_in_text(text),
+            IdentifierType::PhoneNumber => personal.detect_phones_in_text(text),
+            IdentifierType::PersonalName => personal.detect_names_in_text(text),
+            IdentifierType::Birthdate => personal.detect_birthdates_in_text(text),
+            // Username is not yet implemented in the personal module.
+            IdentifierType::Username => return Some(0),
+            _ => return None,
+        };
+        Some(self.push_all(matches))
+    }
+
+    fn scan_network_type(&self, text: &str, id_type: &IdentifierType) -> Option<usize> {
+        let network = NetworkIdentifierBuilder::new();
+        let matches = match id_type {
+            IdentifierType::IpAddress => network.find_ip_addresses_in_text(text),
+            IdentifierType::Url => network.find_urls_in_text(text),
+            IdentifierType::Uuid => network.find_uuids_in_text(text),
+            IdentifierType::MacAddress => network.find_mac_addresses_in_text(text),
+            // Detected by network/token modules via find_all_in_text /
+            // is_X predicates, but the streaming scanner has no dedicated
+            // find_X_in_text methods for them. Skip for now in selective scan.
+            IdentifierType::Domain
+            | IdentifierType::Hostname
+            | IdentifierType::Port
+            | IdentifierType::Jwt
+            | IdentifierType::ApiKey
+            | IdentifierType::SessionId
+            | IdentifierType::OAuthToken
+            | IdentifierType::SshKey
+            | IdentifierType::OnePasswordToken
+            | IdentifierType::OnePasswordVaultRef
+            | IdentifierType::BearerToken
+            | IdentifierType::UrlWithCredentials => return Some(0),
+            _ => return None,
+        };
+        Some(self.push_all(matches))
+    }
+
+    fn scan_financial_type(&self, text: &str, id_type: &IdentifierType) -> Option<usize> {
+        let financial = FinancialIdentifierBuilder::new();
+        match id_type {
+            IdentifierType::CreditCard => {
+                Some(self.push_all(financial.detect_credit_cards_in_text(text)))
+            }
+            IdentifierType::BankAccount
+            | IdentifierType::RoutingNumber
+            | IdentifierType::PaymentToken
+            | IdentifierType::CryptoAddress
+            | IdentifierType::Iban => {
+                // Financial module covers all via detect_all_in_text; filter to
+                // the requested type only.
+                Some(self.push_matching(financial.detect_all_in_text(text), id_type))
+            }
+            _ => None,
+        }
+    }
+
+    fn scan_government_type(&self, text: &str, id_type: &IdentifierType) -> Option<usize> {
+        type Finder = fn(&GovernmentIdentifierBuilder, &str) -> Vec<IdentifierMatch>;
+        type MatchesVariant = fn(&IdentifierType) -> bool;
+        // Lookup of IdentifierType variant -> per-variant finder method. Lets
+        // the helper stay flat regardless of how many country IDs we add.
+        const FINDERS: &[(MatchesVariant, Finder)] = &[
+            (
+                |t| matches!(t, IdentifierType::Ssn),
+                GovernmentIdentifierBuilder::find_ssns_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::DriverLicense),
+                GovernmentIdentifierBuilder::find_driver_licenses_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::Passport),
+                GovernmentIdentifierBuilder::find_passports_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::Ein),
+                GovernmentIdentifierBuilder::find_eins_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::TaxId),
+                GovernmentIdentifierBuilder::find_tax_ids_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::NationalId),
+                GovernmentIdentifierBuilder::find_national_ids_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::KoreaRrn),
+                GovernmentIdentifierBuilder::find_korea_rrns_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::AustraliaTfn),
+                GovernmentIdentifierBuilder::find_australia_tfns_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::AustraliaAbn),
+                GovernmentIdentifierBuilder::find_australia_abns_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::IndiaAadhaar),
+                GovernmentIdentifierBuilder::find_india_aadhaars_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::IndiaPan),
+                GovernmentIdentifierBuilder::find_india_pans_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::IndiaGstin),
+                GovernmentIdentifierBuilder::find_india_gstins_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::IndiaVehicleReg),
+                GovernmentIdentifierBuilder::find_india_vehicle_registrations_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::IndiaVoterId),
+                GovernmentIdentifierBuilder::find_india_voter_ids_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::IndiaPassport),
+                GovernmentIdentifierBuilder::find_india_passports_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::BrazilCpf),
+                GovernmentIdentifierBuilder::find_brazil_cpfs_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::BrazilCnpj),
+                GovernmentIdentifierBuilder::find_brazil_cnpjs_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::MexicoCurp),
+                GovernmentIdentifierBuilder::find_mexico_curps_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::NigeriaNin),
+                GovernmentIdentifierBuilder::find_nigeria_nins_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::ThailandTnin),
+                GovernmentIdentifierBuilder::find_thailand_tnins_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::FinlandHetu),
+                GovernmentIdentifierBuilder::find_finland_hetus_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::PolandPesel),
+                GovernmentIdentifierBuilder::find_poland_pesels_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::ItalyFiscalCode),
+                GovernmentIdentifierBuilder::find_italy_fiscal_codes_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::SingaporeNric),
+                GovernmentIdentifierBuilder::find_singapore_nrics_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::SpainNif),
+                GovernmentIdentifierBuilder::find_spain_nifs_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::SpainNie),
+                GovernmentIdentifierBuilder::find_spain_nies_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::UkNi),
+                GovernmentIdentifierBuilder::find_uk_nis_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::VehicleId),
+                GovernmentIdentifierBuilder::find_vehicle_ids_in_text,
+            ),
+        ];
+
+        let finder = FINDERS
+            .iter()
+            .find(|(matches_variant, _)| matches_variant(id_type))?
+            .1;
+        let government = GovernmentIdentifierBuilder::new();
+        Some(self.push_all(finder(&government, text)))
+    }
+
+    /// Handle domains whose builders expose a single `find_all_in_text` /
+    /// `detect_all_in_text` entry point, plus the credential domain which
+    /// requires context-based detection elsewhere.
+    fn scan_grouped_type(&self, text: &str, id_type: &IdentifierType) -> Option<usize> {
+        match id_type {
+            IdentifierType::EmployeeId
+            | IdentifierType::StudentId
+            | IdentifierType::BadgeNumber => {
+                let organizational = OrganizationalIdentifierBuilder::new();
+                Some(self.push_matching(organizational.find_all_in_text(text), id_type))
+            }
+            IdentifierType::GPSCoordinate
+            | IdentifierType::StreetAddress
+            | IdentifierType::PostalCode => {
+                let location = LocationIdentifierBuilder::new();
+                Some(self.push_matching(location.find_all_in_text(text), id_type))
+            }
+            IdentifierType::MedicalRecordNumber
+            | IdentifierType::HealthInsurance
+            | IdentifierType::Prescription
+            | IdentifierType::ProviderID
+            | IdentifierType::MedicalCode
+            | IdentifierType::MedicalLicense => {
+                let medical = MedicalIdentifierBuilder::new();
+                Some(self.push_matching(medical.find_all_in_text(text), id_type))
+            }
+            IdentifierType::Fingerprint
+            | IdentifierType::FacialRecognition
+            | IdentifierType::IrisScan
+            | IdentifierType::VoicePrint
+            | IdentifierType::DNASequence
+            | IdentifierType::BiometricTemplate => {
+                let biometric = BiometricIdentifierBuilder::new();
+                Some(self.push_matching(biometric.detect_all_in_text(text), id_type))
+            }
+            // Credentials require context-based detection ("password:",
+            // "pin="). Use CredentialIdentifierBuilder directly instead of
+            // pattern-based scanning.
+            IdentifierType::Password
+            | IdentifierType::Pin
+            | IdentifierType::SecurityAnswer
+            | IdentifierType::Passphrase => Some(0),
+            _ => None,
+        }
+    }
+
+    /// Handle one-off variants that don't fit any domain grouping:
+    /// connection strings (credentials), high-entropy strings, and explicit
+    /// no-op variants (Unknown, unimplemented provider tokens).
+    fn scan_special_type(&self, text: &str, id_type: &IdentifierType) -> Option<usize> {
+        match id_type {
+            IdentifierType::ConnectionString => {
+                let creds = CredentialIdentifierBuilder::new();
+                Some(usize::from(
+                    creds.is_connection_string_with_credentials(text),
+                ))
+            }
+            IdentifierType::HighEntropyString => {
+                Some(self.push_all(entropy::detect_high_entropy_strings_in_text(text)))
+            }
+            // Not yet implemented in primitives.
+            IdentifierType::GitHubToken
+            | IdentifierType::GitLabToken
+            | IdentifierType::AwsAccessKey
+            | IdentifierType::AwsSessionToken
+            | IdentifierType::Unknown => Some(0),
+            _ => None,
+        }
     }
 
     /// Drain all matches from the buffer

--- a/crates/octarine/src/primitives/identifiers/token/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/token/detection/mod.rs
@@ -332,6 +332,11 @@ pub fn detect_token_identifier(value: &str) -> Option<IdentifierType> {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
+    // `test_detect_token_type` is a long table of `assert_eq!` calls covering
+    // 40+ provider token formats; each assert counts toward cognitive
+    // complexity. Splitting per provider would scatter the table without
+    // improving safety.
+    #![allow(clippy::cognitive_complexity)]
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Summary

- Refactor 3 production functions below clippy's `cognitive_complexity=25` threshold (52, 29, 28 → all < 25).
- Allow `cognitive_complexity` on 5 table-driven test functions with justification comments — each `assert!`/`assert_eq!` increments the metric, and splitting would scatter the test intent without improving safety.
- Promote `cognitive_complexity = "deny"` across all 3 workspace crates so future regressions fail in CI (`just clippy` is already `-D warnings`).

## Production refactors

| File | Function | Before → After | Strategy |
|---|---|---|---|
| `observe/pii/scanner/domains.rs` | `scan_government` | 29 → ~5 | Const array of `(finder_fn, PiiType)` tuples + single loop |
| `primitives/identifiers/streaming.rs` | `StreamingScanner::scan_types` | 52 → < 25 | 6 per-domain helpers chained via `or_else()`; government uses per-variant finder lookup table |
| `primitives/data/network/url.rs` | `normalize_url_path_with_options` | 28 → < 25 | Split into `process_with_dot_segments`, `process_simple`, `split_segments`, `apply_post_normalization`, `finalize` |

## Test-module allows (with justification)

- `observe/pii/types/tests.rs` — `from_identifier_type_direct_mappings` is an exhaustive 170-line `From` mapping table
- `primitives/identifiers/token/detection/mod.rs` — `test_detect_token_type` covers 40+ provider formats
- `primitives/data/paths/mod.rs` — `test_security_builder`/`test_filename_builder` drive entire builder APIs in one function each
- `primitives/identifiers/network/validation/hostname/tld.rs` — `test_is_common_tld` exhausts the common-TLD list

## Lint promotion

Added `cognitive_complexity = "deny"` to `[lints.clippy]` in:
- `crates/octarine/Cargo.toml`
- `crates/octarine-derive/Cargo.toml`
- `crates/octarine-problem/Cargo.toml`

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -A clippy::all -W clippy::cognitive_complexity` → 0 warnings
- [x] `just clippy` (`-D warnings`) passes
- [x] `just preflight` (fmt + clippy + arch-check + test) passes — 6674+ tests, 0 failures
- [x] Targeted module tests pass: `observe::pii::scanner` (25), `primitives::identifiers::streaming` (9), `primitives::data::network::url` (13)

## Pre-review findings

- 1x `missing-test-file` (`crates/octarine/src/observe/pii/scanner/domains.rs`) — expected: scanner domain helpers are exercised indirectly via the scanner integration tests in `observe/pii/scanner/tests.rs` (25 passing, including coverage of `scan_government`).

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)