### PR TITLE
chore(tooling): adopt hadolint for Dockerfile linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,26 @@ jobs:
       - uses: taiki-e/install-action@just
       - run: just spell
 
+  hadolint:
+    name: Hadolint
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install hadolint
+        # No taiki-e/install-action recipe yet; install the static
+        # Linux binary directly. Pinned to v2.14.0 to match the
+        # version shipped by containers v4.19.0's dev-tools feature
+        # so the dev-container hook and CI run identical binaries.
+        run: |
+          version=2.14.0
+          url="https://github.com/hadolint/hadolint/releases/download/v${version}/hadolint-Linux-x86_64"
+          sudo curl -fsSL "$url" -o /usr/local/bin/hadolint
+          sudo chmod +x /usr/local/bin/hadolint
+          hadolint --version
+      - uses: taiki-e/install-action@just
+      - run: just lint-docker
+
   commit-lint:
     name: Commit Lint
     runs-on: ubuntu-latest

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,9 @@
+# Hadolint — Dockerfile linter configuration.
+# See https://github.com/hadolint/hadolint
+#
+# failure-threshold: warning
+#   Treat `info` and `style` rules as non-fatal so they surface in the
+#   hook output without blocking commits. Real issues (warning/error)
+#   still fail the build. Per-rule overrides will be added when the
+#   first parent-repo Dockerfile lands.
+failure-threshold: warning

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Both must pass before the PR can merge.
 ```bash
 git clone git@github.com:joshjhall/octarine.git
 cd octarine
-just preflight    # fmt + clippy + shellcheck + arch-check + tests
+just preflight    # fmt + clippy + shellcheck + lint-docker + arch-check + tests
 ```
 
 Run `just --list` to discover the full recipe set. All tooling is invoked

--- a/justfile
+++ b/justfile
@@ -116,6 +116,17 @@ shellcheck:
         shellcheck "${files[@]}"
     fi
 
+# Lint Dockerfiles with hadolint (no-op when no repo-local Dockerfiles present; submodule excluded)
+lint-docker:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=$(git ls-files | /usr/bin/grep -E '(^|/)Dockerfile([.-].+)?$' || true)
+    if [ -z "$files" ]; then
+        echo "hadolint: no Dockerfiles to lint"
+    else
+        echo "$files" | xargs hadolint
+    fi
+
 # Lint a commit message against the conform policy (default: HEAD's message)
 commit-lint FILE='.git/COMMIT_EDITMSG':
     conform enforce --commit-msg-file {{FILE}}
@@ -126,8 +137,8 @@ commit-lint-branch:
 
 # ─── Pre-flight (run before push / PR) ──────────────────────────────────────
 
-# Full pre-push validation: fmt, clippy, shellcheck, spell, arch-check, tests
-preflight: fmt-check fmt-data-check clippy shellcheck spell arch-check test
+# Full pre-push validation: fmt, clippy, shellcheck, lint-docker, spell, arch-check, tests
+preflight: fmt-check fmt-data-check clippy shellcheck lint-docker spell arch-check test
 
 # Everything including perf tests (run before releases)
 preflight-full: preflight test-perf

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -111,6 +111,17 @@ pre-commit:
       glob: "*.sh"
       run: shellcheck {staged_files}
 
+    # --- Dockerfile linting ---
+
+    hadolint:
+      glob: "Dockerfile*"
+      # hadolint is shipped by the containers dev-tools feature; skip
+      # gracefully if running outside a dev-tools container — CI is the
+      # safety net.
+      skip:
+        - run: "! command -v hadolint >/dev/null 2>&1"
+      run: hadolint {staged_files}
+
     # --- Architecture enforcement ---
 
     arch-check:


### PR DESCRIPTION
## Summary

- Adopts hadolint for Dockerfile linting in the parent repo. Adds `.hadolint.yaml`, a `just lint-docker` recipe wired into `preflight`, a lefthook pre-commit hook, and a CI job.
- Scoped to parent-repo Dockerfiles only via `git ls-files` (which naturally excludes the `containers/` submodule — that repo has its own hadolint CI). Today the recipe is a no-op; it auto-activates when a parent-repo Dockerfile is added.
- hadolint pinned to **v2.14.0** in CI to match what containers v4.19.0's dev-tools feature ships, so dev-container hook and CI run identical binaries.
- lefthook hook has a `skip:` clause matching the `conform` precedent — devs without hadolint installed aren't blocked locally; CI is the safety net.

## Test plan

- [x] `just --list` shows `lint-docker` with a clean one-line description
- [x] `just lint-docker` no-op when no parent-repo Dockerfiles: prints `hadolint: no Dockerfiles to lint`, exits 0
- [x] `just lint-docker` against a smoke Dockerfile (`FROM ubuntu:latest` + unpinned `apt-get install`) flags DL3007 / DL3008 / DL3015 / DL3009 and exits 123
- [x] `lefthook run pre-commit --command hadolint` fires on a staged Dockerfile and surfaces the violations
- [x] `skip:` clause confirmed: with hadolint hidden from `PATH`, lefthook reports `hadolint (skip) by condition` and exits 0
- [x] All other pre-commit hooks (dprint, typos, gitleaks, conform, etc.) pass on the diff
- [x] `just fmt-data-check` clean (dprint passes on edited YAML)
- [x] Pre-push hooks pass: `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo test --workspace`

Closes #251