### PR TITLE
chore(tooling): adopt rumdl for Markdown linting

### DIFF
--- a/.claude/agents/audit-octarine-identifiers/audit-octarine-identifiers.md
+++ b/.claude/agents/audit-octarine-identifiers/audit-octarine-identifiers.md
@@ -68,7 +68,8 @@ partial error.
 ### octarine-identifiers/missing-validation (severity: high)
 
 For each `is_{type}` detection function, check for corresponding `validate_{type}`:
-```
+
+```text
 Grep pattern="pub fn is_" path="crates/octarine/src/primitives/identifiers/{domain}/detection/"
 Grep pattern="pub fn validate_" path="crates/octarine/src/primitives/identifiers/{domain}/validation/"
 ```
@@ -83,14 +84,16 @@ Flag only types that are PII or sensitive data.
 ### octarine-identifiers/missing-builder-method (severity: high)
 
 For each `is_{type}` detection function, check the primitives builder:
-```
+
+```text
 Grep pattern="fn is_{type}" path="crates/octarine/src/primitives/identifiers/{domain}/builder/"
 ```
 
 ### octarine-identifiers/missing-public-builder-method (severity: high)
 
 For each primitives builder method, check the public builder:
-```
+
+```text
 Grep pattern="fn is_{type}\|fn validate_{type}\|fn redact_{type}" \
   path="crates/octarine/src/identifiers/builder/{domain}.rs"
 ```
@@ -98,7 +101,8 @@ Grep pattern="fn is_{type}\|fn validate_{type}\|fn redact_{type}" \
 ### octarine-identifiers/missing-shortcut (severity: medium)
 
 For common operations, check shortcuts:
-```
+
+```text
 Grep pattern="fn is_{type}\|fn validate_{type}\|fn redact_{type}" \
   path="crates/octarine/src/identifiers/shortcuts.rs"
 ```
@@ -106,7 +110,8 @@ Grep pattern="fn is_{type}\|fn validate_{type}\|fn redact_{type}" \
 ### octarine-identifiers/incomplete-dual-api (severity: medium)
 
 For each domain, check both exist:
-```
+
+```text
 Grep pattern="fn detect_{domain}_identifier" path="..."
 Grep pattern="fn is_{domain}_identifier" path="..."
 ```
@@ -114,7 +119,8 @@ Grep pattern="fn is_{domain}_identifier" path="..."
 ### octarine-identifiers/naming-violation (severity: medium)
 
 Scan for prohibited prefixes:
-```
+
+```text
 Grep pattern="pub(\(crate\) )?fn (has_|contains_|check_|verify_|ensure_|remove_)" \
   path="crates/octarine/src/primitives/identifiers/"
 ```
@@ -122,7 +128,8 @@ Grep pattern="pub(\(crate\) )?fn (has_|contains_|check_|verify_|ensure_|remove_)
 ### octarine-identifiers/inheritance-arrow-violation (severity: high)
 
 Detection must NOT import from validation or sanitization:
-```
+
+```text
 Grep pattern="use (super::validation|super::sanitization)" \
   path="crates/octarine/src/primitives/identifiers/*/detection/"
 ```

--- a/.claude/agents/audit-octarine-layers/audit-octarine-layers.md
+++ b/.claude/agents/audit-octarine-layers/audit-octarine-layers.md
@@ -69,51 +69,60 @@ Categories use `octarine-layers/<slug>` format (e.g., `octarine-layers/primitive
 ### primitives-observe-import (severity: high)
 
 Scan all files under `primitives/` for:
+
 - `use crate::observe` — flag UNLESS the import is ONLY `Problem` or `crate::observe::Problem`
 - `observe::info`, `observe::warn`, `observe::debug`, `observe::fail` — flag any observe function calls
 - `increment_by(`, `record(` — flag metrics calls (these are L3 concerns)
 
-```
+```text
 Grep pattern="use crate::observe" path="crates/octarine/src/primitives/"
 ```
+
 Then read each matching file to verify whether the import is limited to `Problem`.
 
 ### primitives-layer3-import (severity: high)
 
 Scan all files under `primitives/` for imports from Layer 3 modules:
-```
+
+```text
 Grep pattern="use crate::(identifiers|data|runtime|crypto|security|auth|http|io)::" path="crates/octarine/src/primitives/"
 ```
 
 ### observe-layer3-import (severity: high)
 
 Scan all files under `observe/` for imports from Layer 3 modules:
-```
+
+```text
 Grep pattern="use crate::(identifiers|data|runtime|crypto|security|auth|http|io)::" path="crates/octarine/src/observe/"
 ```
 
 ### observe-testing-import (severity: high)
 
 Scan `observe/` for testing imports outside cfg(test):
-```
+
+```text
 Grep pattern="use crate::testing" path="crates/octarine/src/observe/"
 ```
+
 Then verify matches are NOT inside `#[cfg(test)]` blocks.
 
 ### wrong-layer-visibility (severity: medium)
 
 Scan `primitives/**/mod.rs` files for module declarations that use `pub mod`
 instead of `pub(crate) mod`:
-```
+
+```text
 Grep pattern="pub mod " path="crates/octarine/src/primitives/" glob="mod.rs"
 ```
+
 Flag any `pub mod` that is not `pub(crate) mod`.
 
 ### event-in-primitives (severity: medium)
 
 Scan primitives for direct observe function calls even without explicit imports
 (could use fully-qualified paths):
-```
+
+```text
 Grep pattern="observe::(info|warn|debug|error|fail|event)" path="crates/octarine/src/primitives/"
 Grep pattern="(increment_by|record)\(" path="crates/octarine/src/primitives/"
 ```
@@ -123,7 +132,7 @@ Grep pattern="(increment_by|record)\(" path="crates/octarine/src/primitives/"
 Scan primitives for doc test code fences that will try to run (no `ignore`,
 `no_run`, or `compile_fail` annotation):
 
