### PR TITLE
chore(tooling): adopt conform for conventional-commit enforcement

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,0 +1,95 @@
+# conform configuration — enforces conventional-commit format on every
+# commit (via lefthook commit-msg) and every PR branch + title (via the
+# Commit Lint CI job).
+#
+# Types listed below = 8 observed in octarine git history (build, chore,
+# deps, docs, feat, fix, refactor, test) + ci and perf from the
+# Conventional Commits spec for forward-compat.
+#
+# Run locally:  conform enforce --commit-msg-file <path>
+# Run on a PR:  conform enforce --base-branch origin/main
+policies:
+  - type: commit
+    spec:
+      header:
+        # The conventional-commit policy below also enforces a 72-char
+        # cap on the description (text after `type(scope): `) per spec.
+        # The 89-char header ceiling here is the *outer* budget — it
+        # allows long `type(scope):` prefixes without expanding the
+        # description budget.
+        length: 89
+        invalidLastCharacters: .
+      body:
+        required: false
+      dco: false
+      gpg:
+        required: false
+      conventional:
+        types:
+          - build
+          - chore
+          - ci
+          - deps
+          - docs
+          - feat
+          - fix
+          - perf
+          - refactor
+          - test
+        # Scope allowlist curated from `git log` of last ~300 commits
+        # plus octarine top-level modules. Permissive on purpose —
+        # easier to prune than to add after a rejection. Adding a new
+        # scope: open a PR; the bar is "we'll plausibly use this more
+        # than once".
+        #
+        # IMPORTANT — entries are Go regular expressions, NOT exact
+        # matches. See conform's check_conventional_commit.go: each
+        # scope is compiled with regexp.MustCompile and tested with
+        # re.MatchString — which is unanchored. Without `^...$`,
+        # `op` would match `feat(operation):` and `r` would match any
+        # scope containing the letter r. Anchor every entry.
+        scopes:
+          # --- octarine source modules (crates/octarine/src/*) ---
+          - ^auth$
+          - ^crypto$
+          - ^data$
+          - ^http$
+          - ^identifiers$
+          - ^io$
+          - ^observe$
+          - ^primitives$
+          - ^runtime$
+          - ^security$
+          - ^testing$
+          # --- cross-cutting subsystems / process ---
+          - ^ai$
+          - ^api$
+          - ^architecture$
+          - ^arch-check$
+          - ^ci$
+          - ^claude$
+          - ^claude-md$
+          - ^containers$
+          - ^credentials$
+          - ^deps$
+          - ^devcontainer$
+          - ^docs$
+          - ^examples$
+          - ^just$
+          - ^license$
+          - ^lints$
+          - ^memory$
+          - ^naming$
+          - ^pii$
+          - ^pii-scanner$
+          - ^pii-sync$
+          - ^platform$
+          - ^release$
+          - ^shell$
+          - ^test$
+          - ^tests$
+          - ^timing$
+          - ^tooling$
+          - ^types$
+          - ^visibility$
+          - ^xml$

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,42 @@ jobs:
       - uses: taiki-e/install-action@just
       - run: just spell
 
+  commit-lint:
+    name: Commit Lint
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # conform --base-branch needs full history to diff against
+          # origin/main. Default fetch-depth: 1 would fail.
+          fetch-depth: 0
+      - name: Install conform
+        # No taiki-e/install-action recipe yet; install the naked
+        # binary directly. Pinned to the version shipped by containers
+        # v4.19.0 so the dev-container hook and CI run identical
+        # binaries.
+        run: |
+          version=0.1.0-alpha.31
+          url="https://github.com/siderolabs/conform/releases/download/v${version}/conform-linux-amd64"
+          sudo curl -fsSL "$url" -o /usr/local/bin/conform
+          sudo chmod +x /usr/local/bin/conform
+          conform version
+      - name: Lint branch commits
+        run: conform enforce --base-branch origin/main
+      - name: Lint PR title
+        # Squash-merge uses the PR title as the merge subject, so it
+        # must also pass. Write to a tmp file and pass through
+        # --commit-msg-file (the only flag that accepts arbitrary text).
+        env:
+          # Read via env to avoid shell injection via malicious PR
+          # titles (actionlint-recommended pattern).
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          tmp=$(mktemp)
+          printf '%s\n' "$PR_TITLE" > "$tmp"
+          conform enforce --commit-msg-file "$tmp"
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,71 @@ overview and [docs/architecture/](docs/architecture/) for the three-layer
 design.
 
 This file is deliberately minimal — it covers dev setup and the SemVer policy.
