### PR TITLE
chore(tooling): adopt shfmt for shell script formatting

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 
 echo "==> Verifying lefthook..."
 # lefthook is preinstalled in the devcontainer via the containers submodule.
-command -v lefthook >/dev/null || { echo "ERROR: lefthook not on PATH"; exit 1; }
+command -v lefthook >/dev/null || {
+  echo "ERROR: lefthook not on PATH"
+  exit 1
+}
 
 echo "==> Warming cargo cache..."
 cargo fetch --manifest-path /workspace/octarine/Cargo.toml

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -13,12 +13,12 @@ setup-glab
 
 # --- Git hooks via lefthook ---
 if command -v lefthook &>/dev/null; then
-    echo "==> Installing lefthook hooks..."
-    # lefthook refuses to install when core.hooksPath is set
-    git config --unset-all core.hooksPath 2>/dev/null || true
-    lefthook install
+  echo "==> Installing lefthook hooks..."
+  # lefthook refuses to install when core.hooksPath is set
+  git config --unset-all core.hooksPath 2>/dev/null || true
+  lefthook install
 else
-    echo "WARN: lefthook not found. Check that the containers submodule is present."
+  echo "WARN: lefthook not found. Check that the containers submodule is present."
 fi
 
 echo "==> Post-start setup complete."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,18 @@ jobs:
       - uses: taiki-e/install-action@just
       - run: just fmt-data-check
 
+  shfmt:
+    name: Shfmt
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: shfmt
+      - uses: taiki-e/install-action@just
+      - run: just fmt-sh-check
+
   typos:
     name: Typos
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -116,6 +116,28 @@ shellcheck:
         shellcheck "${files[@]}"
     fi
 
+# Format shell scripts with shfmt (no-op when no .sh files present; submodule excluded)
+fmt-sh:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=$(git ls-files | /usr/bin/grep -E '\.sh$' || true)
+    if [ -z "$files" ]; then
+        echo "shfmt: no shell scripts to format"
+    else
+        echo "$files" | xargs shfmt -w -i 2 -ci -bn
+    fi
+
+# Check shell script formatting with shfmt (no-op when no .sh files present; submodule excluded)
+fmt-sh-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    files=$(git ls-files | /usr/bin/grep -E '\.sh$' || true)
+    if [ -z "$files" ]; then
+        echo "shfmt: no shell scripts to check"
+    else
+        echo "$files" | xargs shfmt -d -i 2 -ci -bn
+    fi
+
 # Lint Dockerfiles with hadolint (no-op when no repo-local Dockerfiles present; submodule excluded)
 lint-docker:
     #!/usr/bin/env bash
@@ -138,7 +160,7 @@ commit-lint-branch:
 # ─── Pre-flight (run before push / PR) ──────────────────────────────────────
 
 # Full pre-push validation: fmt, clippy, shellcheck, lint-docker, spell, arch-check, tests
-preflight: fmt-check fmt-data-check clippy shellcheck lint-docker spell arch-check test
+preflight: fmt-check fmt-data-check fmt-sh-check clippy shellcheck lint-docker spell arch-check test
 
 # Everything including perf tests (run before releases)
 preflight-full: preflight test-perf

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -111,6 +111,11 @@ pre-commit:
       glob: "*.sh"
       run: shellcheck {staged_files}
 
+    shfmt:
+      glob: "*.sh"
+      run: shfmt -w -i 2 -ci -bn {staged_files}
+      stage_fixed: true
+
     # --- Dockerfile linting ---
 
     hadolint:


### PR DESCRIPTION
## Summary

Adopt `shfmt` to format shell scripts consistently alongside `shellcheck`. The containers submodule (v4.19.0) already ships `shfmt v3.13.1`, so the blocker noted in the issue (containers v4.17.0 missing shfmt) is resolved.

- `justfile`: new `fmt-sh` / `fmt-sh-check` recipes (flags `-i 2 -ci -bn`); `fmt-sh-check` added to `preflight`. File selection uses `git ls-files | grep '\.sh$'` so the `containers/` submodule (which uses `-i 4` and ships its own config) is auto-excluded.
- `lefthook.yml`: new `shfmt` pre-commit hook with `stage_fixed: true`.
- `.github/workflows/ci.yml`: new `Shfmt` job using `taiki-e/install-action@v2` (shfmt manifest available — no manual curl needed, unlike hadolint/conform).
- `.devcontainer/post-create.sh`, `post-start.sh`: one-time reformat (brace expansion + 4→2 space indent). No behavioral change.

## Test plan

- [x] `just fmt-sh-check` — fails before reformat, passes after
- [x] `just fmt-sh` applies the reformat
- [x] `just shellcheck`, `just fmt-check`, `just fmt-data-check`, `just lint-docker`, `just spell`, `just arch-check`, `just clippy` all pass
- [x] `lefthook validate` clean
- [x] Pre-commit hook fired the new `shfmt` step at commit time
- [ ] New `Shfmt` CI job runs green on this PR

Closes #250