### PR TITLE
chore(tooling): adopt cargo-nextest for test runs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,28 @@
+# Octarine nextest configuration.
+# Reference: https://nexte.st/docs/configuration/reference/
+
+[profile.default]
+# Surface failures immediately, then a final summary. The built-in "final"
+# default hides failures until the run ends — annoying during long local runs.
+failure-output = "immediate-final"
+success-output = "never"
+status-level = "pass"
+# Anything taking longer than 60s gets a warning; terminate after three slow
+# intervals (180s total). The repo's slowest integration tests sit at 5–10s,
+# so 60s catches genuine pathologies without spamming on large fixtures.
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+[profile.ci]
+# Inherits default thresholds; overrides only the CI-relevant knobs.
+failure-output = "immediate-final"
+status-level = "fail"
+# Two retries with exponential backoff. Flaky tests (network, timing) pass
+# on retry; consistently broken tests still fail after three attempts.
+retries = { backoff = "exponential", count = 2, delay = "1s", jitter = true }
+# Run every test even after failures so the JUnit report is complete.
+fail-fast = false
+
+[profile.ci.junit]
+# Resolves to target/nextest/ci/junit.xml.
+path = "junit.xml"
+report-name = "octarine"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -11,6 +11,16 @@ command -v lefthook >/dev/null || {
   exit 1
 }
 
+# .cargo/config.toml sets linker = "clang" + -fuse-ld=mold for Linux. mold
+# ships with the containers submodule's rust-dev feature; clang does not
+# (only libclang-dev for bindgen), so install it explicitly. Without this,
+# `cargo test` and rustdoc fail to link.
+if ! command -v clang >/dev/null; then
+  echo "==> Installing clang (needed by .cargo/config.toml linker setting)..."
+  sudo apt-get update -qq
+  sudo apt-get install -y --no-install-recommends clang
+fi
+
 echo "==> Warming cargo cache..."
 cargo fetch --manifest-path /workspace/octarine/Cargo.toml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,20 @@ jobs:
         with:
           toolchain: "1.94"
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-nextest
       - uses: taiki-e/install-action@just
-      - run: just test
+      - name: Run nextest (ci profile)
+        run: cargo nextest run --workspace --all-features --build-jobs 4 --profile ci
+      - name: Run doctests
+        run: cargo test --workspace --all-features --doc -j4
+      - name: Upload JUnit XML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-xml
+          path: target/nextest/ci/junit.xml
+          if-no-files-found: error
+          retention-days: 30
 
   coverage:
     name: Coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,9 +308,15 @@ The `testing/` module provides:
 (`--all-features`, `-j4`, etc.) across agents, CI, and human developers. Raw
 commands can miss feature-gated code or use wrong flags.
 
+Tests run under [`cargo-nextest`](https://nexte.st/) (process-per-test isolation,
+retry support, JUnit output). Doctests still run via `cargo test --doc` because
+nextest cannot drive them. `just test` runs both.
+
 ```bash
-just test                                 # All workspace tests
-just test-octarine                        # Octarine crate only
+just test                                 # nextest + doctests (full workspace)
+just test-nextest                         # nextest only (skip doctests)
+just test-docs                            # doctests only
+just test-octarine                        # Octarine crate only (nextest)
 just test-mod "module::path"              # Unit tests by module path (e.g., "correlation::proximity")
 just test-filter PATTERN                  # Filter by test name across workspace
 just test-verbose                         # All tests with output visible
@@ -336,7 +342,9 @@ assertions under CI coverage. Run them manually before releases:
 just test-perf
 ```
 