-Branching, commit conventions, and the full PR workflow are documented in
-[CLAUDE.md](CLAUDE.md) and the project skills under `.claude/skills/`.
+Branching and the full PR workflow are documented in the project skills under
+`.claude/skills/git-workflow/`. Commit format is enforced automatically — see
+[Commit Format](#commit-format) below.
+
+## Commit Format
+
+octarine enforces [Conventional Commits](https://www.conventionalcommits.org/)
+via [conform](https://github.com/siderolabs/conform). The source of truth for
+allowed types, scopes, and length limits is [`.conform.yaml`](.conform.yaml) —
+read that file before adding a new scope.
+
+### Format
+
+```text
+<type>(<scope>): <subject>
+
+<optional body>
+
+<optional footers>
+```
+
+- **type** — one of: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`,
+  `build`, `ci`, `deps`, `perf`.
+- **scope** — a single entry from `.conform.yaml` (no comma-separated
+  lists). New scopes welcome: open a PR adding an anchored `^name$` entry.
+- **subject** — imperative mood, no trailing period. The Conventional
+  Commits spec caps the **description** (text after `<type>(<scope>): `) at
+  **72 characters**, enforced by conform. The full header has a generous
+  89-character ceiling so longer `type(scope):` prefixes still fit.
+
+### Examples
+
+```text
+feat(crypto): add Ed25519 keypair generation
+fix(observe): prevent panic on writer shutdown race
+docs(architecture): document layer-3 cascading visibility
+chore(deps): bump tokio to 1.42
+```
+
+### Local enforcement
+
+The `commit-msg` lefthook hook runs conform on every commit. Install hooks
+once per clone:
+
+```bash
+lefthook install
+```
+
+If you're working outside the dev container and don't have conform installed,
+the hook is a no-op locally — but CI's `Commit Lint` job will reject the PR.
+Install conform via:
+
+```bash
+go install github.com/siderolabs/conform/cmd/conform@latest
+```
+
+### CI enforcement
+
+The `Commit Lint` job in `.github/workflows/ci.yml` runs on every PR and
+validates:
+
+1. Every commit in the branch (against `origin/main`).
+2. The PR title (used as the squash-merge subject).
+
+Both must pass before the PR can merge.
 
 ## Development Setup
 

--- a/justfile
+++ b/justfile
@@ -116,6 +116,14 @@ shellcheck:
         shellcheck "${files[@]}"
     fi
 
+# Lint a commit message against the conform policy (default: HEAD's message)
+commit-lint FILE='.git/COMMIT_EDITMSG':
+    conform enforce --commit-msg-file {{FILE}}
+
+# Lint every commit on this branch against origin/main
+commit-lint-branch:
+    conform enforce --base-branch origin/main
+
 # ─── Pre-flight (run before push / PR) ──────────────────────────────────────
 
 # Full pre-push validation: fmt, clippy, shellcheck, spell, arch-check, tests

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -127,6 +127,19 @@ pre-commit:
         fi
 
 # ============================================================================
+# commit-msg stage: validates the message before the commit lands
+# ============================================================================
+commit-msg:
+  commands:
+    conform:
+      # conform is shipped by the containers dev-tools feature; skip
+      # gracefully if running outside a dev-tools container — CI is the
+      # safety net.
+      skip:
+        - run: "! command -v conform >/dev/null 2>&1"
+      run: conform enforce --commit-msg-file {1}
+
+# ============================================================================
 # Pre-push stage: runs on `git push`
 # ============================================================================
 pre-push:


### PR DESCRIPTION
## Summary

- Add `.conform.yaml` policy: 10 types (real-history 8 + `ci`/`perf`), ~40 anchored Go-regex scopes (`^name$` — unanchored leaks enforcement), 89-char header outer ceiling. The Conventional Commits parser also enforces the spec's 72-char description cap internally.
- Wire conform into `lefthook.yml` `commit-msg` stage with a skip-if-not-installed guard (CI is the safety net for hosts without conform).
- Add `Commit Lint` job to `.github/workflows/ci.yml` — installs the same pinned conform binary that ships with `containers/` v4.19.0, lints every branch commit against `origin/main`, and lints the PR title (squash-merge subject) via tempfile using the `env: PR_TITLE` actionlint-safe pattern.
- Update `CONTRIBUTING.md` — add a "Commit Format" section, fix the stale claim that `CLAUDE.md` documents commit conventions.
- Add `just commit-lint` / `just commit-lint-branch` recipes.

Modeled directly on `containers/.conform.yaml` (sister repo, in production). The issue's "containers rebuild required" caveat was already resolved — `conform` ships in `containers/` v4.19.0 (current submodule pin).

## Test plan

- [x] `yq eval '.' .conform.yaml` → valid YAML
- [x] All scopes anchored `^...$` — verified with `grep -vE '^\^[^$]+\$$'`
- [x] Conform rejects bad messages locally (`no type bad subject`, `feat(crypto, observe): multi-scope`, `feat(bogus): unknown-scope`)
- [x] Conform accepts well-formed messages (this PR's own commit subject passes the policy — 65 chars)
- [x] `lefthook install` wires the `commit-msg` hook; verified end-to-end with `git commit --allow-empty -m 'no type'` (rejected)
- [x] `just fmt-check`, `just fmt-data-check`, `just spell`, `just arch-check`, `just shellcheck`, `actionlint` — all clean
- [x] Pre-push hook (`cargo clippy` + `cargo test`) — passed on push
- [ ] `Commit Lint` CI job runs on this PR — confirmed by GitHub after CI starts

## Notes

- Description cap is **72 chars** (Conventional Commits spec strict mode), not the 89-char header ceiling — documented in both `.conform.yaml` comments and `CONTRIBUTING.md`. Some historical squash-merge commits with long subjects + `(#NNN)` suffix would fail under this policy; that's acceptable forward-only behavior since `--base-branch origin/main` only lints commits ahead of `main`.
- Scope `data/paths` (slash-subscope, used 2x in history) is intentionally not in the allowlist — single-scope only going forward.

Closes #252