### PR TITLE
chore(tooling): adopt cargo-machete for unused-dependency detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,16 @@ jobs:
       - uses: taiki-e/install-action@just
       - run: just lint-md
 
+  machete:
+    name: Machete
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-machete
+      - uses: taiki-e/install-action@just
+      - run: just lint-deps
+
   commit-lint:
     name: Commit Lint
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,25 @@ Project config: `bacon.toml`. The `check` / `clippy` / `test` jobs use the
 same flag set as `just check` / `just clippy` / `just test`, so bacon
 output matches `just preflight` and CI.
 
+### Dependency hygiene
+
+[cargo-machete](https://github.com/bnjbvr/cargo-machete) flags unused
+dependencies on every CI run and on pre-commit when `Cargo.toml` changes.
+Pre-installed in the devcontainer via `INCLUDE_RUST_DEV`. Run locally:
+
+```bash
+just lint-deps
+```
+
+If machete flags a dependency you intentionally keep (e.g., a feature-gated
+re-export used only at the boundary), document it with a
+`[package.metadata.cargo-machete]` entry in the relevant `Cargo.toml`:
+
+```toml
+[package.metadata.cargo-machete]
+ignored = ["some-dep"]   # why it's kept
+```
+
 ## SemVer Policy
 
 octarine is a foundational library. Downstream crates depend on a stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,12 +2242,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "ipnetwork"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,9 +2759,7 @@ dependencies = [
  "http",
  "http-body-util",
  "indicatif",
- "ipnetwork",
  "jsonwebtoken",
- "keccak",
  "lazy_static",
  "libc",
  "local-ip-address",
@@ -2781,7 +2773,6 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "pem",
- "pkcs8 0.11.0",
  "predicates",
  "pretty_assertions",
  "proptest",
@@ -2793,7 +2784,6 @@ dependencies = [
  "reqwest",
  "rexpect",
  "rstest",
- "secrecy",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2820,7 +2810,6 @@ dependencies = [
  "unicode-security",
  "url",
  "uuid",
- "which",
  "wiremock",
  "x25519-dalek",
  "x509-parser",
@@ -4008,15 +3997,6 @@ dependencies = [
  "generic-array",
  "pkcs8 0.10.2",
  "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
  "zeroize",
 ]
 
@@ -5550,15 +5530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -36,7 +36,6 @@ unicode-security = "0.1"
 
 # URL and network validation
 url = { workspace = true }
-ipnetwork = "0.21"
 
 # Unique identifiers
 uuid = { workspace = true }
@@ -45,9 +44,7 @@ uuid = { workspace = true }
 base64 = "0.22"
 sha2 = "0.11"
 sha3 = "0.11"
-keccak = "0.2"
 hex = "0.4"
-secrecy = "0.10"
 zeroize = { version = "1.8", features = ["derive"] }
 chacha20poly1305 = "0.10.1"
 aes-gcm = "0.10.3"
@@ -68,9 +65,6 @@ console = { version = "0.16.2", optional = true }
 # CLI framework (optional)
 clap = { workspace = true, optional = true }
 indicatif = { version = "0.18", optional = true }
-
-# File and path operations
-which = "8.0"
 
 # Shell command safety (for process module)
 xshell = "0.2"
@@ -152,7 +146,6 @@ serde_yaml = { version = "0.9", optional = true }
 pem = { version = "3.0", optional = true }
 x509-parser = { version = "0.18", optional = true }
 ssh-key = { version = "0.6", optional = true }
-pkcs8 = { version = "0.11", optional = true }
 
 # Testing infrastructure (optional)
 proptest = { version = "1.4", optional = true }
@@ -199,7 +192,7 @@ auth = ["http", "dep:jsonwebtoken", "dep:zxcvbn"]
 auth-hibp = ["auth", "dep:sha1"]
 auth-totp = ["auth", "dep:totp-rs"]
 auth-full = ["auth-hibp", "auth-totp"]
-crypto-validation = ["dep:pem", "dep:x509-parser", "dep:ssh-key", "dep:pkcs8"]
+crypto-validation = ["dep:pem", "dep:x509-parser", "dep:ssh-key"]
 shell = []
 testing = [
     "dep:proptest",

--- a/justfile
+++ b/justfile
@@ -199,8 +199,8 @@ commit-lint-branch:
 
 # ─── Pre-flight (run before push / PR) ──────────────────────────────────────
 
-# Full pre-push validation: fmt, clippy, shellcheck, lint-docker, lint-md, spell, arch-check, tests
-preflight: fmt-check fmt-data-check fmt-sh-check clippy shellcheck lint-docker lint-md spell arch-check test
+# Full pre-push validation: fmt, clippy, shellcheck, lint-docker, lint-md, lint-deps, spell, arch-check, tests
+preflight: fmt-check fmt-data-check fmt-sh-check clippy shellcheck lint-docker lint-md lint-deps spell arch-check test
 
 # Everything including perf tests (run before releases)
 preflight-full: preflight test-perf
@@ -230,6 +230,13 @@ deps-osv:
 
 # Full dependency health check: audit + deny + osv + outdated
 deps-check: deps-audit deps-deny deps-osv deps-outdated
+
+# Detect unused workspace dependencies. Scopes to our crates only so the
+# containers submodule's Cargo.toml files (and any future workspace
+# additions) don't surface false positives. Exit 0 = clean; exit 1 =
+# unused deps found.
+lint-deps:
+    cargo machete --skip-target-dir crates/octarine crates/octarine-derive crates/octarine-problem
 
 # ─── Utilities ───────────────────────────────────────────────────────────────
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -98,6 +98,18 @@ pre-commit:
       glob: "*.rs"
       run: cargo fmt --all --
 
+    # --- Cargo dependency hygiene ---
+
+    cargo-machete:
+      glob: "**/Cargo.toml"
+      # cargo-machete is shipped by INCLUDE_RUST_DEV; skip gracefully
+      # outside that container — CI is the safety net. A Cargo.toml change
+      # may surface unused deps anywhere in the workspace, so the run:
+      # command scopes to all our crates rather than just {staged_files}.
+      skip:
+        - run: "! command -v cargo-machete >/dev/null 2>&1"
+      run: cargo machete --skip-target-dir crates/octarine crates/octarine-derive crates/octarine-problem
+
     # --- JSON/YAML formatting (dprint) ---
 
     dprint:


### PR DESCRIPTION
## Summary

Add cargo-machete as a CI gate, lefthook pre-commit hook, and `just lint-deps` recipe. First-pass cleanup removed **5 genuinely-unused deps** from `crates/octarine/Cargo.toml`, verified via grep (zero `use {dep}::` matches across the source tree for any of them):

| Dep | Why it's safe to remove |
|---|---|
| `ipnetwork` | No `use ipnetwork::` anywhere |
| `keccak` | `sha3` crate already handles Keccak; standalone `keccak` crate unused |
| `secrecy` | Project rolls its own secret types under `crypto::secrets/` |
| `which` | Not imported anywhere; the word `which` appears only as English in comments |
| `pkcs8` | Optional, gated by `crypto-validation` feature, but no code under `crypto::validation/` actually imports it |

### Breaking (pre-1.0)

Removed `pkcs8` from the `crypto-validation` feature list. Downstream consumers enabling `crypto-validation` no longer get `pkcs8` transitively. Project is on `0.x`; per the pre-1.0 policy, breaking renames are preferred over deprecation aliases.

### New surface

- **`just lint-deps`** runs `cargo machete --skip-target-dir` scoped to `crates/octarine`, `crates/octarine-derive`, `crates/octarine-problem` (skips the containers submodule).
- **New `Machete` CI job** runs `just lint-deps` on every push and PR (excluded from the schedule cron).
- **New lefthook `cargo-machete` pre-commit hook** fires on `**/Cargo.toml` changes, with `skip-when-missing` for non-devcontainer contributors.
- **`just preflight`** now includes `lint-deps` between `lint-md` and `spell`.
- **`CONTRIBUTING.md`** gains a "Dependency hygiene" subsection documenting the workflow and the `[package.metadata.cargo-machete] ignored = [...]` escape hatch.

## Test plan

- [x] `cargo machete --skip-target-dir crates/octarine crates/octarine-derive crates/octarine-problem` → "didn't find any unused dependencies" for all 3 crates
- [x] `cargo check --workspace --all-features` → clean after the 5 dep removals
- [x] `just lint-deps` → exit 0
- [x] `just preflight` includes lint-deps as expected
- [x] `actionlint .github/workflows/ci.yml` → OK
- [x] `just lint-md` → 76 files clean
- [x] `just arch-check` → exit 0
- [x] `taplo` (pre-commit) validates the modified Cargo.toml
- [x] **The new `cargo-machete` pre-commit hook self-validated on this very commit** — it fired during `git commit` and passed
- [x] Full local lefthook pre-push: `cargo clippy` (33s) + `cargo test` (102s) — both green
- [ ] CI green on this PR — especially the new `Machete` job

Closes #260