### PR TITLE
chore(tooling): add .zed/settings.json with dprint/taplo LSP overrides

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,25 @@
+{
+  // LSP binary overrides for Zed extensions whose own binary fetch races
+  // their postinstall (toast: "failed to start language server <name>").
+  // The matching binaries ship in this devcontainer via the dev-tools
+  // feature; redirecting here skips the per-extension npm install /
+  // download entirely.
+  //
+  // Mirrored at:
+  //   containers/.zed/settings.json
+  //   containers/lib/features/lib/dev-tools/zed-lsp-config-first-startup.sh
+  "lsp": {
+    "dprint": {
+      "binary": {
+        "path": "/usr/local/bin/dprint",
+        "arguments": ["lsp"]
+      }
+    },
+    "taplo": {
+      "binary": {
+        "path": "/usr/local/bin/taplo",
+        "arguments": ["lsp", "stdio"]
+      }
+    }
+  }
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -38,6 +38,7 @@ pre-commit:
       glob: "*.json"
       exclude:
         - ".devcontainer/devcontainer.json"
+        - ".zed/settings.json"
       run: |
         fail=0
         for f in {staged_files}; do
@@ -99,6 +100,7 @@ pre-commit:
       glob: "*.json"
       exclude:
         - ".devcontainer/**"
+        - ".zed/**"
       run: biome check --write {staged_files}
       stage_fixed: true
 


### PR DESCRIPTION
## Summary
- Add `.zed/settings.json` at the octarine repo root mirroring `containers/.zed/settings.json` — points the Zed `dprint` and `taplo` extensions at `/usr/local/bin/` binaries shipped by the `dev-tools` container feature
- Exclude `.zed/` from the `check-json` and `biome-json` lefthook hooks (Zed `settings.json` is JSONC, same exemption pattern already used for `.devcontainer/`)

Eliminates the "failed to start language server dprint/taplo" toasts that fired on every Zed startup inside the devcontainer due to the per-extension binary fetch racing the postinstall step.

## Decision on `rust-analyzer`
**Not added.** The container's first-startup script (`containers/lib/features/lib/dev-tools/zed-lsp-config-first-startup.sh`) only overrides `dprint` and `taplo` — no rust mention. Zed's Rust extension starts cleanly with its bundled rust-analyzer; the startup race only affects extensions that npm-install their own LSP binary.

## Test plan
- [x] `git push` ran pre-push hooks (`cargo-clippy`, `cargo-test`) — both pass
- [x] `lefthook` pre-commit ran on the changed files — `check-json` now correctly skips `.zed/settings.json`
- [ ] Manual verification (out of session): reopen octarine in Zed inside the devcontainer; confirm no `failed to start language server dprint` or `failed to start language server taplo` toasts

Closes #350