### PR TITLE
chore(ci): align remaining jobs to just recipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
         with:
           toolchain: "1.94"
           components: rustfmt
-      - run: cargo fmt --all -- --check
+      - uses: taiki-e/install-action@just
+      - run: just fmt-check
 
   dprint:
     name: Dprint
@@ -57,6 +58,15 @@ jobs:
           tool: shfmt
       - uses: taiki-e/install-action@just
       - run: just fmt-sh-check
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
+      - run: just shellcheck
 
   typos:
     name: Typos
@@ -193,9 +203,8 @@ jobs:
         with:
           toolchain: "1.94"
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc --workspace --no-deps --all-features
-        env:
-          RUSTDOCFLAGS: -D warnings
+      - uses: taiki-e/install-action@just
+      - run: just doc
 
   audit:
     name: Cargo Audit
@@ -276,7 +285,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: windows
-      - run: cargo check --workspace --all-features
+      - uses: taiki-e/install-action@just
+      - run: just check
 
   check-macos:
     name: Check (macOS)
@@ -316,7 +326,8 @@ jobs:
           # only caused breakage on macOS. The toolchain itself lives in
           # ~/.rustup/toolchains and is reinstalled by dtolnay each run.
           cache-bin: false
-      - run: cargo check --workspace --all-features
+      - uses: taiki-e/install-action@just
+      - run: just check
 
   test-nightly:
     name: Test (nightly)

--- a/justfile
+++ b/justfile
@@ -8,13 +8,17 @@ default: check clippy test
 
 # ─── Build & Check ───────────────────────────────────────────────────────────
 
-# Type-check the workspace
+# Type-check the workspace (matches CI flag set — see check-windows / check-macos)
 check:
-    cargo check --workspace
+    cargo check --workspace --all-features
 
 # Build the workspace
 build:
     cargo build --workspace
+
+# Generate rustdoc with warnings denied (matches CI doc job)
+doc:
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
 
 # ─── Lint ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Swap `fmt`, `doc`, `check-windows`, `check-macos` to `just` recipes via `taiki-e/install-action@just`, matching the pattern adopted in #246 for Dprint.
- Add a new `shellcheck` CI job so shell-script linting runs in CI, not only as part of local `just preflight`.
- Justfile: expand `just check` to `--all-features` (matching the cross-platform CI jobs); add a new `just doc` recipe wrapping `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`.

This closes the last remaining tooling-drift gaps between `just preflight` and CI — contributors running preflight locally now exercise the exact same invocations CI does, and recipe edits propagate to CI automatically.

The macOS cache-poisoning mitigations (`shared-key: macos-v2`, `cache-bin: false`, the `Ensure \$CARGO_HOME/bin on PATH` step, and the cargo-resolves-to-toolchain verification) are preserved as-is.

## Test plan

- [x] `just check` — runs `cargo check --workspace --all-features` (12.3s, clean)
- [x] `just doc` — runs with `RUSTDOCFLAGS=-D warnings`, no doc warnings (16.4s, clean)
- [x] `just fmt-check` — unchanged, passes
- [x] `just shellcheck` — no-op as expected ("no shell scripts to lint")
- [x] `just arch-check` — exit 0
- [x] `actionlint .github/workflows/ci.yml` — OK
- [x] `just test` — 242 + 184 doctests pass
- [ ] CI green on this PR (will verify after push)

Closes #353