-```
+```text
 Grep pattern="/// ```$|/// ```rust$" path="crates/octarine/src/primitives/"
 ```
 

--- a/.claude/agents/audit-octarine-observe/audit-octarine-observe.md
+++ b/.claude/agents/audit-octarine-observe/audit-octarine-observe.md
@@ -41,12 +41,14 @@ When invoked, you receive a work manifest in the task prompt containing:
 ## What Layer 3 Builders Must Have
 
 Every builder in these directories wraps primitives with observe:
+
 - `crates/octarine/src/identifiers/builder/`
 - `crates/octarine/src/data/*/builder/`
 - `crates/octarine/src/security/*/builder*`
 - `crates/octarine/src/crypto/*/builder*`
 
 Each must include:
+
 1. Metric name definitions (`define_metrics!` or `MetricName::new`)
 2. Timing metrics (`record()` calls)
 3. Count metrics (`increment_by()` calls)
@@ -82,15 +84,18 @@ Categories use `octarine-observe/<slug>` format.
 ### missing-metrics (severity: high)
 
 Scan each Layer 3 builder for metrics:
-```
+
+```text
 Grep pattern="MetricName|define_metrics!" path="{builder_file}"
 ```
+
 If neither found, the builder has NO metrics.
 
 ### missing-silent-mode (severity: medium)
 
 Check builder struct for `emit_events` field and both constructors:
-```
+
+```text
 Grep pattern="emit_events" path="{builder_file}"
 Grep pattern="fn new\(\)|fn silent\(\)" path="{builder_file}"
 ```
@@ -99,7 +104,8 @@ Grep pattern="fn new\(\)|fn silent\(\)" path="{builder_file}"
 
 Layer 3 builders should use 2-arg shortcuts API (`observe::warn("op", "msg")`),
 not 1-arg event API (`event::warn("msg")`):
-```
+
+```text
 Grep pattern="event::(info|warn|debug|error)\(" path="{builder_file}"
 ```
 
@@ -117,9 +123,11 @@ Methods returning `bool` may skip timing (cheap operations).
 ### unguarded-observe-call (severity: medium)
 
 Verify observe calls are inside `if self.emit_events` blocks:
-```
+
+```text
 Grep pattern="observe::|increment_by|record\(" path="{builder_file}"
 ```
+
 Unguarded calls break silent mode.
 
 ## Certainty Assignment

--- a/.claude/agents/audit-octarine-platforms/audit-octarine-platforms.md
+++ b/.claude/agents/audit-octarine-platforms/audit-octarine-platforms.md
@@ -106,13 +106,15 @@ or block without a corresponding `#[cfg(not(unix))]` or `#[cfg(windows)]`
 means the code silently vanishes on the uncovered platform.
 
 Grep patterns:
-```
+
+```text
 Grep pattern="#\[cfg\(unix\)\]" path="crates/octarine/src/"
 Grep pattern="#\[cfg\(windows\)\]" path="crates/octarine/src/"
 Grep pattern="#\[cfg\(target_os" path="crates/octarine/src/"
 ```
 
 For each match:
+
 1. Read the file and identify the cfg-gated item (function, impl block, or module)
 2. Search the same file and parent `mod.rs` for a complementary cfg gate
    (`not(unix)`, `not(windows)`, `cfg_if!` with else)
@@ -126,7 +128,8 @@ Platform-conditional code with no test coverage on the non-default platform.
 CI runs on ubuntu-latest/x86_64, so Windows and macOS paths are untested.
 
 Grep patterns:
-```
+
+```text
 Grep pattern="#\[cfg\(windows\)\]" path="crates/octarine/src/"
 Grep pattern="#\[cfg\(target_os = \"macos\"\)\]" path="crates/octarine/src/"
 Grep pattern="#\[cfg\(target_arch" path="crates/octarine/src/"
@@ -144,12 +147,14 @@ Public functions or methods that only exist on Unix with no cross-platform
 alternative. Users calling these on Windows get a compile error.
 
 Grep patterns:
-```
+
+```text
 Grep pattern="#\[cfg\(unix\)\]\s*\n\s*pub fn" path="crates/octarine/src/" multiline=true
 Grep pattern="#\[cfg\(unix\)\]\s*\n\s*pub(crate) fn" path="crates/octarine/src/" multiline=true
 ```
 
 For each match:
+
 1. Check if the function has a `#[cfg(not(unix))]` counterpart
 2. Check if it is behind a feature gate (acceptable if documented)
 3. Check if the parent module is entirely cfg-gated (acceptable — the
@@ -164,13 +169,15 @@ Literal `/` or `\\` used in path construction instead of `std::path::Path`,
 regex patterns, and documentation strings.
 
 Grep patterns:
-```
+
+```text
 Grep pattern='format!\(".*[/\\\\].*"' path="crates/octarine/src/"
 Grep pattern='push_str\(".*[/\\\\]' path="crates/octarine/src/"
 Grep pattern='\.to_string\(\) \+ "[/\\\\]' path="crates/octarine/src/"
 ```
 
 For each match, read context to determine if:
+
 - It is a filesystem path (flag) vs URL/URI path (skip)
 - It is in a const/static string for display purposes (skip)
 - It uses `format!` to build a filesystem path with literal separators (flag)
@@ -182,7 +189,8 @@ documenting the difference. A permission check that works on Unix but is
 a no-op on Windows is a security gap.
 
 Grep patterns:
-```
+
+```text
 Grep pattern="#\[cfg\(unix\)\]" path="crates/octarine/src/primitives/security/"
 Grep pattern="#\[cfg\(unix\)\]" path="crates/octarine/src/security/"
 Grep pattern="#\[cfg\(unix\)\]" path="crates/octarine/src/primitives/io/"
@@ -191,6 +199,7 @@ Grep pattern="mode\(\)|permissions\(\)|set_permissions" path="crates/octarine/sr
 ```
 
 For each match:
+
 1. Read the function and its cfg counterpart (if any)
 2. Check if the Windows path provides equivalent security guarantees
 3. Flag if the Windows arm is missing, a no-op, or weaker than the Unix arm
@@ -202,7 +211,8 @@ behavior. Developers maintaining this code need to understand WHY
 a block is platform-gated.
 
 Grep patterns:
-```
+
+```text
 Grep pattern="#\[cfg\((unix|windows|target_os|target_arch)" path="crates/octarine/src/"
 ```
 
@@ -213,12 +223,14 @@ explaining the platform-specific behavior. Flag if no comment present.
 
 Code that assumes pointer size, endianness, or CPU features without a
 `cfg(target_arch)` guard. Common violations:
+
 - `as usize` on values that could overflow on 32-bit
 - `mem::size_of::<usize>()` used as a constant (8 on 64-bit, 4 on 32-bit)
 - Byte order assumptions without `cfg(target_endian)`
 
 Grep patterns:
-```
+
+```text
 Grep pattern="mem::size_of::<usize>\(\)" path="crates/octarine/src/"
 Grep pattern="as usize.*>> (32|16)" path="crates/octarine/src/"
 Grep pattern="\.to_be_bytes\(\)|\.to_le_bytes\(\)" path="crates/octarine/src/"
@@ -233,7 +245,8 @@ Architecture-specific blocks (e.g., `#[cfg(target_arch = "x86_64")]`) without
 a fallback for other architectures.
 
 Grep patterns:
-```
+
+```text
 Grep pattern="#\[cfg\(target_arch" path="crates/octarine/src/"
 ```
 
@@ -254,6 +267,7 @@ or a generic fallback. Flag if no fallback exists.
 | arch-specific-no-fallback  | MEDIUM | deterministic | 0.85       |
 
 Notes on confidence:
+
 - `cfg-without-else` is 0.90 not 0.95 because some cfg items are intentionally
   platform-exclusive (the agent must read context to distinguish)
 - `hardcoded-path-separator` is 0.65 due to false positives from URL paths

--- a/.claude/agents/audit-octarine-tests/audit-octarine-tests.md
+++ b/.claude/agents/audit-octarine-tests/audit-octarine-tests.md
@@ -64,7 +64,7 @@ deduplicates, and assigns final sequential IDs.
 
 Find tests that assert on absolute elapsed time without `#[ignore]`:
 
-```
+```text
 Grep pattern="elapsed\(\).*<|elapsed\(\).*>|as_millis\(\).*<|as_micros\(\).*<" path="crates/octarine/"
 ```
 
@@ -77,7 +77,7 @@ If not, flag it — CI coverage instrumentation inflates timing 10-100x.
 
 Find `test_perf_*` functions without `#[ignore]`:
 
-```
+```text
 Grep pattern="fn test_perf_" path="crates/octarine/"
 ```
 
@@ -87,7 +87,7 @@ ALL performance tests MUST have `#[ignore]`.
 
 Find `sleep()` calls in tests NOT inside a polling loop:
 
-```
+```text
 Grep pattern="thread::sleep|tokio::time::sleep" path="crates/octarine/"
 ```
 
@@ -99,7 +99,7 @@ Grep pattern="thread::sleep|tokio::time::sleep" path="crates/octarine/"
 
 Find tests asserting on absolute global state:
 
-```
+```text
 Grep pattern="assert.*get_count|assert.*total_written.*==\s*\d" path="crates/octarine/"
 ```
 
@@ -109,7 +109,7 @@ Tests should compare deltas (before/after) not absolute values.
 
 Find async tests without timeout:
 
-```
+```text
 Grep pattern="#\[tokio::test\]" path="crates/octarine/"
 ```
 
@@ -119,7 +119,7 @@ Check for `tokio::time::timeout()` or deadline check.
 
 Find patterns suggesting race conditions:
 
-```
+```text
 Grep pattern="spawn.*assert|thread::spawn.*assert" path="crates/octarine/"
 ```
 
@@ -132,7 +132,7 @@ proper synchronization.
 
 Scan for timing-related assertions without message:
 
-```
+```text
 Grep pattern="assert!\(.*elapsed|assert!\(.*millis|assert!\(.*duration" path="crates/octarine/"
 ```
 
@@ -142,7 +142,7 @@ Flag matches lacking a trailing `, "..."` message argument.
 
 Tests modifying global state without cleanup:
 
-```
+```text
 Grep pattern="env::set_var|std::env::set_var" path="crates/octarine/"
 ```
 

--- a/.claude/agents/audit-octarine-visibility/audit-octarine-visibility.md
+++ b/.claude/agents/audit-octarine-visibility/audit-octarine-visibility.md
@@ -70,16 +70,19 @@ Categories use `octarine-visibility/<slug>` format.
 ### pubsuper-for-reexport (severity: medium)
 
 Scan for re-exports using `pub(super) use` instead of `pub use`:
-```
+
+```text
 Grep pattern="pub\(super\) use" path="crates/octarine/src/"
 ```
 
 ### pub-module-at-sublevel (severity: medium)
 
 In feature modules (NOT primitives, NOT root-level), scan for `pub mod`:
-```
+
+```text
 Grep pattern="^pub mod " path="crates/octarine/src/" glob="mod.rs"
 ```
+
 Exclude root-level feature modules: `identifiers/mod.rs`, `data/mod.rs`,
 `security/mod.rs`, `runtime/mod.rs`, `crypto/mod.rs`, `io/mod.rs`,
 `auth/mod.rs`, `http/mod.rs`, `observe/mod.rs`.
@@ -87,16 +90,18 @@ Exclude root-level feature modules: `identifiers/mod.rs`, `data/mod.rs`,
 ### business-logic-in-builder (severity: high)
 
 Identify non-mod.rs, non-core.rs files in `builder/` directories. Check for:
+
 - `Regex::new(` — regex compilation belongs in detection files
-- `for ` / `while ` / `loop ` — iteration belongs in implementation
+- `for` / `while` / `loop` — iteration belongs in implementation
 - Complex `match` on string content
 - >5 lines of logic between method signature and delegation call
 
 ### shortcut-bypasses-builder (severity: high)
 
-```
+```text
 Grep pattern="crate::primitives::" path="crates/octarine/src/" glob="shortcuts.rs"
 ```
+
 Shortcuts must use the builder, not import from primitives directly.
 
 ### missing-reexport (severity: medium)

--- a/.claude/memory/feedback_audit_severity.md
+++ b/.claude/memory/feedback_audit_severity.md
@@ -4,6 +4,7 @@ description: When running codebase audits, file all findings (including low seve
 type: feedback
 originSessionId: 4463311d-805b-4c18-b59e-4729660c355c
 ---
+
 When running `/codebase-audit`, default to `severity-threshold=low` (file everything) but ensure each filed issue is clearly defined and deduplicated against existing open issues.
 
 **Why:** User closed 100+ issues in the 3-4 weeks before 2026-04-16, so backlog flooding is not a concern — quality and dedup are. Duplicate issues create noise; missed findings create hidden debt. The plan is to run audits iteratively: file everything → work through for 1-2 weeks → run another audit pass → repeat.

--- a/.claude/memory/feedback_github_labels.md
+++ b/.claude/memory/feedback_github_labels.md
@@ -4,6 +4,7 @@ description: Ensure status/pr-pending exists alongside status/in-progress, statu
 type: feedback
 originSessionId: 62b38eb1-d94a-4b80-9d19-bda2bdac77bb
 ---
+
 `/next-issue-ship` (Option 1, Branch+PR) requires a `status/pr-pending`
 label on the GitHub repo. It was missing from joshjhall/octarine on
 2026-04-17 — `gh issue edit` failed atomically so neither the add nor

--- a/.claude/memory/feedback_just_recipes.md
+++ b/.claude/memory/feedback_just_recipes.md
@@ -4,6 +4,7 @@ description: All verification, testing, linting, AND ad-hoc dev commands must us
 type: feedback
 originSessionId: 0641e80c-85a8-41f7-9026-371e1fa16da1
 ---
+
 Always use `just` recipes — in plans, verification sections, documentation, AND for ad-hoc commands during development iteration. Never invoke `cargo test`, `cargo clippy`, `cargo build`, `cargo fmt`, or `bash scripts/*` directly, even when tempted to "just check this one thing quickly."
 
 **Why:** `just` recipes are the single source of truth for how to run things. Agents, hooks, CI, and humans should all use the same recipes. Raw commands are implementation details that can drift, miss feature flags, or use wrong job counts. Reinforced 2026-04-29: agent reached for `cargo build` and `cargo test` mid-implementation when `just test-octarine` / `just test-mod` would have done the same job; user pushed back firmly.

--- a/.claude/memory/feedback_loc_excludes_docs_tests.md
+++ b/.claude/memory/feedback_loc_excludes_docs_tests.md
@@ -4,6 +4,7 @@ description: When evaluating file size against octarine size limits (preferred <
 type: feedback
 originSessionId: 8b312243-2a09-4133-8ff4-148b83dddacb
 ---
+
 When checking whether a file exceeds octarine's size limits documented in CLAUDE.md (preferred <300 LOC, warn >500, split at >800), the LOC measurement is **production code only**. Exclude:
 
 - Doc comments (`///`, `//!`, `/** */`)
@@ -13,6 +14,7 @@ When checking whether a file exceeds octarine's size limits documented in CLAUDE
 **Why:** A 2014-line file with ~1000 lines of tests and ~200 lines of doc comments is really ~800 lines of production code. The size guidance targets the cognitive load of reviewable production logic, not test coverage or documentation thoroughness. Tests are a feature, not debt — splitting a file just because tests pushed it over the line is wrong.
 
 **How to apply:**
+
 - Before flagging or planning a split, compute production LOC: `wc -l file.rs` minus the test module line count minus large doc comment blocks.
 - When sizing target submodules in a split plan, target <300 LOC of production code per file (tests bundled with the production code don't count against that target).
 - When reporting "this file is X LOC" in plans/PRs, qualify with "(of which N is tests, M is docs)" if tests/docs are a significant fraction.

--- a/.claude/memory/feedback_pr_auto_merge.md
+++ b/.claude/memory/feedback_pr_auto_merge.md
@@ -4,6 +4,7 @@ description: When a PR opened via /next-issue-ship goes green, squash-merge with
 type: feedback
 originSessionId: 332028ef-8736-458e-a34d-2fedb2a3582a
 ---
+
 When a PR (typically opened via `/next-issue-ship` Option 1) reports all CI
 checks green, immediately:
 

--- a/.claude/memory/feedback_pre_1_0_breaking_changes.md
+++ b/.claude/memory/feedback_pre_1_0_breaking_changes.md
@@ -12,6 +12,7 @@ While pre-1.0 (`0.x` line), do breaking renames directly — drop the old name i
 **Why:** Octarine is at `0.3.0-beta.x`, not published to crates.io, and the SemVer policy explicitly says `0.X.0` minor bumps may include breaking changes. The whole point of the beta line is to absorb breakage cheaply. Carrying parallel old+new names doubles the public surface, splits documentation, and forces the cleanup to happen *twice* (rename, then later remove). Downstream callers in this state are few and updating callsites in one go is straightforward.
 
 **How to apply:**
+
 - When a naming/API change qualifies as "breaking" per the breaking-change catalog in [[octarine-release]] AND the project is on `0.x`: rename in place, delete the old symbol, and document the break under `### Changed` in CHANGELOG `[Unreleased]`.
 - The version bump remains `minor` (which finalizes a beta to stable per `octarine-release` SKILL.md) — don't add a synthetic `#[deprecated]` step just because the change is breaking.
 - After 1.0 ships, the calculus flips — deprecation cycles become the right tool. Reassess this guidance when crossing 1.0.

