### PR TITLE
refactor(runtime): use FileMode::PRIVATE constant in with_secure_file

### DIFF
--- a/crates/octarine/src/runtime/config/builder.rs
+++ b/crates/octarine/src/runtime/config/builder.rs
@@ -253,6 +253,8 @@ impl ConfigBuilder {
     pub fn with_secure_file(mut self, path: impl AsRef<Path>) -> Result<Self, ConfigError> {
         use std::os::unix::fs::PermissionsExt;
 
+        use crate::primitives::io::file::FileMode;
+
         let path = path.as_ref();
         if !path.exists() {
             return Err(ConfigError::file_error(path, "file not found"));
@@ -262,7 +264,7 @@ impl ConfigBuilder {
         let metadata =
             std::fs::metadata(path).map_err(|e| ConfigError::file_error(path, e.to_string()))?;
         let mode = metadata.permissions().mode() & 0o777;
-        if mode != 0o600 {
+        if mode != FileMode::PRIVATE.as_raw() {
             return Err(ConfigError::insecure_permissions(
                 path,
                 "0600 (owner read/write only)",


### PR DESCRIPTION
## Summary

- Replace the inline `0o600` literal at `crates/octarine/src/runtime/config/builder.rs:265` with `FileMode::PRIVATE.as_raw()`.
- The named constant `FileMode::PRIVATE` already exists at `primitives/io/file/permissions.rs:61` and is the canonical owner-only mode for sensitive configuration files — no new constant introduced.
- Import is scoped inside the `#[cfg(unix)]` `with_secure_file` body alongside the existing `PermissionsExt` import, so Windows builds are unaffected.

## Test plan

- [x] `just fmt-check` — clean
- [x] `just arch-check` — clean (Layer 3 → Layer 1 dependency direction is valid)
- [x] `just clippy` — no warnings
- [x] `just test-mod runtime::config` — 69 passed, 0 failed (`with_secure_file` test at builder.rs:1230+ exercises the changed predicate against a 0o600 temp file)
- [x] Pre-push hooks: full workspace clippy + test suite green

Closes #76