### PR TITLE
chore(tooling): adopt dprint for YAML and JSON formatting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,7 @@
         // Linting & formatting
         "redhat.vscode-yaml",
         "biomejs.biome",
+        "dprint.dprint",
         // Database
         "mtxr.sqltools",
         "mtxr.sqltools-driver-pg",
@@ -61,21 +62,21 @@
           "editor.defaultFormatter": "rust-lang.rust-analyzer"
         },
 
-        // YAML settings (Red Hat YAML)
+        // YAML settings (dprint)
         "[yaml]": {
           "editor.formatOnSave": true,
-          "editor.defaultFormatter": "redhat.vscode-yaml"
+          "editor.defaultFormatter": "dprint.dprint"
         },
         "yaml.format.bracketSpacing": false,
 
-        // JSON settings (biome)
+        // JSON settings (dprint)
         "[json]": {
           "editor.formatOnSave": true,
-          "editor.defaultFormatter": "biomejs.biome"
+          "editor.defaultFormatter": "dprint.dprint"
         },
         "[jsonc]": {
           "editor.formatOnSave": true,
-          "editor.defaultFormatter": "biomejs.biome"
+          "editor.defaultFormatter": "dprint.dprint"
         },
 
         // General editor settings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
     if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v4
-      - uses: dprint/check@v2.3
-        with:
-          dprint-version: "0.54.0"
+      - uses: taiki-e/install-action@dprint
+      - uses: taiki-e/install-action@just
+      - run: just fmt-data-check
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,20 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE*'
+      - "**.md"
+      - "docs/**"
+      - "LICENSE*"
   pull_request:
     branches: [main]
     paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE*'
+      - "**.md"
+      - "docs/**"
+      - "LICENSE*"
   schedule:
     # Daily dependency-health sweep against main: surfaces new RustSec
     # advisories within 24h even when no PRs are open. Off-mark minute to
     # avoid the :00 stampede on the GitHub Actions runners.
-    - cron: '17 6 * * *'
+    - cron: "17 6 * * *"
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,6 +35,16 @@ jobs:
           toolchain: "1.94"
           components: rustfmt
       - run: cargo fmt --all -- --check
+
+  dprint:
+    name: Dprint
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dprint/check@v2.3
+        with:
+          dprint-version: "0.54.0"
 
   clippy:
     name: Clippy
@@ -137,7 +147,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
           cache: pip
       - run: pip install pytest
       - uses: taiki-e/install-action@just

--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -4,19 +4,19 @@ on:
   push:
     branches: [main]
     paths:
-      - '**.md'
-      - 'docs/**'
-      - '.github/workflows/doc-links.yml'
-      - '.lycheeignore'
-      - 'lychee.toml'
+      - "**.md"
+      - "docs/**"
+      - ".github/workflows/doc-links.yml"
+      - ".lycheeignore"
+      - "lychee.toml"
   pull_request:
     branches: [main]
     paths:
-      - '**.md'
-      - 'docs/**'
-      - '.github/workflows/doc-links.yml'
-      - '.lycheeignore'
-      - 'lychee.toml'
+      - "**.md"
+      - "docs/**"
+      - ".github/workflows/doc-links.yml"
+      - ".lycheeignore"
+      - "lychee.toml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,23 @@
+{
+  "yaml": {
+    "printWidth": 120
+  },
+  "json": {
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "excludes": [
+    "CHANGELOG.md",
+    "target/**",
+    "node_modules/**",
+    "tests/results/**",
+    ".git/**",
+    ".venv/**",
+    "/containers/",
+    "**/*.lock"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.21.3.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm"
+  ]
+}

--- a/justfile
+++ b/justfile
@@ -31,6 +31,14 @@ fmt-check:
 fmt:
     cargo fmt --all
 
+# Check YAML/JSON formatting via dprint (no fixes)
+fmt-data-check:
+    dprint check
+
+# Format YAML/JSON via dprint
+fmt-data:
+    dprint fmt
+
 # Run all formatters and file fixers via pre-commit on every file in the repo
 fmt-all: pre-commit
 
@@ -101,7 +109,7 @@ shellcheck:
 # ─── Pre-flight (run before push / PR) ──────────────────────────────────────
 
 # Full pre-push validation: fmt, clippy, shellcheck, arch-check, tests
-preflight: fmt-check clippy shellcheck arch-check test
+preflight: fmt-check fmt-data-check clippy shellcheck arch-check test
 
 # Everything including perf tests (run before releases)
 preflight-full: preflight test-perf

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,7 +13,6 @@ pre-commit:
   commands:
 
     # --- General file checks (native shell, no Python runtime) ---
-
     trailing-whitespace:
       run: containers/bin/fix-trailing-whitespace.sh {staged_files}
       stage_fixed: true
@@ -94,14 +93,11 @@ pre-commit:
       glob: "*.rs"
       run: cargo fmt --all --
 
-    # --- JSON linting (Biome) ---
+    # --- JSON/YAML formatting (dprint) ---
 
-    biome-json:
-      glob: "*.json"
-      exclude:
-        - ".devcontainer/**"
-        - ".zed/**"
-      run: biome check --write {staged_files}
+    dprint:
+      glob: "*.{json,yml,yaml}"
+      run: dprint fmt {staged_files}
       stage_fixed: true
 
     # --- Shell script linting ---


### PR DESCRIPTION
## Summary

Adopts dprint (yaml + json plugins) as the canonical formatter for YAML and JSON files in the repo, with matching `just` recipes, a lefthook pre-commit hook, and a CI check. Closes #246.

- `dprint.json` configures the json and pretty_yaml plugins with project-wide excludes (CHANGELOG, target, containers submodule, lockfiles).
- `just fmt-data` / `just fmt-data-check` wrap `dprint fmt` / `dprint check`. `just preflight` now includes `fmt-data-check`.
- `lefthook.yml` pre-commit fixes staged `*.{json,yml,yaml}` files via `dprint fmt {staged_files}` with `stage_fixed: true`.
- CI `Dprint` job uses `taiki-e/install-action@dprint` + `just fmt-data-check` — same recipe contributors run locally, so a green local preflight implies a green Dprint job.
- Separate commit for the one-time reformat pass to keep the enforcement commit reviewable.

## Test plan

- [x] `just fmt-data-check` passes on this branch
- [ ] CI Dprint job passes
- [ ] CI as a whole stays green

## Follow-ups

- #353 — align remaining CI jobs (`fmt`, `doc`, `check-windows`, `check-macos`, shellcheck) to `just` recipes for the same local/CI parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)