### PR TITLE
refactor(observe): migrate builders to crate::define_metrics! macro

### DIFF
--- a/crates/octarine/src/crypto/validation/builder.rs
+++ b/crates/octarine/src/crypto/validation/builder.rs
@@ -18,45 +18,18 @@
 use std::time::Instant;
 
 use crate::observe::ProblemExt;
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::observe::{Problem, event};
 use crate::primitives::identifiers::crypto::{KeyFormat, KeyType, SignatureAlgorithm};
 use crate::primitives::security::crypto::{CryptoAuditResult, CryptoPolicy, CryptoSecurityBuilder};
 
-// Pre-validated metric names for crypto validation
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    /// Time to validate a certificate (PEM or DER)
-    pub fn validate_cert_ms() -> MetricName {
-        MetricName::new("crypto.validation.certificate_ms").expect("valid metric name")
-    }
-
-    /// Time to validate an SSH key
-    pub fn validate_ssh_ms() -> MetricName {
-        MetricName::new("crypto.validation.ssh_key_ms").expect("valid metric name")
-    }
-
-    /// Time to perform a full audit
-    pub fn audit_ms() -> MetricName {
-        MetricName::new("crypto.validation.audit_ms").expect("valid metric name")
-    }
-
-    /// Count of successfully validated items
-    pub fn validated_count() -> MetricName {
-        MetricName::new("crypto.validation.validated").expect("valid metric name")
-    }
-
-    /// Count of blocking threats that caused validation failure
-    pub fn threats_blocked() -> MetricName {
-        MetricName::new("crypto.validation.threats_blocked").expect("valid metric name")
-    }
-
-    /// Count of warnings issued
-    pub fn warnings_count() -> MetricName {
-        MetricName::new("crypto.validation.warnings").expect("valid metric name")
-    }
+crate::define_metrics! {
+    validate_cert_ms => "crypto.validation.certificate_ms",
+    validate_ssh_ms => "crypto.validation.ssh_key_ms",
+    audit_ms => "crypto.validation.audit_ms",
+    validated_count => "crypto.validation.validated",
+    threats_blocked => "crypto.validation.threats_blocked",
+    warnings_count => "crypto.validation.warnings",
 }
 
 #[cfg(feature = "crypto-validation")]

--- a/crates/octarine/src/data/network/builder.rs
+++ b/crates/octarine/src/data/network/builder.rs
@@ -8,7 +8,7 @@
 use std::borrow::Cow;
 use std::time::Instant;
 
