### PR TITLE
chore(tooling): adopt taplo for TOML formatting and schema linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,24 @@ jobs:
       - uses: taiki-e/install-action@just
       - run: just lint-workflows
 
+  taplo:
+    name: Taplo
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      # taiki-e/install-action ships a taplo-cli recipe; pin to 0.10.0
+      # to match the version shipped by containers v4.17.0+ so the
+      # dev-container hook and CI run identical binaries.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli@0.10.0
+      - uses: taiki-e/install-action@just
+      # Split into two steps so format-drift and schema-lint failures
+      # are distinguishable in the CI log.
+      - run: just fmt-toml-check
+      - run: just lint-toml
+
   machete:
     name: Machete
     runs-on: ubuntu-latest

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -15,9 +15,9 @@ exclude = [
   ".git/**",
   ".vscode/**",
   ".devcontainer/**",
-  "containers/**",          # submodule — has its own .rumdl.toml + CI gate
-  ".claude/memory/tmp/**",  # ephemeral session state (gitignored anyway)
-  ".claude/worktrees/**",   # parallel-agent worktrees (gitignored anyway)
+  "containers/**",         # submodule — has its own .rumdl.toml + CI gate
+  ".claude/memory/tmp/**", # ephemeral session state (gitignored anyway)
+  ".claude/worktrees/**",  # parallel-agent worktrees (gitignored anyway)
 ]
 
 disable = [

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,20 @@
+# Taplo configuration — TOML formatter and schema linter.
+# Config reference: https://taplo.tamasfe.dev/configuration/file.html
+#
+# Style choices:
+#   - 2-space indent: matches dprint's JSON indent and the
+#     containers/taplo.toml standard. TOML config is data, not Rust code,
+#     so alignment with dprint is the better analogy than rustfmt's 4.
+#   - column_width 100: matches .rustfmt.toml's max_width so Cargo.toml
+#     inline tables wrap consistently with the Rust they describe.
+#   - reorder_keys NOT enabled: crates/octarine/Cargo.toml groups deps
+#     under category comments (# Error handling, # Serialization, …)
+#     that alphabetisation would shatter. Intentional divergence from
+#     issue #249's text — see commit body for rationale.
+
+include = ["**/*.toml"]
+exclude = ["containers/**", "target/**", "tests/results/**", "node_modules/**", ".git/**"]
+
+[formatting]
+indent_string = "  "
+column_width = 100

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "crates/octarine",
-    "crates/octarine-derive",
-    "crates/octarine-problem",
-]
+members = ["crates/octarine", "crates/octarine-derive", "crates/octarine-problem"]
 
 [workspace.package]
 version = "0.3.0-beta.3"

--- a/_typos.toml
+++ b/_typos.toml
@@ -4,10 +4,7 @@
 [default]
 # Skip identifiers that look like hex blobs or base64; these surface in
 # crypto/identifier fixtures and test vectors as legitimate non-words.
-extend-ignore-identifiers-re = [
-    "^[A-Fa-f0-9]{6,}$",
-    "^[A-Za-z0-9+/]{32,}={0,2}$",
-]
+extend-ignore-identifiers-re = ["^[A-Fa-f0-9]{6,}$", "^[A-Za-z0-9+/]{32,}={0,2}$"]
 
 [default.extend-words]
 # Discworld lore — eighth color of the spectrum, project namesake
@@ -75,14 +72,14 @@ unparseable = "unparseable"
 
 [files]
 extend-exclude = [
-    "CHANGELOG.md",
-    "Cargo.lock",
-    "target/**",
-    "node_modules/**",
-    ".git/**",
-    "containers/**",
-    "**/*.lock",
-    "tests/results/**",
-    "**/proptest-regressions/**",
-    "**/fixtures/**",
+  "CHANGELOG.md",
+  "Cargo.lock",
+  "target/**",
+  "node_modules/**",
+  ".git/**",
+  "containers/**",
+  "**/*.lock",
+  "tests/results/**",
+  "**/proptest-regressions/**",
+  "**/fixtures/**",
 ]

--- a/bacon.toml
+++ b/bacon.toml
@@ -20,9 +20,14 @@ need_stdout = false
 # Clippy with deny-warnings, all features, all targets. Matches `just clippy`.
 [jobs.clippy]
 command = [
-    "cargo", "clippy",
-    "--workspace", "--all-targets", "--all-features",
-    "--", "-D", "warnings",
+  "cargo",
+  "clippy",
+  "--workspace",
+  "--all-targets",
+  "--all-features",
+  "--",
+  "-D",
+  "warnings",
 ]
 need_stdout = false
 
@@ -35,11 +40,7 @@ need_stdout = true
 # Run a single test by name pattern. Invoke as:
 #   bacon test-filter -- PATTERN
 [jobs.test-filter]