--- a/.claude/memory/project_audit_ai_config_gitignored.md
+++ b/.claude/memory/project_audit_ai_config_gitignored.md
@@ -4,6 +4,7 @@ description: audit-ai-config findings against .claude/settings.local.json cannot
 type: project
 originSessionId: a25812db-9b4f-4430-bd87-4b4f668d9456
 ---
+
 `audit-ai-config` scans `.claude/settings.local.json`, but that file is
 gitignored (`.gitignore:47`) and has never been tracked in the repo.
 Findings against it (e.g., issues #188, #75) cannot close through the
@@ -16,6 +17,7 @@ manually in each dev's local file.
 
 **How to apply:** When `/next-issue` picks an issue that only touches
 `.claude/settings.local.json`:
+
 1. Apply the fix locally (Edit tool is fine).
 2. Validate JSON with `python3 -c 'import json; json.load(...)'`.
 3. Close the issue with a comment explaining the local fix — don't

--- a/.claude/memory/project_dependabot_coordinated_bumps.md
+++ b/.claude/memory/project_dependabot_coordinated_bumps.md
@@ -14,6 +14,7 @@ When Dependabot files multiple PRs touching crates from the same release cycle (
 **How to apply:** when you see multiple failing Dependabot PRs touching crates that share a version number or release cadence, don't try to merge them individually or rebase them — close them all as superseded and file ONE unified bump PR that updates all of them together. The trait errors disappear once the lockfile resolves to a single version, and typically no call-site changes are needed (the API across versions in a coordinated release is usually stable).
 
 **Examples of coordinated families to watch for:**
+
 - `opentelemetry*` (opentelemetry, opentelemetry_sdk, opentelemetry-otlp, opentelemetry-http, opentelemetry-proto)
 - `tonic*` (tonic, tonic-build, tonic-types)
 - `tracing*` (tracing, tracing-subscriber, tracing-core)

--- a/.claude/skills/octarine-architecture/SKILL.md
+++ b/.claude/skills/octarine-architecture/SKILL.md
@@ -37,6 +37,7 @@ primitives/{domain}/builder/core.rs  pub(crate) struct XBuilder  # Orchestration
 ```
 
 **Critical rules**:
+
 - Primitives modules: `pub(crate) mod` — never `pub mod`
 - Sub-level feature modules: `pub(super) mod` or `pub(crate) mod` — never `pub mod`
 - Re-exports at ALL levels: `pub use` — NEVER `pub(super) use`
@@ -102,6 +103,7 @@ pub fn is_email(value: &str) -> bool {
 ```
 
 ## Verification
+
 - `just arch-check` — verify layer boundary compliance
 - `just clippy` — catch visibility modifier errors
 

--- a/.claude/skills/octarine-architecture/decision-trees.md
+++ b/.claude/skills/octarine-architecture/decision-trees.md
@@ -46,6 +46,7 @@ Where does this code go?
 | `#[cfg(test)]` blocks | ALLOW | ALLOW | ALLOW | ALLOW |
 
 **Allowed `observe` import in primitives** (the ONLY exception):
+
 ```rust
 use crate::observe::Problem;  // OK — error type only
 ```

--- a/.claude/skills/octarine-identifier-checklist/SKILL.md
+++ b/.claude/skills/octarine-identifier-checklist/SKILL.md
@@ -48,7 +48,7 @@ Every identifier type requires ALL applicable steps.
 ### Layer 3: Public API (pub)
 
 9. **Public builder** — `identifiers/builder/{domain}.rs`
-    - Wraps primitives builder + adds observe (metrics, events, timing)
+   - Wraps primitives builder + adds observe (metrics, events, timing)
 
 10. **Shortcuts** — `identifiers/shortcuts.rs`
     - `pub fn is_{type}(v: &str) -> bool { {Domain}Builder::new().is_{type}(v) }`

--- a/.claude/skills/octarine-identifier-checklist/implementation-template.md
+++ b/.claude/skills/octarine-identifier-checklist/implementation-template.md
@@ -28,12 +28,14 @@ pub fn detect_{type}s_in_text(text: &str) -> Vec<IdentifierMatch> {
 ```
 
 Register in `detection/mod.rs`:
+
 ```rust
 pub(crate) mod {type};
 pub use {type}::*;
 ```
 
 Add to domain's `detect_{domain}_identifier()`:
+
 ```rust
 if is_{type}(value) {
     return Some(IdentifierType::{Type});
@@ -107,6 +109,7 @@ pub fn redact_{type}(value: &str, strategy: {Type}RedactionStrategy) -> String {
 ### Steps 6-8: Primitives Builder Methods
 
 In `primitives/identifiers/{domain}/builder/detection_methods.rs`:
+
 ```rust
 impl {Domain}IdentifierBuilder {
     pub fn is_{type}(&self, value: &str) -> bool {
@@ -119,6 +122,7 @@ impl {Domain}IdentifierBuilder {
 ```
 
 In `builder/validation_methods.rs`:
+
 ```rust
 impl {Domain}IdentifierBuilder {
     pub fn validate_{type}(&self, value: &str) -> Result<(), Problem> {
@@ -128,6 +132,7 @@ impl {Domain}IdentifierBuilder {
 ```
 
 In `builder/sanitization_methods.rs`:
+
 ```rust
 impl {Domain}IdentifierBuilder {
     pub fn redact_{type}(&self, value: &str, strategy: {Type}RedactionStrategy) -> String {
@@ -194,6 +199,7 @@ pub fn redact_{type}(value: &str) -> String {
 ### Step 11: PII Registration (if PII)
 
 In `crates/octarine/src/identifiers/types/core.rs`, add variant:
+
 ```rust
 pub enum IdentifierType {
     // ... existing variants
@@ -206,6 +212,7 @@ In PII scanner, add detection mapping.
 ### Step 12: Tests
 
 Each layer gets its own test:
+
 ```rust
 #[cfg(test)]
 mod tests {
@@ -248,6 +255,7 @@ crates/octarine/src/primitives/identifiers/{domain}/
 ```
 
 Then wire up in parent `mod.rs` files:
+
 - `primitives/identifiers/mod.rs`: add `pub(crate) mod {domain};`
 - `identifiers/builder/mod.rs`: add `pub(crate) mod {domain};` + builder struct
 - `identifiers/mod.rs`: add re-exports

--- a/.claude/skills/octarine-observe-integration/patterns.md
+++ b/.claude/skills/octarine-observe-integration/patterns.md
@@ -34,6 +34,7 @@ mod metric_names {
 ## Existing Metric Registry
 
 ### data.paths.*
+
 - `data.paths.context.sanitized` — context sanitization count
 - `data.paths.filename.threats_detected` — filename threat count
 - `data.paths.filename.sanitize_ms` — filename sanitization timing
@@ -47,10 +48,12 @@ mod metric_names {
 - `data.paths.format.converted` — format conversion count
 
 ### data.network.*
+
 - `data.network.normalize_ms` — URL normalization timing
 - `data.network.normalize_count` — URL normalization count
 
 ### data.identifiers.{domain}.*
+
 - `data.identifiers.personal.detect_ms` — personal detection timing
 - `data.identifiers.personal.validate_ms` — personal validation timing
 - `data.identifiers.personal.redact_ms` — personal redaction timing
@@ -59,6 +62,7 @@ mod metric_names {
 - (Similar pattern for financial, government, network, token, etc.)
 
 ### security.*
+
 - `security.commands.threats_detected` — command injection threats
 - `security.commands.validate_ms` — command validation timing
 - `security.commands.escape_ms` — command escaping timing
@@ -67,6 +71,7 @@ mod metric_names {
 - `security.paths.sanitize_ms` — path security sanitization timing
 
 ### crypto.*
+
 - `crypto.validation.certificate_ms` — certificate validation timing
 - `crypto.validation.ssh_key_ms` — SSH key validation timing
 - `crypto.validation.audit_ms` — crypto audit timing
@@ -75,15 +80,18 @@ mod metric_names {
 - `crypto.validation.warnings` — crypto warnings count
 
 ### secrets.*
+
 - `secrets.storage.created` — encrypted storage created
 - `secrets.insert_count` — secret insertions
 - `secrets.access_count` — secret accesses
 - `secrets.expired_count` — secret expirations
 
 ### http.*
+
 - `http.request.latency_ms` — HTTP request latency
 
 ### Modules MISSING Metrics (need attention)
+
 - `security/formats/builder.rs` — XXE, JSON depth, YAML bombs (logging only)
 - `security/network/builder.rs` — SSRF, dangerous schemes (logging only)
 - `security/queries/builder.rs` — SQL/NoSQL/LDAP injection (logging only)
@@ -103,7 +111,7 @@ For a new Layer 3 module `{module}/{concern}/`:
 └── types.rs            # Public types (optional)
 ```
 
-### mod.rs template:
+### mod.rs template
 
 ```rust
 //! {Concern} operations with observability
@@ -117,7 +125,7 @@ pub use builder::{Concern}Builder;
 pub use builder::shortcuts::*;
 ```
 
-### builder/mod.rs template:
+### builder/mod.rs template
 
 ```rust
 use std::time::Instant;
@@ -163,7 +171,7 @@ impl {Concern}Builder {
 }
 ```
 
-### builder/shortcuts.rs template:
+### builder/shortcuts.rs template
 
 ```rust
 use super::{Concern}Builder;

--- a/.claude/skills/octarine-pii-bridge/SKILL.md
+++ b/.claude/skills/octarine-pii-bridge/SKILL.md
@@ -45,6 +45,7 @@ pub enum PiiType {
 ```
 
 Update classification methods:
+
 - `domain()` — return correct `PiiDomain::{Domain}`
 - `is_high_risk()` — if the type is high-risk PII
 - `is_gdpr_protected()` — if GDPR-relevant
@@ -60,6 +61,7 @@ current classifications before deciding which to update.
 File: `crates/octarine/src/observe/pii/scanner/domains.rs`
 
 Add detection call to the appropriate `scan_{domain}` function:
+
 ```rust
 pub(super) fn scan_{domain}(text: &str, pii_types: &mut Vec<PiiType>) {
     let builder = {Domain}IdentifierBuilder::new();

--- a/.claude/skills/octarine-release/SKILL.md
+++ b/.claude/skills/octarine-release/SKILL.md
@@ -77,7 +77,7 @@ When in doubt, run `cargo semver-checks check-release --workspace
 
 The state machine enforces a strict forward-only lifecycle:
 
-```
+```text
         beta ───────► rc ───────► (finalize via patch/minor)
         ▲
         │

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,25 @@ jobs:
       - uses: taiki-e/install-action@just
       - run: just lint-docker
 
+  rumdl:
+    name: Rumdl
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install rumdl
+        # No taiki-e/install-action recipe yet; install the static
+        # Linux tarball directly. Pinned to v0.1.91 to match the
+        # version shipped by containers v4.19.0's dev-tools feature
+        # so the dev-container hook and CI run identical binaries.
+        run: |
+          version=0.1.91
+          url="https://github.com/rvben/rumdl/releases/download/v${version}/rumdl-v${version}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSL "$url" | sudo tar -xz -C /usr/local/bin rumdl
+          rumdl --version
+      - uses: taiki-e/install-action@just
+      - run: just lint-md
+
   commit-lint:
     name: Commit Lint
     runs-on: ubuntu-latest

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -45,3 +45,11 @@ disable = [
 line_length = 120
 code_blocks = false
 tables = false
+
+# Per-file overrides: .claude/ files use YAML frontmatter with long
+# description fields by design (skill discovery, memory schema), so
+# MD013 doesn't apply there.
+[per-file-ignores]
+".claude/memory/**" = ["MD013"]
+".claude/skills/**" = ["MD013"]
+".claude/agents/**" = ["MD013"]

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,47 @@
+# rumdl configuration — Markdown linting and formatting
+#
+# Baseline adopted from containers/.rumdl.toml (which migrated from mado
+# + dprint-markdown in 2026-04). Rules disabled below either don't fit
+# our docs (e.g., MD041 — agent/skill templates put titles in YAML
+# frontmatter) or require project-specific data we don't maintain
+# (name lists, TOC templates, forbidden-term lists).
+
+respect-gitignore = true
+
+exclude = [
+  "CHANGELOG.md",
+  "target/**",
+  "node_modules/**",
+  ".git/**",
+  ".vscode/**",
+  ".devcontainer/**",
+  "containers/**",          # submodule — has its own .rumdl.toml + CI gate
+  ".claude/memory/tmp/**",  # ephemeral session state (gitignored anyway)
+  ".claude/worktrees/**",   # parallel-agent worktrees (gitignored anyway)
+]
+
+disable = [
+  # Our agent/skill templates put the title in YAML frontmatter rather
+  # than an H1 heading. rumdl's front-matter-title exemption doesn't
+  # suppress the finding on our templates, so keep it off.
+  "MD041",
+  # Opinionated / requires project-specific configuration:
+  "MD043", # required heading structure (needs a template)
+  "MD044", # proper names capitalization (needs a names list)
+  "MD054", # link/image style — redundant with MD048-MD050
+  "MD057", # relative link existence (many cross-refs resolve at build time)
+  "MD059", # link text should be descriptive
+  "MD060", # table column alignment
+  "MD061", # forbidden terms (needs a term list)
+  "MD063", # heading capitalization
+  "MD072", # frontmatter keys alphabetical
+  "MD073", # TOC matches document headings (needs a TOC)
+  "MD074", # MkDocs nav entries (we don't use MkDocs)
+]
+
+# Line length: 120 characters of prose is plenty; code blocks and tables
+# often exceed that legitimately.
+[MD013]
+line_length = 120
+code_blocks = false
+tables = false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance for working with the octarine project.
 
 ## Overview
 
-**Octarine** is the foundation library providing security primitives and observability tools for Rust applications. Named after the eighth color of the Discworld spectrum - the color of magic, visible only to wizards.
+**Octarine** is the foundation library providing security primitives and
+observability tools for Rust applications. Named after the eighth color of the
+Discworld spectrum - the color of magic, visible only to wizards.
 
 ## Architecture (CRITICAL)
 
@@ -240,7 +242,7 @@ layout.
 
 ### Naming Conventions (CRITICAL)
 
-**Core Rule: Prefix indicates return type**
+**Core Rule:** Prefix indicates return type
 
 | Return Type | Prefix | Example |
 |-------------|--------|---------|
@@ -273,9 +275,12 @@ The project enforces strict clippy lints via `Cargo.toml [lints.clippy]`. Key de
 | `dbg_macro` | **deny** | No debug macros in committed code |
 | `print_stdout` / `print_stderr` | **deny** | Use `observe` module for all output |
 
-**In test modules**, add `#![allow(clippy::panic, clippy::expect_used)]` at the module level. Do NOT allow `indexing_slicing` — use `.first()`, `.get()`, etc. even in tests.
+**In test modules**, add `#![allow(clippy::panic, clippy::expect_used)]` at
+the module level. Do NOT allow `indexing_slicing` — use `.first()`, `.get()`,
+etc. even in tests.
 
-**For static regexes**, use `#![allow(clippy::expect_used)]` at the file level with a comment explaining the patterns are compile-time-known-valid.
+**For static regexes**, use `#![allow(clippy::expect_used)]` at the file
+level with a comment explaining the patterns are compile-time-known-valid.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ read that file before adding a new scope.
 - **scope** — a single entry from `.conform.yaml` (no comma-separated
   lists). New scopes welcome: open a PR adding an anchored `^name$` entry.
 - **subject** — imperative mood, no trailing period. The Conventional
-  Commits spec caps the **description** (text after `<type>(<scope>): `) at
+  Commits spec caps the **description** (text after `<type>(<scope>):`) at
   **72 characters**, enforced by conform. The full header has a generous
   89-character ceiling so longer `type(scope):` prefixes still fit.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Octarine
 
-Foundation library for security and observability in Rust. Named after the eighth color of the Discworld spectrum — the color of magic, visible only to wizards.
+Foundation library for security and observability in Rust. Named after the
+eighth color of the Discworld spectrum — the color of magic, visible only to
+wizards.
 
 ## Features
 
-- **Security Primitives** — Input validation, sanitization, and threat detection following OWASP patterns
-- **Compliance-Grade Observability** — Automatic WHO/WHAT/WHEN/WHERE context capture, PII redaction, SOC2/HIPAA/GDPR/PCI-DSS control mapping
+- **Security Primitives** — Input validation, sanitization, and threat
+  detection following OWASP patterns
+- **Compliance-Grade Observability** — Automatic WHO/WHAT/WHEN/WHERE context
+  capture, PII redaction, SOC2/HIPAA/GDPR/PCI-DSS control mapping
 - **Three-Layer Architecture** — Clean separation of primitives, observability, and instrumented operations
 - **Post-Quantum Cryptography** — ML-KEM and X25519 key exchange, ChaCha20-Poly1305 and AES-GCM encryption
 - **Modular Feature Flags** — Enable only what you need (20 feature flags)

--- a/docs/api/error-architecture.md
+++ b/docs/api/error-architecture.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-The octarine library uses a unified `Problem` type for error handling that automatically captures context, generates events, and maintains audit trails. This architecture separates the error (what went wrong) from the context (who/where/when) for better observability and compliance.
+The octarine library uses a unified `Problem` type for error handling that automatically captures context, generates
+events, and maintains audit trails. This architecture separates the error (what went wrong) from the context
+(who/where/when) for better observability and compliance.
 
 ## Core Principles
 

--- a/docs/api/naming-conventions.md
+++ b/docs/api/naming-conventions.md
@@ -1,6 +1,7 @@
 # API Naming Conventions
 
-This document defines the naming conventions for all public API methods in octarine's `data/` modules. Consistent naming ensures predictability, discoverability, and makes the API easier for both humans and AI agents to use correctly.
+This document defines the naming conventions for all public API methods in octarine's `data/` modules. Consistent naming
+ensures predictability, discoverability, and makes the API easier for both humans and AI agents to use correctly.
 
 ## Core Rule: Prefix Indicates Return Type
 
@@ -100,7 +101,8 @@ fn detect_extension(path: &str) -> Option<&str>;  // detect_* returns Vec
 
 ### Accessors: No Prefix
 
-Simple property access uses no prefix. The `get_*` prefix is prohibited — drop it and name the accessor after the property:
+Simple property access uses no prefix. The `get_*` prefix is prohibited — drop it and name the accessor after the
+property:
 
 ```rust
 // ✅ CORRECT

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,11 +4,14 @@ This section covers the system design, patterns, and architectural decisions for
 
 ## Quick Links
 
-- **Layer Architecture**: [`layer-architecture.md`](./layer-architecture.md) - **START HERE** - Three-layer dependency rules
+- **Layer Architecture**: [`layer-architecture.md`](./layer-architecture.md) - **START HERE** - Three-layer dependency
+  rules
 - **Module Patterns**: [`module-patterns.md`](./module-patterns.md) - Three-layer pattern and builder pattern
 - **System Design**: [`system-design.md`](./system-design.md) - Overall library architecture
 - **Testing Patterns**: [`testing-patterns.md`](./testing-patterns.md) - Shared test infrastructure
-- **Async + Observability Integration**: [`../runtime/observability-integration.md`](../runtime/observability-integration.md) - Comprehensive async runtime instrumentation
+- **Async + Observability Integration**:
+  [`../runtime/observability-integration.md`](../runtime/observability-integration.md) - Comprehensive async runtime
+  instrumentation
 - **Refactor Status**: [`refactor-plan.md`](./refactor-plan.md) - Completed refactor summary (v0.3.0-beta.1)
 
 ## In This Section

--- a/docs/architecture/builder-pattern.md
+++ b/docs/architecture/builder-pattern.md
@@ -14,7 +14,8 @@ module/
 └── mod.rs               # Minimal exports
 ```
 
-**Note**: Shortcuts are organized by domain (`feature_shortcuts.rs`) rather than a single `shortcuts.rs` file. This improves clarity, discoverability, and maintainability.
+**Note**: Shortcuts are organized by domain (`feature_shortcuts.rs`) rather than a single `shortcuts.rs` file. This
+improves clarity, discoverability, and maintainability.
 
 ### Dual Function Pattern
 
@@ -52,7 +53,8 @@ module/
 
 ### Why Domain-Specific Shortcuts?
 
-As modules grow, a single `shortcuts.rs` file becomes unwieldy. Instead, we organize shortcuts by their functional domain:
+As modules grow, a single `shortcuts.rs` file becomes unwieldy. Instead, we organize shortcuts by their functional
+domain:
 
 1. **Clarity**: `payment_shortcuts.rs` clearly contains payment-related shortcuts
 1. **Discoverability**: Developers can easily find relevant shortcuts

--- a/docs/architecture/layer-architecture.md
+++ b/docs/architecture/layer-architecture.md
@@ -1,6 +1,7 @@
 # Layer Architecture
 
-This document defines the strict layer architecture that governs module dependencies in octarine. Understanding and following these rules is critical to prevent circular dependencies and maintain clean separation of concerns.
+This document defines the strict layer architecture that governs module dependencies in octarine. Understanding and
+following these rules is critical to prevent circular dependencies and maintain clean separation of concerns.
 
 ## Overview
 
@@ -87,7 +88,8 @@ octarine uses a **three-layer architecture** where each layer can only depend on
 
 **Visibility**: `pub(crate)` - Only accessible within octarine
 
-**Purpose**: Pure utility functions with ZERO internal dependencies. These are the building blocks that observe and security modules use internally.
+**Purpose**: Pure utility functions with ZERO internal dependencies. These are the building blocks that observe and
+security modules use internally.
 
 **Rules**:
 
@@ -96,7 +98,8 @@ octarine uses a **three-layer architecture** where each layer can only depend on
 - MUST NOT import from observe, security, runtime, or testing
 - MUST NOT generate events or log anything
 
-**Why Internal Only**: Forces external consumers to use Layer 3 APIs which include proper observability. Prevents bypassing audit logging.
+**Why Internal Only**: Forces external consumers to use Layer 3 APIs which include proper observability. Prevents
+bypassing audit logging.
 
 ```rust
 // primitives/paths/validation.rs
@@ -116,7 +119,8 @@ Layer 1 also includes shared test infrastructure, which is feature-gated and act
 
 **Visibility**: `pub` with `#[cfg(feature = "testing")]`
 
-**Purpose**: Reusable test utilities, fixtures, and generators that can be shared across octarine and all consuming projects.
+**Purpose**: Reusable test utilities, fixtures, and generators that can be shared across octarine and all consuming
+projects.
 
 **Rules**:
 
@@ -125,7 +129,8 @@ Layer 1 also includes shared test infrastructure, which is feature-gated and act
 - Only compiled when `testing` feature is enabled
 - Only used in `[dev-dependencies]` by consumers
 
-**Why Public**: Allows consistent testing patterns across all projects using octarine. Security test generators match the attack patterns that octarine defends against.
+**Why Public**: Allows consistent testing patterns across all projects using octarine. Security test generators match
+the attack patterns that octarine defends against.
 
 ```rust
 // testing/generators/attacks.rs
@@ -143,7 +148,8 @@ pub fn arb_path_traversal() -> impl Strategy<Value = String> {
 
 **Visibility**: `pub` - Full public API
 
-**Purpose**: Event generation, metrics, PII redaction, and audit logging. Provides the observability infrastructure used by Layer 3.
+**Purpose**: Event generation, metrics, PII redaction, and audit logging. Provides the observability infrastructure used
+by Layer 3.
 
 **Rules**:
 
@@ -284,7 +290,8 @@ module docstring.
 
 ## The Critical Rule: Testing is a Consumer
 
-The `testing` module breaks the normal "down only" rule because it's a **consumer** of the public API, not a **provider** to it:
+The `testing` module breaks the normal "down only" rule because it's a **consumer** of the public API, not a
+**provider** to it:
 
 ```text
 Normal dependency flow:       Testing dependency flow:
@@ -381,7 +388,8 @@ When adding new functionality, ask:
 
 ## Three Orthogonal Concerns in Primitives
 
-The `primitives/` module is organized around three orthogonal concerns that apply across all domains (paths, network, text):
+The `primitives/` module is organized around three orthogonal concerns that apply across all domains (paths, network,
+text):
 
 | Concern | Module | Question | Purpose |
 |---------|--------|----------|---------|

--- a/docs/architecture/metric-validation-migration-plan.md
+++ b/docs/architecture/metric-validation-migration-plan.md
@@ -154,4 +154,5 @@ The security module should check for:
 
 ## Conclusion
 
-Moving validation to the security module is the right architectural decision. It should be done gradually, maintaining backward compatibility while adding security depth.
+Moving validation to the security module is the right architectural decision. It should be done gradually, maintaining
+backward compatibility while adding security depth.

--- a/docs/architecture/metrics-best-practices-gap-analysis.md
+++ b/docs/architecture/metrics-best-practices-gap-analysis.md
@@ -250,15 +250,15 @@ pub struct Exemplar {
 ### Medium Priority (Next Phase)
 
 5. **Units of Measurement** - Improves clarity
-1. **Metric Documentation** - Helps users
-1. **Stale Metric Cleanup** - Prevents memory leaks
-1. **Rate Windows** - Better monitoring
+6. **Metric Documentation** - Helps users
+7. **Stale Metric Cleanup** - Prevents memory leaks
+8. **Rate Windows** - Better monitoring
 
 ### Low Priority (Nice to Have)
 
 9. **Percentile Accuracy** - Current approximation probably OK
-1. **Zero-Overhead** - Only if performance critical
-1. **Exemplars** - Advanced feature
+10. **Zero-Overhead** - Only if performance critical
+11. **Exemplars** - Advanced feature
 
 ## Example Implementation: Labels
 

--- a/docs/architecture/module-patterns.md
+++ b/docs/architecture/module-patterns.md
@@ -2,15 +2,19 @@
 
 ## Overview
 
-octarine uses consistent architectural patterns across all modules to ensure maintainability, security, and ease of use. The primary patterns are the Three-Layer Pattern for module structure and the Builder Pattern for complex configurations.
+octarine uses consistent architectural patterns across all modules to ensure maintainability, security, and ease of use.
+The primary patterns are the Three-Layer Pattern for module structure and the Builder Pattern for complex
+configurations.
 
 ## The Three-Layer Pattern
 
-Every module in octarine follows a three-layer architecture that separates concerns and provides multiple levels of API access.
+Every module in octarine follows a three-layer architecture that separates concerns and provides multiple levels of API
+access.
 
 ### Layer 1: Core Implementation (Private)
 
-The innermost layer contains the actual business logic. These are private or `pub(crate)` functions that do the real work.
+The innermost layer contains the actual business logic. These are private or `pub(crate)` functions that do the real
+work.
 
 ```text
 module/

--- a/docs/architecture/observability-severity-levels.md
+++ b/docs/architecture/observability-severity-levels.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-The observe module provides a smart logging system with automatic severity assignment based on the type of issue detected. This document explains when to use each severity level.
+The observe module provides a smart logging system with automatic severity assignment based on the type of issue
+detected. This document explains when to use each severity level.
 
 ## Severity Hierarchy
 

--- a/docs/architecture/security/identifiers.md
+++ b/docs/architecture/security/identifiers.md
@@ -62,7 +62,7 @@ ______________________________________________________________________
 
 ### 1. Zero-Trust Security
 
-**"Trust nothing, verify everything, validate at every boundary."**
+> "Trust nothing, verify everything, validate at every boundary."
 
 Every identifier is untrusted regardless of source:
 

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-octarine is a foundational security and observability library for Rust applications. It provides two main modules that work together to create secure, auditable, and maintainable applications.
+octarine is a foundational security and observability library for Rust applications. It provides two main modules that
+work together to create secure, auditable, and maintainable applications.
 
 ## High-Level Architecture
 
@@ -31,11 +32,13 @@ octarine is a foundational security and observability library for Rust applicati
 
 ## Core Modules
 
-Octarine uses a three-layer architecture that prevents circular dependencies. See [`layer-architecture.md`](./layer-architecture.md) for the full dependency rules.
+Octarine uses a three-layer architecture that prevents circular dependencies. See
+[`layer-architecture.md`](./layer-architecture.md) for the full dependency rules.
 
 ### Layer 1: Primitives (`crates/octarine/src/primitives/`)
 
-Pure functions with no observability dependencies. Visibility is `pub(crate)` — primitives are always wrapped by a Layer 3 module for public use. Organized around three orthogonal concerns:
+Pure functions with no observability dependencies. Visibility is `pub(crate)` — primitives are always wrapped by a Layer
+3 module for public use. Organized around three orthogonal concerns:
 
 | Concern | Purpose | Example question |
 |---------|---------|------------------|
@@ -43,11 +46,15 @@ Pure functions with no observability dependencies. Visibility is `pub(crate)` �
 | `primitives/security/` | THREATS | "Is this dangerous?" |
 | `primitives/identifiers/` | CLASSIFICATION | "What is it? Is it PII?" |
 
-Each concern has sub-domains (paths, network, text, and so on), yielding cells such as `primitives/security/paths/` (path-traversal detection) and `primitives/identifiers/network/` (IP/MAC/URL/UUID classification). Supporting primitive modules: `crypto/`, `io/`, `runtime/`, `types/`.
+Each concern has sub-domains (paths, network, text, and so on), yielding cells such as `primitives/security/paths/`
+(path-traversal detection) and `primitives/identifiers/network/` (IP/MAC/URL/UUID classification). Supporting primitive
+modules: `crypto/`, `io/`, `runtime/`, `types/`.
 
 ### Layer 2: Observe (`crates/octarine/src/observe/`)
 
-Public observability module that depends only on primitives. Submodules include `audit/`, `builder/`, `compliance/` (SOC2, HIPAA, GDPR, PCI-DSS mappings), `context/` (automatic WHO/WHAT/WHEN/WHERE capture), `event/`, `metrics/`, `pii/` (detection and redaction), `problem/`, `tracing/`, and `writers/` (console, file, SQLite, PostgreSQL).
+Public observability module that depends only on primitives. Submodules include `audit/`, `builder/`, `compliance/`
+(SOC2, HIPAA, GDPR, PCI-DSS mappings), `context/` (automatic WHO/WHAT/WHEN/WHERE capture), `event/`, `metrics/`, `pii/`
+(detection and redaction), `problem/`, `tracing/`, and `writers/` (console, file, SQLite, PostgreSQL).
 
 #### Event Flow
 
@@ -73,7 +80,8 @@ Event Sent to Writers
 
 ### Layer 3: Public Operations
 
-Public modules that wrap primitives with observe instrumentation. Every Layer 3 operation emits events and metrics automatically:
+Public modules that wrap primitives with observe instrumentation. Every Layer 3 operation emits events and metrics
+automatically:
 
 - `data/` — normalization and canonicalization (paths, network, text, formats, tokens)
 - `security/` — threat detection and validation (commands, formats, network, paths, queries)
@@ -86,7 +94,8 @@ Public modules that wrap primitives with observe instrumentation. Every Layer 3 
 
 ### Testing Infrastructure (`crates/octarine/src/testing/`, feature-gated)
 
-Shared test fixtures, attack-pattern generators, and security assertions. Compiled only when the `testing` feature is enabled; production code never imports it.
+Shared test fixtures, attack-pattern generators, and security assertions. Compiled only when the `testing` feature is
+enabled; production code never imports it.
 
 ## Key Design Patterns
 

--- a/docs/architecture/testing-patterns.md
+++ b/docs/architecture/testing-patterns.md
@@ -1,6 +1,7 @@
 # Testing Patterns
 
-This document describes octarine's shared test infrastructure and how to use it effectively in both octarine itself and consuming projects.
+This document describes octarine's shared test infrastructure and how to use it effectively in both octarine itself and
+consuming projects.
 
 ## Overview
 

--- a/docs/architecture/visibility-refactor-summary.md
+++ b/docs/architecture/visibility-refactor-summary.md
@@ -2,7 +2,8 @@
 
 ## ✅ Refactor Complete
 
-The async runtime refactor has been completed. The old `async_runtime` module has been replaced with a proper three-layer architecture:
+The async runtime refactor has been completed. The old `async_runtime` module has been replaced with a proper
+three-layer architecture:
 
 ### Architecture Overview
 

--- a/docs/benchmarks/pii-redaction-results.md
+++ b/docs/benchmarks/pii-redaction-results.md
@@ -175,7 +175,8 @@ A few scenarios exceed 100μs but are still acceptable:
 
 **Result**: ✅ **PASS** - PII redaction system meets the \<100μs performance target for all typical use cases.
 
-The system achieves excellent performance while providing comprehensive PII protection. The few edge cases that exceed 100μs (5+ PII types, ProductionStrict) are acceptable trade-offs for security and rare in practice.
+The system achieves excellent performance while providing comprehensive PII protection. The few edge cases that exceed
+100μs (5+ PII types, ProductionStrict) are acceptable trade-offs for security and rare in practice.
 
 **Recommendation**: Deploy PII redaction with confidence for production use.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,4 +113,5 @@ Start with the section index, then drill down to specific topics as needed.
 See [`../CLAUDE.md`](../CLAUDE.md) for contributor and AI-assistant workflow,
 and [`./architecture/testing-patterns.md`](./architecture/testing-patterns.md)
 for testing conventions.
+
 - Review process

--- a/docs/module-quality.md
+++ b/docs/module-quality.md
@@ -1,6 +1,7 @@
 # Module Quality Scorecard & Evaluation Methodology
 
-**Purpose**: This document provides an objective, reproducible methodology for evaluating the quality of Rust security modules. Use this as a quality gate for new modules and for scoring refactored modules.
+**Purpose**: This document provides an objective, reproducible methodology for evaluating the quality of Rust security
+modules. Use this as a quality gate for new modules and for scoring refactored modules.
 
 **Version**: 1.0
 **Date**: 2025-11-10
@@ -505,7 +506,8 @@ For internal modules (marked `pub(crate)` or `pub(super)`):
 - ✅ Show correct usage patterns even if not compilable
 - ❌ Never omit examples just because module is internal
 
-**Why**: Documentation is for developers working on the codebase. Internal APIs need documentation as much as public ones.
+**Why**: Documentation is for developers working on the codebase. Internal APIs need documentation as much as public
+ones.
 
 **Handling Private/Internal Code**:
 
@@ -550,17 +552,21 @@ Check for comprehensive architectural documentation:
 ## Design Decisions
 
 ### Why Three Layers?
+
 1. **Domain files** contain pure business logic for testing
 2. **Builder** provides configuration API without logic
 3. **Shortcuts** offer convenience for common patterns
 
 ### Detection Order Rationale
+
 Credentials checked first because:
+
 - Most security-sensitive
 - Specific patterns (less false positives)
 - Early exit improves performance
 
 ### Module Organization
+
 - `credential.rs` - 15 functions, ~300 LOC (cohesive domain)
 - `characteristic.rs` - 8 functions, ~200 LOC (path properties)
 - Split avoids mixing security checks with general properties
@@ -779,7 +785,8 @@ ______________________________________________________________________
 | **validation/paths** | 12/15 | 9/15 | 2/15 | 8/10 | 7/10 | 9/10 | 8/10 | 10/10 | 4/5 | **69/100** | **D** |
 | **sanitization/paths** | 12/15 | 9/15 | 2/15 | 8/10 | 7/10 | 9/10 | 8/10 | 10/10 | 5/5 | **70/100** | **C** |
 
-**Key Takeaway**: The duplication issue significantly impacts validation and sanitization scores. Creating security_core would bring both modules to B+ grade.
+**Key Takeaway**: The duplication issue significantly impacts validation and sanitization scores. Creating security_core
+would bring both modules to B+ grade.
 
 ______________________________________________________________________
 
@@ -814,4 +821,4 @@ If new quality dimensions emerge:
 
 ______________________________________________________________________
 
-**End of Scorecard**
+End of Scorecard.

--- a/docs/observe/compliance.md
+++ b/docs/observe/compliance.md
@@ -1,6 +1,7 @@
 # Observe Module - Compliance Guide
 
-This guide provides detailed compliance control mapping for the observe module, covering SOC2, HIPAA, GDPR, PCI-DSS, and ISO 27001 requirements.
+This guide provides detailed compliance control mapping for the observe module, covering SOC2, HIPAA, GDPR, PCI-DSS, and
+ISO 27001 requirements.
 
 ## Overview
 

--- a/docs/observe/integration.md
+++ b/docs/observe/integration.md
@@ -1,6 +1,7 @@
 # Observe Module - Integration Guide
 
-This guide covers integrating the observe module with external systems including SIEM platforms, monitoring tools, and custom backends.
+This guide covers integrating the observe module with external systems including SIEM platforms, monitoring tools, and
+custom backends.
 
 ## Overview
 
@@ -95,7 +96,6 @@ may freely `.await` tokio I/O — HTTP clients, file handles, database
 drivers, async channels — and do not need to spawn their own runtime.
 A failure returned from `write` is logged to stderr and does not block
 dispatch to other registered writers.
-
 
 ```rust
 use octarine::observe::writers::{Writer, WriterError, HealthStatus};

--- a/docs/operations/audit-logging.md
+++ b/docs/operations/audit-logging.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-The octarine observe module provides a comprehensive event system for audit logging, compliance, and observability. Events are automatically generated for security-relevant operations, errors, and business activities.
+The octarine observe module provides a comprehensive event system for audit logging, compliance, and observability.
+Events are automatically generated for security-relevant operations, errors, and business activities.
 
 ## Event Categories
 

--- a/docs/patterns/builder-hierarchy-pattern.md
+++ b/docs/patterns/builder-hierarchy-pattern.md
@@ -1,11 +1,13 @@
 # Builder Hierarchy Pattern
 
 > **Related:** This document covers **file organization** and **directory structure** for builders.
-> For the **visibility mechanics** (how `pub`/`pub(super)` cascading works), see [Cascading Visibility Pattern](./cascading-visibility.md).
+> For the **visibility mechanics** (how `pub`/`pub(super)` cascading works), see [Cascading Visibility
+  Pattern](./cascading-visibility.md).
 
 ## Overview
 
-This document defines the standard pattern for organizing builders in a hierarchical module structure. This pattern provides a single, unified API at the root level while keeping internal implementation details encapsulated.
+This document defines the standard pattern for organizing builders in a hierarchical module structure. This pattern
+provides a single, unified API at the root level while keeping internal implementation details encapsulated.
 
 ## Core Principles
 

--- a/docs/patterns/cascading-visibility.md
+++ b/docs/patterns/cascading-visibility.md
@@ -1,7 +1,8 @@
 # Cascading Visibility Pattern
 
 > **Related:** This document explains the **visibility mechanics** of the builder cascade.
-> For **file organization** and **directory structure**, see [Builder Hierarchy Pattern](./builder-hierarchy-pattern.md).
+> For **file organization** and **directory structure**, see [Builder Hierarchy
+  Pattern](./builder-hierarchy-pattern.md).
 
 ## The Problem This Solves
 
@@ -202,7 +203,8 @@ pub(super) use super::identifiers::IdentifierDetector;  // ❌ Can't see it!
 // ERROR: `IdentifierDetector` is private
 ```
 
-**Why it fails:** `pub(super)` makes it visible to the PARENT only, not to SIBLINGS. So `detection/builder/` (a sibling of `identifiers/`) cannot see it.
+**Why it fails:** `pub(super)` makes it visible to the PARENT only, not to SIBLINGS. So `detection/builder/` (a sibling
+of `identifiers/`) cannot see it.
 
 ### ✅ CORRECT: Using `pub` for re-exports
 
@@ -214,7 +216,8 @@ pub use builder::IdentifierDetector;  // ✅ Visible within identifiers/ tree
 pub use super::identifiers::IdentifierDetector;  // ✅ Can access it!
 ```
 
-**Why it works:** `pub` makes it visible within the module tree. Even though the MODULE `identifiers` is `pub(super)`, the RE-EXPORTED items can be `pub`.
+**Why it works:** `pub` makes it visible within the module tree. Even though the MODULE `identifiers` is `pub(super)`,
+the RE-EXPORTED items can be `pub`.
 
 ## Visual Summary
 
@@ -416,6 +419,7 @@ pub struct EventBuilder {
 
 ## Related Patterns
 
-- [Builder Hierarchy Pattern](./builder-hierarchy-pattern.md) - File organization, naming conventions, directory structure
+- [Builder Hierarchy Pattern](./builder-hierarchy-pattern.md) - File organization, naming conventions, directory
+  structure
 - [Module Patterns](../architecture/module-patterns.md) - Three-layer architecture (core/builder/shortcuts)
 - [Refactor Plan](../architecture/refactor-plan.md) - Strategy for migrating to primitives module

--- a/docs/releases/changelog-format.md
+++ b/docs/releases/changelog-format.md
@@ -47,7 +47,7 @@ git history; the operator curates it before push.
 
 ### Other
 
-- summary  # commits without a recognized prefix
+- summary # commits without a recognized prefix
 ```
 
 Sections are emitted in the order above and only appear when they have
@@ -112,6 +112,7 @@ Example of curated output:
 ```
 
 Compared to the raw auto-generated entry, this:
+
 - Combined 5 dependabot bumps into a single bullet
 - Added explicit migration notes for the rand 0.10 break
 - Marked the IdentifierType variant as breaking (it is — exhaustive matches)

--- a/docs/releases/checklist.md
+++ b/docs/releases/checklist.md
@@ -54,6 +54,7 @@ In order:
    - Annotate breaking changes explicitly with **BREAKING:** prefix
    - Remove the `<!-- TODO: review and curate before push -->` marker
 2. **Amend** if you curated:
+
    ```bash
    git add CHANGELOG.md
    git commit --amend --no-edit

--- a/docs/releases/versioning.md
+++ b/docs/releases/versioning.md
@@ -21,7 +21,7 @@ to support across patch releases.
 
 ## Decision tree
 
-```
+```text
 1. Does the change alter the public API or default behavior in a way callers
    could depend on?
    → YES, see step 2

--- a/docs/runtime/metrics-reference.md
+++ b/docs/runtime/metrics-reference.md
@@ -6,7 +6,8 @@
 
 ## Overview
 
-Comprehensive observability for all async runtime infrastructure. Every operation, state transition, and error condition is instrumented with metrics.
+Comprehensive observability for all async runtime infrastructure. Every operation, state transition, and error condition
+is instrumented with metrics.
 
 ## Module Breakdown
 

--- a/docs/runtime/observability-integration.md
+++ b/docs/runtime/observability-integration.md
@@ -1,6 +1,7 @@
 # Async + Observability Integration Project
 
-**Goal**: Integrate runtime and observe modules throughout security/data, following the pattern established in detection module.
+**Goal**: Integrate runtime and observe modules throughout security/data, following the pattern established in detection
+module.
 
 **Status**: In Progress
 **Started**: 2025-11-16
@@ -130,7 +131,8 @@ ______________________________________________________________________
 1. `src/runtime/mod.rs` - Exported `interval` publicly
 1. `src/observe/metrics/async_dispatch.rs` - Removed `use tokio::time::interval`, uses `crate::runtime::interval()`
 1. `src/observe/writers/async_dispatch.rs` - Removed `use tokio::time::interval`, uses `crate::runtime::interval()`
-1. `src/runtime/writer.rs` - Removed `use tokio::time::interval`, uses `crate::runtime::interval()` and `sleep_ms()` in tests
+1. `src/runtime/writer.rs` - Removed `use tokio::time::interval`, uses `crate::runtime::interval()` and `sleep_ms()` in
+   tests
 1. `src/runtime/retry.rs` - Removed `use tokio::time::sleep`, uses `crate::runtime::sleep()`
 1. `src/runtime/circuit_breaker.rs` - Uses `crate::runtime::sleep_ms()` in tests
 1. `src/runtime/worker.rs` - Uses `crate::runtime::sleep_ms()` in tests
@@ -146,8 +148,10 @@ ______________________________________________________________________
 
 **Remaining Direct tokio Usage** (Intentional - Infrastructure Only):
 
-- `observe/metrics/async_dispatch.rs` - Uses `tokio::sync::mpsc`, `tokio::runtime::Builder`, `tokio::select!` (async dispatcher infrastructure)
-- `observe/writers/async_dispatch.rs` - Uses `tokio::sync::mpsc`, `tokio::runtime::Builder`, `tokio::select!` (async dispatcher infrastructure)
+- `observe/metrics/async_dispatch.rs` - Uses `tokio::sync::mpsc`, `tokio::runtime::Builder`, `tokio::select!` (async
+  dispatcher infrastructure)
+- `observe/writers/async_dispatch.rs` - Uses `tokio::sync::mpsc`, `tokio::runtime::Builder`, `tokio::select!` (async
+  dispatcher infrastructure)
 - All files in `runtime/` module - Legitimate implementation of centralized wrappers
 - `#[tokio::test]` attributes - Test harness (cannot be abstracted)
 

--- a/docs/security/patterns/detection-validation-sanitization.md
+++ b/docs/security/patterns/detection-validation-sanitization.md
@@ -185,7 +185,7 @@ ______________________________________________________________________
 
 ### Examples
 
-**Scenario 1: User Uploads File**
+#### Scenario 1: User Uploads File
 
 ```rust
 // Step 1: DETECT potential issues (logging)
@@ -200,7 +200,7 @@ validation::validate_no_traversal(path)?;  // Rejects if unsafe
 let safe_path = sanitization::sanitize_path_strict(path)?;
 ```
 
-**Scenario 2: Security Scanner**
+#### Scenario 2: Security Scanner
 
 ```rust
 // Use DETECTION only - we want to find everything
@@ -213,7 +213,7 @@ let issues = vec![
 generate_security_report(issues);  // Report includes false positives
 ```
 
-**Scenario 3: API Endpoint**
+#### Scenario 3: API Endpoint
 
 ```rust
 // Use VALIDATION only - strict enforcement
@@ -387,7 +387,8 @@ detection.rs  ──→  validation.rs  ──→  sanitization.rs
 
 ### Why Validators Should Use Detectors
 
-**Principle:** Validators should call detection functions FIRST to confirm input format before applying validation rules.
+**Principle:** Validators should call detection functions FIRST to confirm input format before applying validation
+rules.
 
 ```rust
 // ✅ CORRECT: Validator uses detector first
@@ -444,7 +445,9 @@ Some modules have architectural reasons for NOT using detection first:
 
 **Location:** `primitives/identifiers/biometric/validation.rs`
 
-**Reason:** Detection patterns require labels (e.g., "fingerprint: abc123") to avoid false positives with git commit hashes and other hex strings. Validators work on bare application IDs (e.g., "FP-A1B2C3D4"), so detection would always return false.
+**Reason:** Detection patterns require labels (e.g., "fingerprint: abc123") to avoid false positives with git commit
+hashes and other hex strings. Validators work on bare application IDs (e.g., "FP-A1B2C3D4"), so detection would always
+return false.
 
 ```rust
 // Detection layer: Requires labeled format
@@ -459,7 +462,8 @@ validate_fingerprint_id_strict("FP-A1B2C3D4")  // ✅ validates directly
 
 **Location:** `primitives/identifiers/location/validation.rs`
 
-**Reason:** Location validators use the **conversion layer** for format detection instead of the detection layer because:
+**Reason:** Location validators use the **conversion layer** for format detection instead of the detection layer
+because:
 
 - Conversion layer is case-insensitive (UK postcodes, Canadian postal codes)
 - Returns specific format types (`GpsFormat`, `PostalCodeType`) needed for validation
@@ -482,13 +486,15 @@ A comprehensive audit of all 9 identifier modules found:
 | Validators not using detection | ~31 | Fixed in #39-#48 |
 | Documented exceptions | 2 | Biometric, Location |
 
-**Conclusion:** The inheritance arrow is strictly respected. All modules now follow the "validators use detectors" pattern where architecturally appropriate.
+**Conclusion:** The inheritance arrow is strictly respected. All modules now follow the "validators use detectors"
+pattern where architecturally appropriate.
 
 ______________________________________________________________________
 
 ## Conversion Module Patterns
 
-The conversion layer handles **format transformation** and **metadata extraction**. Unlike sanitization (which cleans dangerous input), conversion transforms valid input between formats.
+The conversion layer handles **format transformation** and **metadata extraction**. Unlike sanitization (which cleans
+dangerous input), conversion transforms valid input between formats.
 
 ### Where Conversion Fits in the Inheritance Arrow
 
@@ -518,7 +524,8 @@ ______________________________________________________________________
 
 ### Conversion Return Type Patterns
 
-Unlike validation (which uses `Result<(), Problem>` vs `bool`), conversion uses return types to signal **operation semantics**:
+Unlike validation (which uses `Result<(), Problem>` vs `bool`), conversion uses return types to signal **operation
+semantics**:
 
 | Return Type | When to Use | Semantics |
 |-------------|-------------|-----------|
@@ -552,7 +559,8 @@ pub fn normalize_email(email: &str) -> Result<String, Problem> {
 }
 ```
 
-**Rule**: Return `String` when normalization is pure character stripping (digits_only, uppercase, remove separators). Return `Result<String, Problem>` when normalization requires parsing or validation.
+**Rule**: Return `String` when normalization is pure character stripping (digits_only, uppercase, remove separators).
+Return `Result<String, Problem>` when normalization requires parsing or validation.
 
 ______________________________________________________________________
 
@@ -613,7 +621,8 @@ pub fn extract_jwt_algorithm(token: &str) -> Result<String, Problem> {
 }
 ```
 
-**Rule**: Use `Option` when the component may legitimately not exist in valid input. Use `Result` when extraction requires specific format validation.
+**Rule**: Use `Option` when the component may legitimately not exist in valid input. Use `Result` when extraction
+requires specific format validation.
 
 ______________________________________________________________________
 
@@ -643,7 +652,8 @@ pub fn detect_postal_code_type(input: &str) -> Option<PostalCodeType> {
 }
 ```
 
-**Rule**: Detection functions return `Option<Enum>` to allow for unknown formats. They should NOT return `Result` because an unrecognized format is not an error—it's just unclassified.
+**Rule**: Detection functions return `Option<Enum>` to allow for unknown formats. They should NOT return `Result`
+because an unrecognized format is not an error—it's just unclassified.
 
 ______________________________________________________________________
 
@@ -691,7 +701,8 @@ pub fn normalize_email(email: &str) -> Result<String, Problem> {
 }
 ```
 
-**Exception**: Format detection functions (`detect_*_format()`) may need more sophisticated logic than simple detection. They can implement their own pattern matching when returning rich type information.
+**Exception**: Format detection functions (`detect_*_format()`) may need more sophisticated logic than simple detection.
+They can implement their own pattern matching when returning rich type information.
 
 ______________________________________________________________________
 
@@ -796,7 +807,8 @@ ______________________________________________________________________
 
 ## Test Data Detection Pattern
 
-The `is_test_*` functions help identify test/development/sample data that should be excluded from analytics, treated specially in production, or flagged during security audits.
+The `is_test_*` functions help identify test/development/sample data that should be excluded from analytics, treated
+specially in production, or flagged during security audits.
 
 ### Purpose
 
@@ -921,4 +933,6 @@ ______________________________________________________________________
 
 **Last Updated**: 2025-11-24
 **Status**: Established architectural pattern across all modules
-**Related Issues**: #15 (audit), #20 (conversion patterns), #22 (cache standardization), #23 (test data detection), #39-#48 (module fixes), #49 (cache security)
+**Related Issues**: #15 (audit), #20 (conversion patterns), #22
+(cache standardization), #23 (test data detection), #39-#48
+(module fixes), #49 (cache security)

--- a/docs/security/patterns/input-architecture.md
+++ b/docs/security/patterns/input-architecture.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-The security input module provides a unified, secure API for all input handling in octarine. It implements defense-in-depth through multiple layers of validation, sanitization, and type safety.
+The security input module provides a unified, secure API for all input handling in octarine. It implements
+defense-in-depth through multiple layers of validation, sanitization, and type safety.
 
 ## Core Principles
 

--- a/docs/security/patterns/zero-trust.md
+++ b/docs/security/patterns/zero-trust.md
@@ -2,7 +2,8 @@
 
 ## Core Principle
 
-"Never Trust, Always Verify, Assume Breach" - Every input source is untrusted by default, including internal systems and secure vaults.
+"Never Trust, Always Verify, Assume Breach" - Every input source is untrusted by default, including internal systems and
+secure vaults.
 
 ## Trust Boundaries
 

--- a/docs/security/security-guidelines.md
+++ b/docs/security/security-guidelines.md
@@ -2,7 +2,8 @@
 
 > **For vulnerability reporting and security policy**, see [SECURITY.md](../../SECURITY.md) in the repository root.
 
-This document outlines critical security principles and anti-patterns discovered during development of the octarine security library.
+This document outlines critical security principles and anti-patterns discovered during development of the octarine
+security library.
 
 ## Table of Contents
 

--- a/docs/tasks/primitives-future-integrations.md
+++ b/docs/tasks/primitives-future-integrations.md
@@ -6,7 +6,8 @@ Ideas for leveraging `primitives/common` (RingBuffer, LruCache) that require mor
 
 **Location:** `src/observe/metrics/aggregation/mod.rs:62-83`
 
-**Current Issue:** `snapshot()` creates full clones of all metrics every call, which is expensive for high-frequency exports.
+**Current Issue:** `snapshot()` creates full clones of all metrics every call, which is expensive for high-frequency
+exports.
 
 **Proposed Solution:** Use LruCache to cache recent snapshots with short TTL (1-5 seconds).
 
@@ -25,7 +26,8 @@ ______________________________________________________________________
 
 **Location:** `src/observe/context/capture.rs:96-100`
 
-**Current Issue:** Generates new `Uuid::new_v4()` per event, which is expensive (allocation + randomness). Code already notes: "can be expensive, future optimization".
+**Current Issue:** Generates new `Uuid::new_v4()` per event, which is expensive (allocation + randomness). Code already
+notes: "can be expensive, future optimization".
 
 **Proposed Solution:** Cache correlation IDs per request scope using task-local storage + LruCache.
 
@@ -38,7 +40,8 @@ ______________________________________________________________________
 
 **Benefit:** Reduce UUID allocations, enable proper distributed tracing.
 
-**Related Work:** This ties into the broader observability story - may want to design alongside OpenTelemetry integration.
+**Related Work:** This ties into the broader observability story - may want to design alongside OpenTelemetry
+integration.
 
 ______________________________________________________________________
 
@@ -48,7 +51,8 @@ ______________________________________________________________________
 
 **Current State:** Feature flags are loaded once at startup from environment variables into a static HashMap.
 
-**Why Not Applicable Now:** LruCache only makes sense if flags are dynamically fetched from a service with TTL-based refresh. Current design is static.
+**Why Not Applicable Now:** LruCache only makes sense if flags are dynamically fetched from a service with TTL-based
+refresh. Current design is static.
 
 **Future Consideration:** If we add a feature flag service integration:
 
@@ -66,7 +70,8 @@ ______________________________________________________________________
 
 ## Implementation Notes
 
-These items were identified during Phase 2.1 of the primitives migration. They represent opportunities to leverage the new `primitives/common` module but require architectural decisions beyond simple refactoring.
+These items were identified during Phase 2.1 of the primitives migration. They represent opportunities to leverage the
+new `primitives/common` module but require architectural decisions beyond simple refactoring.
 
 When ready to implement:
 

--- a/docs/type-safety-improvements.md
+++ b/docs/type-safety-improvements.md
@@ -2,9 +2,11 @@
 
 ## Overview
 
-This document tracks opportunities to improve compile-time safety in the observe module by replacing string-based fields with validated newtype wrappers, following the pattern established in the FileWriter refactoring.
+This document tracks opportunities to improve compile-time safety in the observe module by replacing string-based fields
+with validated newtype wrappers, following the pattern established in the FileWriter refactoring.
 
-**Pattern**: Use newtype wrappers + builder pattern to move validation from runtime to compile-time, preventing invalid configurations from being created in the first place.
+**Pattern**: Use newtype wrappers + builder pattern to move validation from runtime to compile-time, preventing invalid
+configurations from being created in the first place.
 
 **Benefits**:
 
@@ -529,7 +531,7 @@ ______________________________________________________________________
 
 Based on MetricName success, apply same pattern to remaining priorities:
 
-**Week 1: Identity Types**
+#### Week 1: Identity Types
 
 1. ✅ MetricName, MetricLabel - COMPLETE
 1. Implement `TenantId`, `UserId` (Priority 2)
@@ -537,14 +539,14 @@ Based on MetricName success, apply same pattern to remaining priorities:
    - Compiler finds all call sites
    - ~1-2 hours estimated
 
-**Week 2: Event System Types**
+#### Week 2: Event System Types
 
 1. Implement `OperationName` (Priority 3)
 1. Implement `ResourceType`, `ResourceId` (Priority 4)
    - Each as separate atomic commits
    - ~1 hour per type estimated
 
-**Week 3: Testing & Documentation**
+#### Week 3: Testing & Documentation
 
 1. Add integration tests for all new types
 1. Update documentation with examples

--- a/justfile
+++ b/justfile
@@ -149,6 +149,14 @@ lint-docker:
         echo "$files" | xargs hadolint
     fi
 
+# Lint Markdown with rumdl (config: .rumdl.toml; submodule excluded there)
+lint-md:
+    rumdl check .
+
+# Format Markdown with rumdl (writes; review diff before committing)
+fmt-md:
+    rumdl fmt .
+
 # Lint a commit message against the conform policy (default: HEAD's message)
 commit-lint FILE='.git/COMMIT_EDITMSG':
     conform enforce --commit-msg-file {{FILE}}
@@ -159,8 +167,8 @@ commit-lint-branch:
 
 # ─── Pre-flight (run before push / PR) ──────────────────────────────────────
 
-# Full pre-push validation: fmt, clippy, shellcheck, lint-docker, spell, arch-check, tests
-preflight: fmt-check fmt-data-check fmt-sh-check clippy shellcheck lint-docker spell arch-check test
+# Full pre-push validation: fmt, clippy, shellcheck, lint-docker, lint-md, spell, arch-check, tests
+preflight: fmt-check fmt-data-check fmt-sh-check clippy shellcheck lint-docker lint-md spell arch-check test
 
 # Everything including perf tests (run before releases)
 preflight-full: preflight test-perf

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -127,6 +127,20 @@ pre-commit:
         - run: "! command -v hadolint >/dev/null 2>&1"
       run: hadolint {staged_files}
 
+    # --- Markdown linting (rumdl) ---
+
+    rumdl:
+      glob: "*.md"
+      exclude:
+        - "CHANGELOG.md"
+      # rumdl is shipped by the containers dev-tools feature; skip
+      # gracefully if running outside a dev-tools container — CI is the
+      # safety net. Lint-only; format via `just fmt-md` and review the
+      # diff (rumdl fmt has aggressive rewrites on nested code fences).
+      skip:
+        - run: "! command -v rumdl >/dev/null 2>&1"
+      run: rumdl check {staged_files}
+
     # --- Architecture enforcement ---
 
     arch-check:


### PR DESCRIPTION
## Summary

Adopt rumdl (Rust, single binary) as the canonical Markdown linter/formatter, following the same tooling-adoption pattern as #360 (shfmt), #359 (hadolint), #357 (conform), and #356 (typos). Containers v4.19.0 already ships rumdl at `/usr/local/bin/rumdl`, so no submodule bump is needed.

Two commits, designed to review independently:

1. **`3931430` — infrastructure**: `.rumdl.toml` config (forked from `containers/.rumdl.toml`), `lint-md` / `fmt-md` justfile recipes, lefthook pre-commit hook (lint-only; format via `just fmt-md`), CI job pinned to `v0.1.91` to match `RUMDL_VERSION` in `containers/lib/features/dev-tools.sh`.
2. **`131ddd1` — one-time reformat**: applied `rumdl fmt .` followed by hand-wrapped MD013 prose lines and targeted fixes for MD036 (emphasis-as-heading) / MD029 (ordered list numbering) / MD018 (lines starting with `#N` interpreted as headings). Net: 233 findings → 0.

### Key decisions

- **Excluded `containers/**`** in `.rumdl.toml` since the submodule has its own `.rumdl.toml` and its own CI gate — double-linting would duplicate effort and could conflict.
- **Hook is lint-only**, not fmt-on-stage. Per the containers team's note (`containers/lefthook.yml:89-100`), `rumdl fmt` has aggressive rewrites that misfire on nested code fences. Users opt into formatting via `just fmt-md` and review the diff.
- **`[per-file-ignores]` for `.claude/{memory,skills,agents}/**`** disables MD013 there — those files carry by-design long YAML frontmatter `description` fields that drive Claude skill discovery and memory search.
- **Pinned CI version to `0.1.91`** so dev-container hook and CI run identical binaries (same pattern as hadolint #359).

## Test plan

- [x] `just lint-md` returns 0 issues across 76 files
- [x] `just fmt-md` is idempotent (no changes on repeat run)
- [x] lefthook `rumdl` hook fires on staged `*.md` (`Success: No issues found in 56 files` during commit 2)
- [x] `preflight` chain includes `lint-md`
- [x] Pre-push hook (clippy + workspace tests) green
- [ ] CI: the new "Rumdl" job runs and passes
- [ ] CI: existing jobs (Shfmt, Hadolint, Typos, Dprint, Commit Lint, Test, Analyze) remain green

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)