-See `docs/architecture/testing-patterns.md` for thresholds and details.
+Other timing-sensitive tests get two retries on CI (via nextest's `ci` profile)
+so transient runner contention does not block PRs. See
+`docs/architecture/testing-patterns.md` for thresholds and details.
 
 ## Common Patterns
 

--- a/justfile
+++ b/justfile
@@ -65,38 +65,48 @@ semver-check:
 
 # ─── Test ────────────────────────────────────────────────────────────────────
 
-# Run all workspace tests (all features — matches `just clippy`)
-test:
-    cargo test --workspace --all-features -j4
+# Run all workspace tests + doctests (all features — matches `just clippy`).
+# Tests run under cargo-nextest; doctests run via `cargo test --doc` because
+# nextest cannot drive doctests.
+test: test-nextest test-docs
+
+# Run nextest-managed tests (everything except doctests)
+test-nextest:
+    cargo nextest run --workspace --all-features --build-jobs 4
+
+# Run doctests via cargo (nextest cannot run doctests)
+test-docs:
+    cargo test --workspace --all-features --doc -j4
 
 # Run tests with output visible
 test-verbose:
-    cargo test --workspace --all-features -j4 -- --nocapture
+    cargo nextest run --workspace --all-features --build-jobs 4 --no-capture
 
 # Run tests for the octarine crate only
 test-octarine:
-    cargo test -p octarine --all-features -j4
+    cargo nextest run -p octarine --all-features --build-jobs 4
 
-# Run performance/timing tests (ignored by default, run before releases)
+# Run performance/timing tests (ignored by default, run before releases).
+# Filterset unions three regex patterns matched against the prior cargo
+# substring filters, in a single nextest invocation.
 test-perf:
-    cargo test -p octarine --all-features -j4 test_perf_ -- --ignored
-    cargo test -p octarine --all-features -j4 test_adversarial_ -- --ignored
-    cargo test -p octarine --all-features -j4 test_batch_processor_time_flush -- --ignored
+    cargo nextest run -p octarine --all-features --build-jobs 4 --run-ignored ignored-only \
+        -E 'test(/^test_perf_/) + test(/^test_adversarial_/) + test(test_batch_processor_time_flush)'
 
 # Run tests with the testing feature enabled (kept for explicit minimal-feature runs)
 test-with-fixtures:
-    cargo test -p octarine -j4 --features testing
+    cargo nextest run -p octarine --build-jobs 4 --features testing
 
 # Run a specific test by name pattern
 test-filter PATTERN:
-    cargo test --workspace --all-features -j4 -- {{PATTERN}}
+    cargo nextest run --workspace --all-features --build-jobs 4 -E 'test(/{{PATTERN}}/)'
 
 # Run lib unit tests in octarine by module path, optionally enabling features.
 # Examples:
 #   just test-mod correlation::proximity
 #   just test-mod observe::writers::database sqlite,postgres
 test-mod PATTERN FEATURES='':
-    cargo test -p octarine --lib -j4 --features "{{FEATURES}}" -- {{PATTERN}}
+    cargo nextest run -p octarine --lib --build-jobs 4 --features "{{FEATURES}}" -E 'test(/{{PATTERN}}/)'
 
 # ─── Coverage ────────────────────────────────────────────────────────────────
 
@@ -253,7 +263,7 @@ test-count:
     #!/usr/bin/env bash
     set -euo pipefail
     echo "Counting tests..."
-    count=$(cargo test --workspace -j4 -- --list 2>&1 | grep -c ': test$')
+    count=$(cargo nextest list --workspace --all-features 2>&1 | /usr/bin/grep -cE '^\s+[A-Za-z]' || true)
     echo "$count tests found"
 
 # ─── Release ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Migrate `just test*` recipes and the CI `test` job from `cargo test` to `cargo nextest run` — process-per-test isolation, retry support for flaky tests, and JUnit XML output for CI.
- Add `.config/nextest.toml` with `default` (local) and `ci` profiles. The `ci` profile retries twice with exponential backoff and emits JUnit XML at `target/nextest/ci/junit.xml`.
- `just test` now chains `test-nextest` and `test-docs` because nextest cannot drive doctests. `test-perf` collapses three `cargo test` invocations into one nextest filterset.
- CI `test` job installs `cargo-nextest`, runs the `ci` profile, and uploads the JUnit XML as a workflow artifact. Doctests still run via `cargo test --doc`.
- Drive-by: install `clang` in the devcontainer `post-create.sh`. `.cargo/config.toml` sets `linker = "clang"` but the containers submodule's rust-dev feature only ships `libclang-dev` and `mold`, not the compiler. Discovered while shipping this PR.

CI partitioning is intentionally deferred — the `test` job runs in ~290s; sharding adds orchestration cost without a meaningful wall-clock win. The `ci` profile reads `--partition` cleanly when we need it.

## Test plan

- [x] `cargo nextest show-config test-groups --profile {default,ci}` parses both profiles cleanly
- [x] `just --list` lists `test-nextest`, `test-docs`, plus the migrated recipes
- [x] `just fmt-check`, `just fmt-data-check`, `just arch-check`, `just lint-md`, `just spell`, `shellcheck`, `shfmt` all pass locally
- [x] Pre-push hooks (`cargo clippy --workspace --all-targets --all-features -- -D warnings` + `cargo test --workspace`) pass with `clang` installed
- [ ] CI: `Test` job runs nextest banner output, doctests pass, `junit-xml` artifact uploads
- [ ] CI: wall-clock time neutral or improved vs prior ~290s `cargo test` run

Closes #259