### PR TITLE
chore(tooling): add just quarterly recipe and quarterly-review workflow

### DIFF
--- a/.github/workflows/quarterly-review.yml
+++ b/.github/workflows/quarterly-review.yml
@@ -1,0 +1,106 @@
+name: Quarterly Review
+
+# Opens a tracking issue every quarter (14:07 UTC on the 1st of Jan/Apr/Jul/Oct)
+# with the checklist for the long-cycle maintenance items that need human
+# judgment: `just quarterly` output review, /codebase-audit triage, doc drift,
+# on-hold issue review, advisory-ignore expiry review.
+#
+# The issue is the tracking container — close it when the checklist is done.
+# Idempotent: re-running in the same quarter does NOT create a duplicate.
+#
+# Companion: `just quarterly` recipe (justfile) and CONTRIBUTING.md
+# "Maintenance Cadence" section.
+
+on:
+  schedule:
+    # 14:07 UTC, 1st of Jan/Apr/Jul/Oct. Off-mark minute to avoid the :00
+    # stampede on GitHub Actions runners (matches ci.yml convention).
+    - cron: "7 14 1 1,4,7,10 *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  open-reminder:
+    name: Open quarterly reminder issue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute quarter
+        id: q
+        run: |
+          year=$(date -u +%Y)
+          month=$(date -u +%-m)
+          quarter=$(( (month - 1) / 3 + 1 ))
+          echo "year=$year" >> "$GITHUB_OUTPUT"
+          echo "quarter=$quarter" >> "$GITHUB_OUTPUT"
+          echo "title=Quarterly review — $year Q$quarter" >> "$GITHUB_OUTPUT"
+
+      - name: Check for existing issue (idempotency guard)
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ steps.q.outputs.title }}
+        run: |
+          # `in:title` + label filter so we do not false-match on body mentions
+          # in other issues. --state all so closed prior runs still dedupe.
+          count=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "audit/quarterly" \
+            --state all \
+            --search "in:title \"$TITLE\"" \
+            --json number \
+            --jq 'length')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          if [ "$count" -gt 0 ]; then
+            echo "Issue \"$TITLE\" already exists ($count match) — skipping create."
+          fi
+
+      - name: Create reminder issue
+        if: steps.existing.outputs.count == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ steps.q.outputs.title }}
+          YEAR: ${{ steps.q.outputs.year }}
+          QUARTER: ${{ steps.q.outputs.quarter }}
+        run: |
+          body=$(cat <<EOF
+          Tracking issue for the **$YEAR Q$QUARTER** quarterly maintenance pass.
+          Close this issue when every box below is checked.
+
+          See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#maintenance-cadence)
+          for the cadence rationale and [\`justfile\`](../blob/main/justfile)
+          for the \`just quarterly\` recipe.
+
+          ## Automatable scans
+
+          - [ ] Run \`just quarterly\`, review per-section output, file issues for any action items.
+
+          ## Human-judgment review
+
+          - [ ] Run \`/codebase-audit\` and triage findings into issues.
+          - [ ] Review CLAUDE.md and top-level docs for drift against code reality.
+          - [ ] Walk open \`status/on-hold\` issues; unblock or close stale ones.
+          - [ ] Check advisory ignore-list expiry dates in \`deny.toml\` and re-evaluate due items.
+          - [ ] Review \`severity/medium\`+ open issues for staleness.
+          - [ ] Refresh license allow-list in \`deny.toml\` against the inventory from \`cargo deny list\`.
+
+          ---
+
+          _Opened automatically by \`.github/workflows/quarterly-review.yml\`._
+          EOF
+          )
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TITLE" \
+            --body "$body" \
+            --label "severity/low" \
+            --label "type/operations" \
+            --label "audit/quarterly"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,30 @@ re-export used only at the boundary), document it with a
 ignored = ["some-dep"]   # why it's kept
 ```
 
+### Maintenance Cadence
+
+Two cadences cover dependency and code health:
+
+- **Short cycle (CI / daily)** — `just clippy`, `just test`, `just deps-audit`,
+  `just deps-deny`, `just deps-osv` run on every push, PR, and the daily
+  schedule in `.github/workflows/ci.yml`. These catch regressions and new
+  advisories within 24 hours.
+- **Long cycle (quarterly)** — `just quarterly` chains the short-cycle scans
+  with deeper checks that need human judgment to act on: `cargo outdated`
+  (version bump decisions), `cargo tree --duplicates` (dep-graph drift),
+  `cargo deny list` (license inventory refresh), `just deps-expiry-check`
+  (past-due `re-evaluate YYYY-MM-DD` markers in `deny.toml`), and optional
+  `cargo geiger` (unsafe-code surface). The recipe is non-halting so one
+  failing section does not mask another.
+
+The companion workflow `.github/workflows/quarterly-review.yml` opens a
+**reminder issue** on the 1st of January, April, July, and October with the
+full checklist (automatable scans + judgment-heavy items like
+`/codebase-audit` triage, CLAUDE.md drift review, and `status/on-hold`
+issue triage). The issue is the tracking container — close it when the
+checklist is done. The workflow is idempotent: re-running it within the
+same quarter does not create a duplicate.
+
 ## SemVer Policy
 
 octarine is a foundational library. Downstream crates depend on a stable

--- a/justfile
+++ b/justfile
@@ -252,6 +252,89 @@ deps-check: deps-audit deps-deny deps-osv deps-outdated
 lint-deps:
     cargo machete --skip-target-dir crates/octarine crates/octarine-derive crates/octarine-problem
 
+# Surface past-due "re-evaluate YYYY-MM-DD" markers on advisory ignores in
+# deny.toml. Exit 0 = nothing due; exit 1 = at least one past-due marker.
+# Used by `just quarterly` and safe to wire into preflight later.
+deps-expiry-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    today=$(date +%Y-%m-%d)
+    overdue=0
+    while IFS= read -r line; do
+        match=$(echo "$line" | /usr/bin/grep -oE 're-evaluate [0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+        [ -z "$match" ] && continue
+        marker_date=${match#re-evaluate }
+        if [[ "$marker_date" < "$today" ]]; then
+            echo "PAST DUE ($marker_date): $line"
+            overdue=$((overdue + 1))
+        fi
+    done < <(/usr/bin/grep -E 're-evaluate [0-9]{4}-[0-9]{2}-[0-9]{2}' deny.toml || true)
+    if [ "$overdue" -eq 0 ]; then
+        echo "deps-expiry-check: no past-due re-evaluate markers"
+    else
+        echo "deps-expiry-check: $overdue past-due marker(s) — review deny.toml" >&2
+        exit 1
+    fi
+
+# ─── Quarterly (long-cycle review) ───────────────────────────────────────────
+
+# Composite deep-scan recipe for the quarterly review checklist. Runs each
+# tool independently (non-halting) so one tool's exit code does not mask
+# another's; emits a per-section header and a final pass/fail summary.
+#
+# Differs from `deps-check` in that:
+#   - cargo audit runs WITHOUT --ignore so RUSTSEC-2023-0071 surfaces for
+#     human re-evaluation (its re-evaluate date is in deny.toml).
+#   - Adds cargo tree --duplicates, license inventory, advisory-expiry
+#     check, and optional cargo-geiger.
+#
+# See CONTRIBUTING.md "Maintenance Cadence" for the quarterly workflow.
+quarterly:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    sections=()
+    statuses=()
+    run() {
+        local label=$1
+        shift
+        echo ""
+        echo "══ $label ═══════════════════════════════════════════════════════════"
+        if "$@"; then
+            sections+=("$label")
+            statuses+=("PASS")
+        else
+            sections+=("$label")
+            statuses+=("FAIL")
+        fi
+    }
+    echo "Quarterly review — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    run "cargo audit (no --ignore)"       cargo audit
+    run "cargo deny check"                cargo deny check
+    run "osv-scanner"                     osv-scanner scan source --lockfile=Cargo.lock
+    run "cargo outdated"                  cargo outdated --workspace --depth 1
+    run "cargo tree --duplicates"         cargo tree --duplicates --workspace
+    run "cargo deny list (licenses)"      cargo deny list
+    if command -v cargo-geiger >/dev/null 2>&1; then
+        run "cargo geiger (unsafe scan)"  cargo geiger --workspace
+    else
+        echo ""
+        echo "── cargo geiger: not installed, skipping ──"
+    fi
+    run "deps-expiry-check"               just deps-expiry-check
+    echo ""
+    echo "══ Summary ══════════════════════════════════════════════════════════"
+    fail_count=0
+    for i in "${!sections[@]}"; do
+        printf '  %-35s %s\n' "${sections[$i]}" "${statuses[$i]}"
+        [ "${statuses[$i]}" = "FAIL" ] && fail_count=$((fail_count + 1))
+    done
+    echo ""
+    if [ "$fail_count" -eq 0 ]; then
+        echo "All sections passed. Continue with the human-judgment checklist in the quarterly reminder issue."
+    else
+        echo "$fail_count section(s) reported findings — review output above and triage into issues."
+    fi
+
 # ─── Utilities ───────────────────────────────────────────────────────────────
 
 # Remove build artifacts


### PR DESCRIPTION
## Summary

- Adds `just quarterly` composite recipe: runs `cargo audit` (without `--ignore`), `cargo deny check`, `osv-scanner`, `cargo outdated`, `cargo tree --duplicates`, `cargo deny list`, optional `cargo geiger`, and `deps-expiry-check`. Non-halting per section with a final pass/fail summary.
- Adds `just deps-expiry-check` standalone recipe that flags past-due `re-evaluate YYYY-MM-DD` markers in `deny.toml` (currently the 2026-10-01 RUSTSEC-2023-0071 marker).
- Adds `.github/workflows/quarterly-review.yml` — opens a tracking issue on the 1st of Jan/Apr/Jul/Oct at 14:07 UTC with the full quarterly checklist. Idempotent via `gh issue list --search "in:title"` + `audit/quarterly` label.
- Adds "Maintenance Cadence" subsection to `CONTRIBUTING.md` explaining short- vs long-cycle coverage.

## Design notes

- **`cargo audit` runs without `--ignore` in `quarterly`** so RUSTSEC-2023-0071 surfaces for human re-evaluation each quarter. The daily CI keeps the `--ignore` to avoid spam.
- **`audit/quarterly` label** created out-of-band via `gh label create` (labels are repo-state, not file-state).
- Workflow uses GitHub-Flavored env-var pattern for all interpolated values (`TITLE`, `YEAR`, `QUARTER`) to avoid script-injection risk per actionlint guidance.

## Test plan

- [x] `just deps-expiry-check` — happy path passes
- [x] `just deps-expiry-check` — sad path verified by temporarily setting a past date in `deny.toml`, exits 1 with "PAST DUE" line, then reverted
- [x] `just lint-workflows` (actionlint) passes
- [x] `just lint-md` (rumdl), `just fmt-data-check` (dprint), `just spell` (typos) all pass
- [x] Pre-commit hooks (rumdl, typos, actionlint, gitleaks, conform) all pass
- [x] Title computation + idempotency-guard search query verified locally against the real repo (`Quarterly review — 2026 Q2`, count=0)
- [ ] **Deferred to post-merge**: Live `gh workflow run quarterly-review.yml` dispatch test — GitHub 404s when dispatching workflows that don't exist on the default branch yet. Verify after merge.

Closes #256