### PR TITLE
docs(auth): remove stale "coming soon" markers from lib.rs

### DIFF
--- a/crates/octarine/src/lib.rs
+++ b/crates/octarine/src/lib.rs
@@ -230,11 +230,14 @@ pub mod http;
 /// # Features
 ///
 /// - Password policy validation with zxcvbn strength checking
-/// - Session management with binding and timeouts (coming soon)
-/// - Account lockout with exponential backoff (coming soon)
-/// - CSRF protection (coming soon)
-/// - TOTP/MFA support (`auth-totp` feature, coming soon)
-/// - HIBP breach checking (`auth-hibp` feature, coming soon)
+/// - Session management with binding, idle and absolute timeouts (V3)
+/// - Account lockout with exponential backoff (V2.2)
+/// - CSRF protection with token-based mitigation (V3.4)
+/// - Password reset flow with rate limiting (V2.5)
+/// - Remember-me tokens with selector:validator split (V3.5)
+/// - Constant-time responses to prevent account enumeration (V2.9.1)
+/// - TOTP/MFA support (`auth-totp` feature)
+/// - HIBP breach checking via k-anonymity (`auth-hibp` feature)
 ///
 /// # Quick Start
 ///


### PR DESCRIPTION
## Summary
- The crate-root `lib.rs` auth blurb advertised five features as "(coming soon)" — all of them have shipped under `src/auth/` and are mapped to OWASP ASVS controls in `auth/mod.rs`.
- Replace the stale list with an accurate one mirroring `auth/mod.rs:7-16`, and add the previously-omitted `reset`, `remember`, and `timing` features.
- Doc-only change; no API impact.

## Test plan
- [x] `just clippy` — clean
- [x] `cargo doc -p octarine` — no new warnings in `lib.rs`
- [x] `just test-filter` doc/auth tests pass
- [x] `grep "coming soon" crates/octarine/src/lib.rs` returns no hits

Closes #73