-command = [
-    "cargo", "test",
-    "--workspace", "--all-features", "-j4",
-    "--",
-]
+command = ["cargo", "test", "--workspace", "--all-features", "-j4", "--"]
 need_stdout = true
 
 # Rustdoc. Matches `just doc` minus `RUSTDOCFLAGS=-D warnings` —

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -102,9 +102,9 @@ x25519-dalek = { version = "2.0", features = ["static_secrets", "getrandom", "ze
 
 # Database support (optional)
 sqlx = { version = "0.8", optional = true, default-features = false, features = [
-    "runtime-tokio",
-    "chrono",
-    "uuid",
+  "runtime-tokio",
+  "chrono",
+  "uuid",
 ] }
 
 # OpenTelemetry (optional)
@@ -116,16 +116,19 @@ opentelemetry-otlp = { version = "0.32", optional = true, features = ["grpc-toni
 axum = { version = "0.8", optional = true }
 tower = { version = "0.5", optional = true, features = ["util"] }
 tower-http = { version = "0.6.10", optional = true, features = [
-    "request-id",
-    "util",
-    "cors",
-    "compression-full",
-    "decompression-full",
-    "trace",
-    "timeout",
-    "limit",
+  "request-id",
+  "util",
+  "cors",
+  "compression-full",
+  "decompression-full",
+  "trace",
+  "timeout",
+  "limit",
 ] }
-tower_governor = { version = "0.8", optional = true, default-features = false, features = ["axum", "tracing"] }
+tower_governor = { version = "0.8", optional = true, default-features = false, features = [
+  "axum",
+  "tracing",
+] }
 http = { version = "1.2", optional = true }
 http-body-util = { version = "0.1", optional = true }
 
@@ -181,12 +184,12 @@ postgres = ["database", "dep:sqlx", "sqlx?/postgres"]
 sqlite = ["database", "dep:sqlx", "sqlx?/sqlite"]
 otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
 http = [
-    "dep:axum",
-    "dep:tower",
-    "dep:tower-http",
-    "dep:tower_governor",
-    "dep:http",
-    "dep:http-body-util",
+  "dep:axum",
+  "dep:tower",
+  "dep:tower-http",
+  "dep:tower_governor",
+  "dep:http",
+  "dep:http-body-util",
 ]
 auth = ["http", "dep:jsonwebtoken", "dep:zxcvbn"]
 auth-hibp = ["auth", "dep:sha1"]
@@ -195,14 +198,14 @@ auth-full = ["auth-hibp", "auth-totp"]
 crypto-validation = ["dep:pem", "dep:x509-parser", "dep:ssh-key"]
 shell = []
 testing = [
-    "dep:proptest",
-    "dep:rstest",
-    "dep:assert_fs",
-    "dep:predicates",
-    "dep:wiremock",
-    "dep:assert_cmd",
-    "dep:rexpect",
-    "dep:shell-escape",
+  "dep:proptest",
+  "dep:rstest",
+  "dep:assert_fs",
+  "dep:predicates",
+  "dep:wiremock",
+  "dep:assert_cmd",
+  "dep:rexpect",
+  "dep:shell-escape",
 ]
 
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -9,37 +9,37 @@ all-features = true
 
 [advisories]
 ignore = [
-    # rsa crate has a known timing side-channel with no patch available.
-    # Transitive dep only — we don't use RSA directly for signing or verification.
-    # Re-evaluate by 2026-10-01: check if upstream has patched or if we can drop the dep.
-    # CRITICAL: if RS256 server-side signing is ever added, this MUST be resolved first.
-    { id = "RUSTSEC-2023-0071", reason = "no patch available, transitive dep only — re-evaluate 2026-10-01" },
+  # rsa crate has a known timing side-channel with no patch available.
+  # Transitive dep only — we don't use RSA directly for signing or verification.
+  # Re-evaluate by 2026-10-01: check if upstream has patched or if we can drop the dep.
+  # CRITICAL: if RS256 server-side signing is ever added, this MUST be resolved first.
+  { id = "RUSTSEC-2023-0071", reason = "no patch available, transitive dep only — re-evaluate 2026-10-01" },
 ]
 
 # ─── Licenses ────────────────────────────────────────────────────────────────
 
 [licenses]
 allow = [
-    "MIT",
-    "MIT-0",
-    "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "BSD-1-Clause",
-    "0BSD",
-    "ISC",
-    "Unlicense",
-    "Zlib",
-    "CC0-1.0",
-    "Unicode-3.0",
-    "OpenSSL",
-    "CDLA-Permissive-2.0",
+  "MIT",
+  "MIT-0",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSD-1-Clause",
+  "0BSD",
+  "ISC",
+  "Unlicense",
+  "Zlib",
+  "CC0-1.0",
+  "Unicode-3.0",
+  "OpenSSL",
+  "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
 
 exceptions = [
-    # r-efi is dual-licensed MIT/Apache-2.0/LGPL-2.1+; we use it under MIT/Apache-2.0
-    { allow = ["LGPL-2.1-or-later"], crate = "r-efi" },
+  # r-efi is dual-licensed MIT/Apache-2.0/LGPL-2.1+; we use it under MIT/Apache-2.0
+  { allow = ["LGPL-2.1-or-later"], crate = "r-efi" },
 ]
 
 # ─── Sources ─────────────────────────────────────────────────────────────────

--- a/justfile
+++ b/justfile
@@ -43,6 +43,18 @@ fmt-data-check:
 fmt-data:
     dprint fmt
 
+# Check TOML formatting via taplo (no fixes; config: .taplo.toml)
+fmt-toml-check:
+    taplo format --check
+
+# Format TOML via taplo (writes; config: .taplo.toml)
+fmt-toml:
+    taplo format
+
+# Lint TOML schema correctness via taplo (config: .taplo.toml)
+lint-toml:
+    taplo lint
+
 # Run all formatters and file fixers via pre-commit on every file in the repo
 fmt-all: pre-commit
 
@@ -213,8 +225,8 @@ commit-lint-branch:
 
 # ─── Pre-flight (run before push / PR) ──────────────────────────────────────
 
-# Full pre-push validation: fmt, clippy, shellcheck, lint-docker, lint-md, lint-workflows, lint-deps, spell, arch-check, tests
-preflight: fmt-check fmt-data-check fmt-sh-check clippy shellcheck lint-docker lint-md lint-workflows lint-deps spell arch-check test
+# Full pre-push validation: fmt, clippy, shellcheck, lint-docker, lint-md, lint-workflows, lint-toml, lint-deps, spell, arch-check, tests
+preflight: fmt-check fmt-data-check fmt-toml-check fmt-sh-check clippy shellcheck lint-docker lint-md lint-workflows lint-toml lint-deps spell arch-check test
 
 # Everything including perf tests (run before releases)
 preflight-full: preflight test-perf

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -117,6 +117,18 @@ pre-commit:
       run: dprint fmt {staged_files}
       stage_fixed: true
 
+    # --- TOML formatting (taplo) ---
+
+    taplo-fmt:
+      glob: "*.toml"
+      # The repo-level .taplo.toml excludes containers/**, but lefthook
+      # passes explicit {staged_files} which bypasses taplo's own
+      # include/exclude — re-exclude here.
+      exclude:
+        - "containers/**"
+      run: taplo format {staged_files}
+      stage_fixed: true
+
     # --- Shell script linting ---
 
     shellcheck:


### PR DESCRIPTION
## Summary

Wires `taplo` (TOML formatter/linter, already shipped by containers v4.17.0+) into the same `just`/`lefthook`/CI three-touchpoint pattern as recent tool adoptions (machete #373, nextest #375, actionlint #376).

**Commit 1** — scaffolding (no behavioural changes):
- `.taplo.toml` at repo root: 2-space indent and `column_width = 100` to align with `containers/taplo.toml` and `.rustfmt.toml`'s `max_width`. Excludes the `containers/**` submodule (which owns its own config), `target/**`, `tests/results/**`, `node_modules/**`, `.git/**`.
- `just` recipes: `fmt-toml`, `fmt-toml-check`, `lint-toml`. The two check recipes are wired into `preflight`.
- New `taplo-fmt` lefthook hook with `stage_fixed: true` (mirrors `dprint`). Existing `check-toml` hook (`taplo check`, parse-validity) stays — `taplo lint` is heavier and lives in preflight/CI.
- New `Taplo` CI job using `taiki-e/install-action@v2` with `tool: taplo-cli@0.10.0`. Format-check and lint run as two separate steps so failures are distinguishable in the log.

**Commit 2** — mechanical reformat:
- 6 files reformatted by `just fmt-toml`: `.rumdl.toml`, `Cargo.toml`, `_typos.toml`, `bacon.toml`, `crates/octarine/Cargo.toml`, `deny.toml`. Diff is purely whitespace (4→2 indent + some inline-table wrapping past column 100).

### Deviation from issue text

Issue #249 proposes `reorder_keys = true`. **Left off intentionally** — `crates/octarine/Cargo.toml` groups dependencies under category comments (`# Error handling`, `# Serialization`, …) that alphabetisation would shatter. Documented in `.taplo.toml` header and Commit 1 body so it doesn't get reopened later.

## Test plan

- [x] `just fmt-toml-check` — clean
- [x] `just lint-toml` — clean
- [x] `just fmt-toml` idempotent — second run produces no diff
- [x] `git -C containers diff --exit-code` — submodule untouched
- [x] `just lint-workflows` — actionlint clean on the new CI job
- [x] `lefthook run pre-commit --all-files` — all 20 hooks green, including new `taplo-fmt`
- [x] `just clippy` — clean
- [x] `cargo metadata` — `Cargo.toml` reformat preserves parseability
- [x] Pre-existing flaky timing test (`test_interval`) noted; passes in isolation, unrelated to this change

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)