### PR TITLE
fix(ci): detach to PR head before linting commits with conform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,18 @@ jobs:
           sudo chmod +x /usr/local/bin/conform
           conform version
       - name: Lint branch commits
-        run: conform enforce --base-branch origin/main
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # actions/checkout defaults to pull/*/merge for PR events, which
+          # creates a synthetic "Merge <head> into <base>" commit with a
+          # 92-char non-conventional header. Conform walks
+          # origin/${BASE_REF}..HEAD and flags that commit as invalid,
+          # blocking every PR. Detach HEAD onto the PR head first so
+          # conform sees only the real PR commits.
+          git checkout --detach "$HEAD_SHA"
+          conform enforce --base-branch "origin/$BASE_REF"
       - name: Lint PR title
         # Squash-merge uses the PR title as the merge subject, so it
         # must also pass. Write to a tmp file and pass through


### PR DESCRIPTION
## Summary

Follow-up to #357. The new `Commit Lint` job failed on its first PR because `actions/checkout@v4` defaults to `pull/*/merge` for PR events, which creates a synthetic `Merge <head> into <base>` commit with a 92-char non-conventional header. conform walks `origin/main..HEAD` and flags that synthetic commit as invalid, blocking every PR before it can read the real commits.

Fix: detach `HEAD` onto `github.event.pull_request.head.sha` before invoking conform, so it sees only the real PR commits. Use `github.base_ref` so non-`main` base branches also work. This is the same fix containers/ already runs in its `Validate commit messages (conform)` step.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `just fmt-data-check` — clean
- [x] Conform hook self-passed the commit message
- [ ] Confirmed by this PR's own `Commit Lint` job turning green

## Notes

`Lint PR title` already worked (it uses `--commit-msg-file` with the title text, not commit walking).