### PR TITLE
chore(tooling): adopt actionlint for GitHub Actions workflow linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,26 @@ jobs:
       - uses: taiki-e/install-action@just
       - run: just lint-md
 
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install actionlint
+        # No taiki-e/install-action recipe yet; install the static
+        # Linux binary directly. Pinned to v1.7.12 to match the
+        # version shipped by containers v4.19.2's dev-tools feature
+        # so the dev-container hook and CI run identical binaries.
+        # shellcheck is preinstalled on ubuntu-latest runners.
+        run: |
+          version=1.7.12
+          url="https://github.com/rhysd/actionlint/releases/download/v${version}/actionlint_${version}_linux_amd64.tar.gz"
+          curl -fsSL "$url" | sudo tar -xz -C /usr/local/bin actionlint
+          actionlint -version
+      - uses: taiki-e/install-action@just
+      - run: just lint-workflows
+
   machete:
     name: Machete
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -199,6 +199,10 @@ lint-md:
 fmt-md:
     rumdl fmt .
 
+# Lint GitHub Actions workflows with actionlint (embedded shellcheck at warning severity)
+lint-workflows:
+    actionlint -shellcheck "shellcheck --severity=warning"
+
 # Lint a commit message against the conform policy (default: HEAD's message)
 commit-lint FILE='.git/COMMIT_EDITMSG':
     conform enforce --commit-msg-file {{FILE}}
@@ -209,8 +213,8 @@ commit-lint-branch:
 
 # ─── Pre-flight (run before push / PR) ──────────────────────────────────────
 
-# Full pre-push validation: fmt, clippy, shellcheck, lint-docker, lint-md, lint-deps, spell, arch-check, tests
-preflight: fmt-check fmt-data-check fmt-sh-check clippy shellcheck lint-docker lint-md lint-deps spell arch-check test
+# Full pre-push validation: fmt, clippy, shellcheck, lint-docker, lint-md, lint-workflows, lint-deps, spell, arch-check, tests
+preflight: fmt-check fmt-data-check fmt-sh-check clippy shellcheck lint-docker lint-md lint-workflows lint-deps spell arch-check test
 
 # Everything including perf tests (run before releases)
 preflight-full: preflight test-perf

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -139,6 +139,19 @@ pre-commit:
         - run: "! command -v hadolint >/dev/null 2>&1"
       run: hadolint {staged_files}
 
+    # --- GitHub Actions workflow linting (actionlint) ---
+
+    actionlint:
+      # actionlint is shipped by the containers dev-tools feature; skip
+      # gracefully if running outside a dev-tools container — CI is the
+      # safety net. actionlint embeds shellcheck for `run:` blocks; the
+      # top-level shellcheck hook only globs *.sh, so no double-lint.
+      # --severity=warning matches the project shellcheck policy.
+      glob: ".github/workflows/*.{yml,yaml}"
+      skip:
+        - run: "! command -v actionlint >/dev/null 2>&1"
+      run: actionlint -shellcheck "shellcheck --severity=warning" {staged_files}
+
     # --- Markdown linting (rumdl) ---
 
     rumdl:


### PR DESCRIPTION
## Summary

- Adds `just lint-workflows` recipe wrapping `actionlint -shellcheck "shellcheck --severity=warning"` (mirrored verbatim from the containers submodule so the dev-container hook and host recipe stay identical).
- Adds an `actionlint` pre-commit hook to `lefthook.yml`, globbing `.github/workflows/*.{yml,yaml}` with the skip-if-missing-binary pattern used by `hadolint`/`rumdl`.
- Adds an `Actionlint` CI job pinned to `v1.7.12` (matches containers `v4.19.2` dev-tools). `shellcheck` is preinstalled on `ubuntu-latest` runners.
- Adds `lint-workflows` to the `preflight` chain so pre-push validation covers workflow changes.
- No `.actionlint.yaml` config — current workflows pass clean with defaults; tune later only if false positives appear.

## Test plan

- [x] `just lint-workflows` — exit 0 (no findings on current workflows)
- [x] `lefthook run pre-commit --command actionlint --file .github/workflows/ci.yml` — hook runs and passes
- [x] Skip behavior: invoking the hook with `actionlint` hidden from `PATH` reports `(skip) by condition` instead of erroring
- [x] `just fmt-data-check` — exit 0 (dprint happy with the new ci.yml content)
- [x] Pre-commit hooks (gitleaks, end-of-file-fixer, conform, dprint, etc.) all pass on this commit
- [ ] CI Actionlint job appears green on this PR

Closes #257