-use crate::observe::metrics::{MetricName, increment, record};
+use crate::observe::metrics::{increment, record};
 use crate::primitives::data::network::{
     NormalizeUrlPathOptions as PrimitiveOptions, PathPattern as PrimitivePathPattern,
     normalize_path_segments as prim_normalize_segments,
@@ -18,26 +18,11 @@ use crate::primitives::data::network::{
 
 use super::types::{NormalizeUrlPathOptions, PathPattern};
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn normalize_ms() -> MetricName {
-        MetricName::new("data.network.normalize_ms").expect("valid metric name")
-    }
-
-    pub fn normalize_count() -> MetricName {
-        MetricName::new("data.network.normalize_count").expect("valid metric name")
-    }
-
-    pub fn normalize_segments_ms() -> MetricName {
-        MetricName::new("data.network.normalize_segments_ms").expect("valid metric name")
-    }
-
-    pub fn normalize_segments_count() -> MetricName {
-        MetricName::new("data.network.normalize_segments_count").expect("valid metric name")
-    }
+crate::define_metrics! {
+    normalize_ms => "data.network.normalize_ms",
+    normalize_count => "data.network.normalize_count",
+    normalize_segments_ms => "data.network.normalize_segments_ms",
+    normalize_segments_count => "data.network.normalize_segments_count",
 }
 
 /// URL normalization builder with observability

--- a/crates/octarine/src/data/paths/builder/boundary.rs
+++ b/crates/octarine/src/data/paths/builder/boundary.rs
@@ -28,21 +28,12 @@ use std::time::Instant;
 
 use crate::observe;
 use crate::observe::Problem;
-use crate::observe::metrics::{MetricName, record};
+use crate::observe::metrics::record;
 use crate::primitives::data::paths::BoundaryBuilder as PrimitiveBoundaryBuilder;
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn validate_ms() -> MetricName {
-        MetricName::new("data.paths.boundary.validate_ms").expect("valid metric name")
-    }
-
-    pub fn constrain_ms() -> MetricName {
-        MetricName::new("data.paths.boundary.constrain_ms").expect("valid metric name")
-    }
+crate::define_metrics! {
+    validate_ms => "data.paths.boundary.validate_ms",
+    constrain_ms => "data.paths.boundary.constrain_ms",
 }
 
 /// Boundary operations builder with observability

--- a/crates/octarine/src/data/paths/builder/characteristic.rs
+++ b/crates/octarine/src/data/paths/builder/characteristic.rs
@@ -23,23 +23,14 @@
 //! assert!(chars.is_portable("relative/path"));
 //! ```
 
-use crate::observe::metrics::{MetricName, increment};
+use crate::observe::metrics::increment;
 use crate::primitives::data::paths::CharacteristicBuilder as PrimitiveCharacteristicBuilder;
 
 use crate::data::paths::types::{PathType, Platform};
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn path_type_detected() -> MetricName {
-        MetricName::new("data.paths.characteristic.path_type_detected").expect("valid metric name")
-    }
-
-    pub fn platform_detected() -> MetricName {
-        MetricName::new("data.paths.characteristic.platform_detected").expect("valid metric name")
-    }
+crate::define_metrics! {
+    path_type_detected => "data.paths.characteristic.path_type_detected",
+    platform_detected => "data.paths.characteristic.platform_detected",
 }
 
 /// Path characteristic operations builder with observability

--- a/crates/octarine/src/data/paths/builder/construction.rs
+++ b/crates/octarine/src/data/paths/builder/construction.rs
@@ -21,18 +21,12 @@
 //! ```
 
 use crate::observe::Problem;
-use crate::observe::metrics::{MetricName, increment};
+use crate::observe::metrics::increment;
 
 use super::super::construction;
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn paths_built() -> MetricName {
-        MetricName::new("data.paths.construction.paths_built").expect("valid metric name")
-    }
+crate::define_metrics! {
+    paths_built => "data.paths.construction.paths_built",
 }
 
 /// Path construction builder with observability

--- a/crates/octarine/src/data/paths/builder/context.rs
+++ b/crates/octarine/src/data/paths/builder/context.rs
@@ -21,18 +21,12 @@
 //! ```
 
 use crate::observe::Problem;
-use crate::observe::metrics::{MetricName, increment};
+use crate::observe::metrics::increment;
 
 use super::super::context;
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn context_sanitized() -> MetricName {
-        MetricName::new("data.paths.context.sanitized").expect("valid metric name")
-    }
+crate::define_metrics! {
+    context_sanitized => "data.paths.context.sanitized",
 }
 
 /// Context-specific sanitization builder with observability

--- a/crates/octarine/src/data/paths/builder/filename.rs
+++ b/crates/octarine/src/data/paths/builder/filename.rs
@@ -32,28 +32,16 @@ use std::time::Instant;
 
 use crate::observe;
 use crate::observe::Problem;
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::primitives::data::paths::FilenameBuilder as PrimitiveFilenameBuilder;
 
 // Re-export SanitizationContext from local types module
 pub use crate::data::paths::types::SanitizationContext;
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn threats_detected() -> MetricName {
-        MetricName::new("data.paths.filename.threats_detected").expect("valid metric name")
-    }
-
-    pub fn sanitize_ms() -> MetricName {
-        MetricName::new("data.paths.filename.sanitize_ms").expect("valid metric name")
-    }
-
-    pub fn validated() -> MetricName {
-        MetricName::new("data.paths.filename.validated").expect("valid metric name")
-    }
+crate::define_metrics! {
+    threats_detected => "data.paths.filename.threats_detected",
+    sanitize_ms => "data.paths.filename.sanitize_ms",
+    validated => "data.paths.filename.validated",
 }
 
 /// Filename operations builder with observability

--- a/crates/octarine/src/data/paths/builder/format.rs
+++ b/crates/octarine/src/data/paths/builder/format.rs
@@ -31,24 +31,15 @@
 
 use std::borrow::Cow;
 
-use crate::observe::metrics::{MetricName, increment};
+use crate::observe::metrics::increment;
 use crate::primitives::data::paths::FormatBuilder as PrimitiveFormatBuilder;
 
 // Re-export PathFormat and SeparatorStyle from local types module
 pub use crate::data::paths::types::{PathFormat, SeparatorStyle};
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn format_detected() -> MetricName {
-        MetricName::new("data.paths.format.format_detected").expect("valid metric name")
-    }
-
-    pub fn converted() -> MetricName {
-        MetricName::new("data.paths.format.converted").expect("valid metric name")
-    }
+crate::define_metrics! {
+    format_detected => "data.paths.format.format_detected",
+    converted => "data.paths.format.converted",
 }
 
 /// Path format operations builder with observability

--- a/crates/octarine/src/identifiers/builder/biometric.rs
+++ b/crates/octarine/src/identifiers/builder/biometric.rs
@@ -16,7 +16,7 @@
 use std::borrow::Cow;
 use std::time::Instant;
 
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::observe::{self, Problem};
 use crate::primitives::identifiers::BiometricIdentifierBuilder;
 
@@ -26,30 +26,12 @@ use super::super::types::{
     IrisIdRedactionStrategy, VoiceIdRedactionStrategy,
 };
 
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn detect_ms() -> MetricName {
-        MetricName::new("data.identifiers.biometric.detect_ms").expect("valid metric name")
-    }
-
-    pub fn validate_ms() -> MetricName {
-        MetricName::new("data.identifiers.biometric.validate_ms").expect("valid metric name")
-    }
-
-    pub fn redact_ms() -> MetricName {
-        MetricName::new("data.identifiers.biometric.redact_ms").expect("valid metric name")
-    }
-
-    pub fn detected() -> MetricName {
-        MetricName::new("data.identifiers.biometric.detected").expect("valid metric name")
-    }
-
-    pub fn biometric_data_found() -> MetricName {
-        MetricName::new("data.identifiers.biometric.biometric_data_found")
-            .expect("valid metric name")
-    }
+crate::define_metrics! {
+    detect_ms => "data.identifiers.biometric.detect_ms",
+    validate_ms => "data.identifiers.biometric.validate_ms",
+    redact_ms => "data.identifiers.biometric.redact_ms",
+    detected => "data.identifiers.biometric.detected",
+    biometric_data_found => "data.identifiers.biometric.biometric_data_found",
 }
 
 /// Biometric identifier builder with observability (BIPA compliance)

--- a/crates/octarine/src/identifiers/builder/financial.rs
+++ b/crates/octarine/src/identifiers/builder/financial.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 
 use crate::observe;
 use crate::observe::Problem;
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::primitives::identifiers::{
     BankAccountRedactionStrategy, CreditCardRedactionStrategy, FinancialIdentifierBuilder,
     RoutingNumberRedactionStrategy,
@@ -28,30 +28,12 @@ use super::super::types::{
     CreditCardType, DetectionResult, FinancialTextPolicy, IdentifierMatch, IdentifierType,
 };
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn detect_ms() -> MetricName {
-        MetricName::new("data.identifiers.financial.detect_ms").expect("valid metric name")
-    }
-
-    pub fn validate_ms() -> MetricName {
-        MetricName::new("data.identifiers.financial.validate_ms").expect("valid metric name")
-    }
-
-    pub fn redact_ms() -> MetricName {
-        MetricName::new("data.identifiers.financial.redact_ms").expect("valid metric name")
-    }
-
-    pub fn detected() -> MetricName {
-        MetricName::new("data.identifiers.financial.detected").expect("valid metric name")
-    }
-
-    pub fn pci_data_found() -> MetricName {
-        MetricName::new("data.identifiers.financial.pci_data_found").expect("valid metric name")
-    }
+crate::define_metrics! {
+    detect_ms => "data.identifiers.financial.detect_ms",
+    validate_ms => "data.identifiers.financial.validate_ms",
+    redact_ms => "data.identifiers.financial.redact_ms",
+    detected => "data.identifiers.financial.detected",
+    pci_data_found => "data.identifiers.financial.pci_data_found",
 }
 
 /// Financial identifier builder with observability

--- a/crates/octarine/src/identifiers/builder/government/mod.rs
+++ b/crates/octarine/src/identifiers/builder/government/mod.rs
@@ -24,7 +24,7 @@
 
 use std::time::Instant;
 
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::observe::{self, Problem};
 use crate::primitives::identifiers::{
     DriverLicenseRedactionStrategy, GovernmentIdentifierBuilder, NationalIdRedactionStrategy,
@@ -54,30 +54,13 @@ mod thailand;
 mod uk_ni;
 mod vehicle_id;
 
-#[allow(clippy::expect_used)]
-pub(super) mod metric_names {
-    use super::MetricName;
-
-    pub fn detect_ms() -> MetricName {
-        MetricName::new("data.identifiers.government.detect_ms").expect("valid metric name")
-    }
-
-    pub fn validate_ms() -> MetricName {
-        MetricName::new("data.identifiers.government.validate_ms").expect("valid metric name")
-    }
-
-    pub fn redact_ms() -> MetricName {
-        MetricName::new("data.identifiers.government.redact_ms").expect("valid metric name")
-    }
-
-    pub fn detected() -> MetricName {
-        MetricName::new("data.identifiers.government.detected").expect("valid metric name")
-    }
-
-    pub fn government_data_found() -> MetricName {
-        MetricName::new("data.identifiers.government.government_data_found")
-            .expect("valid metric name")
-    }
+crate::define_metrics! {
+    pub(super)
+    detect_ms => "data.identifiers.government.detect_ms",
+    validate_ms => "data.identifiers.government.validate_ms",
+    redact_ms => "data.identifiers.government.redact_ms",
+    detected => "data.identifiers.government.detected",
+    government_data_found => "data.identifiers.government.government_data_found",
 }
 
 /// Government identifier builder with observability

--- a/crates/octarine/src/identifiers/builder/mod.rs
+++ b/crates/octarine/src/identifiers/builder/mod.rs
@@ -107,32 +107,17 @@ pub use token::TokenBuilder;
 use std::time::Instant;
 
 use crate::observe;
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::primitives::identifiers::StreamingScanner;
 use crate::primitives::identifiers::confidence::ConfidenceBuilder as PrimitiveConfidenceBuilder;
 
 use super::types::{IdentifierMatch, IdentifierType};
 
-// Pre-validated metric names for IdentifierBuilder
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn detect_ms() -> MetricName {
-        MetricName::new("data.identifiers.detect_ms").expect("valid metric name")
-    }
-
-    pub fn scan_ms() -> MetricName {
-        MetricName::new("data.identifiers.scan_ms").expect("valid metric name")
-    }
-
-    pub fn detected() -> MetricName {
-        MetricName::new("data.identifiers.detected").expect("valid metric name")
-    }
-
-    pub fn pii_found() -> MetricName {
-        MetricName::new("data.identifiers.pii_found").expect("valid metric name")
-    }
+crate::define_metrics! {
+    detect_ms => "data.identifiers.detect_ms",
+    scan_ms => "data.identifiers.scan_ms",
+    detected => "data.identifiers.detected",
+    pii_found => "data.identifiers.pii_found",
 }
 
 /// Unified identifier operations builder with observability

--- a/crates/octarine/src/identifiers/builder/network.rs
+++ b/crates/octarine/src/identifiers/builder/network.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::observe::Problem;
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::primitives::identifiers::{
     IpRedactionStrategy, MacRedactionStrategy, NetworkApiKeyRedactionStrategy,
     NetworkIdentifierBuilder, NetworkTextPolicy, UrlRedactionStrategy, UuidRedactionStrategy,
@@ -18,18 +18,9 @@ use crate::primitives::identifiers::{
 
 use super::super::types::{ApiKeyProvider, IdentifierMatch, IdentifierType, UuidVersion};
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn detect_ms() -> MetricName {
-        MetricName::new("data.identifiers.network.detect_ms").expect("valid metric name")
-    }
-
-    pub fn detected() -> MetricName {
-        MetricName::new("data.identifiers.network.detected").expect("valid metric name")
-    }
+crate::define_metrics! {
+    detect_ms => "data.identifiers.network.detect_ms",
+    detected => "data.identifiers.network.detected",
 }
 
 /// Network identifier builder with observability

--- a/crates/octarine/src/identifiers/builder/personal.rs
+++ b/crates/octarine/src/identifiers/builder/personal.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 
 use crate::observe;
 use crate::observe::Problem;
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::primitives::identifiers::{
     BirthdateRedactionStrategy, EmailRedactionStrategy, NameRedactionStrategy,
     PersonalIdentifierBuilder as PrimitivePersonalBuilder, PersonalTextPolicy, PhoneFormatStyle,
@@ -18,30 +18,12 @@ use crate::primitives::identifiers::{
 
 use super::super::types::{IdentifierMatch, IdentifierType, PhoneRegion};
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn detect_ms() -> MetricName {
-        MetricName::new("data.identifiers.personal.detect_ms").expect("valid metric name")
-    }
-
-    pub fn validate_ms() -> MetricName {
-        MetricName::new("data.identifiers.personal.validate_ms").expect("valid metric name")
-    }
-
-    pub fn redact_ms() -> MetricName {
-        MetricName::new("data.identifiers.personal.redact_ms").expect("valid metric name")
-    }
-
-    pub fn detected() -> MetricName {
-        MetricName::new("data.identifiers.personal.detected").expect("valid metric name")
-    }
-
-    pub fn pii_found() -> MetricName {
-        MetricName::new("data.identifiers.personal.pii_found").expect("valid metric name")
-    }
+crate::define_metrics! {
+    detect_ms => "data.identifiers.personal.detect_ms",
+    validate_ms => "data.identifiers.personal.validate_ms",
+    redact_ms => "data.identifiers.personal.redact_ms",
+    detected => "data.identifiers.personal.detected",
+    pii_found => "data.identifiers.personal.pii_found",
 }
 
 /// Personal identifier builder with observability

--- a/crates/octarine/src/observe/metrics/mod.rs
+++ b/crates/octarine/src/observe/metrics/mod.rs
@@ -124,6 +124,22 @@ pub use export::{DefaultLabels, PrometheusConfig, PrometheusExporter, StatsDConf
 /// record(metric_names::latency_ms(), 42.5);
 /// ```
 ///
+/// # Visibility
+///
+/// An optional visibility specifier before the first metric controls the
+/// generated `metric_names` module's visibility. This is needed when sibling
+/// submodules must access the metric names — for example, when a builder's
+/// methods are split across files.
+///
+/// ```rust
+/// use octarine::define_metrics;
+///
+/// define_metrics! {
+///     pub(crate)
+///     requests => "api.requests",
+/// }
+/// ```
+///
 /// # Generated Code
 ///
 /// The macro generates a `metric_names` module with:
@@ -132,9 +148,9 @@ pub use export::{DefaultLabels, PrometheusConfig, PrometheusExporter, StatsDConf
 /// - Clear panic messages identifying the invalid metric if it somehow fails
 #[macro_export]
 macro_rules! define_metrics {
-    ($($name:ident => $metric:literal),* $(,)?) => {
+    ($vis:vis $($name:ident => $metric:literal),* $(,)?) => {
         #[allow(clippy::expect_used)]
-        mod metric_names {
+        $vis mod metric_names {
             use $crate::observe::metrics::MetricName;
 
             $(

--- a/crates/octarine/src/security/commands/builder.rs
+++ b/crates/octarine/src/security/commands/builder.rs
@@ -32,27 +32,15 @@ use std::time::Instant;
 
 use crate::observe;
 use crate::observe::Problem;
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::primitives::security::commands::CommandSecurityBuilder as PrimitiveCommandSecurityBuilder;
 
 use super::types::{AllowList, CommandThreat};
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn threats_detected() -> MetricName {
-        MetricName::new("security.commands.threats_detected").expect("valid metric name")
-    }
-
-    pub fn validate_ms() -> MetricName {
-        MetricName::new("security.commands.validate_ms").expect("valid metric name")
-    }
-
-    pub fn escape_ms() -> MetricName {
-        MetricName::new("security.commands.escape_ms").expect("valid metric name")
-    }
+crate::define_metrics! {
+    threats_detected => "security.commands.threats_detected",
+    validate_ms => "security.commands.validate_ms",
+    escape_ms => "security.commands.escape_ms",
 }
 
 /// Command security operations builder with observability

--- a/crates/octarine/src/security/paths/builder.rs
+++ b/crates/octarine/src/security/paths/builder.rs
@@ -34,28 +34,16 @@ use std::time::Instant;
 
 use crate::observe;
 use crate::observe::Problem;
-use crate::observe::metrics::{MetricName, increment_by, record};
+use crate::observe::metrics::{increment_by, record};
 use crate::primitives::data::paths::PathSanitizationStrategy as PrimitiveSanitizationStrategy;
 use crate::primitives::security::paths::SecurityBuilder as PrimitiveSecurityBuilder;
 
 use super::types::{PathSanitizationStrategy, SecurityThreat};
 
-// Pre-validated metric names
-#[allow(clippy::expect_used)]
-mod metric_names {
-    use super::MetricName;
-
-    pub fn threats_detected() -> MetricName {
-        MetricName::new("security.paths.threats_detected").expect("valid metric name")
-    }
-
-    pub fn validate_ms() -> MetricName {
-        MetricName::new("security.paths.validate_ms").expect("valid metric name")
-    }
-
-    pub fn sanitize_ms() -> MetricName {
-        MetricName::new("security.paths.sanitize_ms").expect("valid metric name")
-    }
+crate::define_metrics! {
+    threats_detected => "security.paths.threats_detected",
+    validate_ms => "security.paths.validate_ms",
+    sanitize_ms => "security.paths.sanitize_ms",
 }
 
 /// Security operations builder with observability


### PR DESCRIPTION
## Summary

- Extends `crate::define_metrics!` to accept an optional `\$vis:vis` prefix (backwards-compatible — existing callers unaffected).
- Migrates 16 Layer 3 builder files from the hand-rolled `mod metric_names { ... }` pattern to the canonical macro call. Net **-196 LOC**.
- Drops per-file `#[allow(clippy::expect_used)]` annotations (the macro carries one) and the now-unused `MetricName` imports.

## Migrated files

`security/{commands,paths}/builder.rs`, `crypto/validation/builder.rs`, `data/network/builder.rs`, `data/paths/builder/{boundary,characteristic,filename,context,construction,format}.rs`, `identifiers/builder/{personal,biometric,financial,network,mod}.rs`, `identifiers/builder/government/mod.rs`.

The `government/mod.rs` case is why the macro needed visibility support — it uses `pub(super) mod metric_names` so its 19 per-country submodules can resolve `metric_names::detect_ms()` via `use super::*;`. The new form is `crate::define_metrics! { pub(super) name => "..." }`.

Metric strings and call sites are unchanged — the metric registry / dashboards stay stable.

## Audit correction

The audit comment in #190 claims `data.network.normalize_count` is dead and should be removed or wired up. It is **not** dead — it's incremented in `normalize()` (line 128), `normalize_strict()` (line 146), and `normalize_for_metrics()` (line 164) of `data/network/builder.rs`. Kept as-is. The "wire it up or remove" bullet from the audit is therefore not actionable.

## Test plan

- [x] \`just fmt-check\` — clean
- [x] \`just clippy\` — clean (no new warnings)
- [x] \`just arch-check\` — clean
- [x] \`just test-octarine\` — 6,674 unit tests pass, 0 failed
- [x] Macro doctests (existing + new `pub(crate)` visibility example) pass

Closes #190