### PR TITLE
feat(identifiers): add Nigeria Vehicle Registration and BVN detection

### DIFF
--- a/crates/octarine/src/identifiers/builder/government/nigeria.rs
+++ b/crates/octarine/src/identifiers/builder/government/nigeria.rs
@@ -1,8 +1,10 @@
-//! Nigeria NIN methods.
+//! Nigeria identifier methods — NIN, BVN, and vehicle registration.
 
 use super::*;
 
 impl GovernmentBuilder {
+    // ---- NIN ----------------------------------------------------------------
+
     /// Check if value matches a Nigerian NIN pattern
     #[must_use]
     pub fn is_nigeria_nin(&self, value: &str) -> bool {
@@ -52,6 +54,120 @@ impl GovernmentBuilder {
                 observe::warn(
                     "nigeria_nin_validation_failed",
                     "Invalid Nigeria NIN format",
+                );
+            }
+        }
+        result
+    }
+
+    // ---- BVN ----------------------------------------------------------------
+
+    /// Check if value matches a Nigerian BVN pattern
+    #[must_use]
+    pub fn is_nigeria_bvn(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_nigeria_bvn(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Nigerian BVNs in text (label-gated)
+    #[must_use]
+    pub fn find_nigeria_bvns_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_nigeria_bvns_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+                increment_by(metric_names::government_data_found(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate Nigerian BVN format (no checksum algorithm exists)
+    pub fn validate_nigeria_bvn(&self, bvn: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_nigeria_bvn(bvn);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "nigeria_bvn_validation_failed",
+                    "Invalid Nigeria BVN format",
+                );
+            }
+        }
+        result
+    }
+
+    // ---- Vehicle Registration -----------------------------------------------
+
+    /// Check if value matches a Nigerian vehicle registration plate
+    #[must_use]
+    pub fn is_nigeria_vehicle_registration(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_nigeria_vehicle_registration(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Nigerian vehicle registration plates in text
+    #[must_use]
+    pub fn find_nigeria_vehicle_registrations_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_nigeria_vehicle_registrations_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+                increment_by(metric_names::government_data_found(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate a Nigerian vehicle registration plate
+    pub fn validate_nigeria_vehicle_registration(&self, reg: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_nigeria_vehicle_registration(reg);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "nigeria_vehicle_reg_validation_failed",
+                    "Invalid Nigeria vehicle registration format",
                 );
             }
         }

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -173,6 +173,8 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             | PiiType::BrazilCnpj
             | PiiType::MexicoCurp
             | PiiType::NigeriaNin
+            | PiiType::NigeriaBvn
+            | PiiType::NigeriaVehicleReg
             | PiiType::ThailandTnin
             | PiiType::SingaporeNric
             | PiiType::FinlandHetu

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -142,6 +142,14 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
             PiiType::NigeriaNin,
         ),
         (
+            GovernmentIdentifierBuilder::find_nigeria_bvns_in_text,
+            PiiType::NigeriaBvn,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_nigeria_vehicle_registrations_in_text,
+            PiiType::NigeriaVehicleReg,
+        ),
+        (
             GovernmentIdentifierBuilder::find_thailand_tnins_in_text,
             PiiType::ThailandTnin,
         ),

--- a/crates/octarine/src/observe/pii/types/classification.rs
+++ b/crates/octarine/src/observe/pii/types/classification.rs
@@ -23,7 +23,7 @@ impl PiiType {
             Self::Ssn | Self::DriverLicense | Self::Passport | Self::Ein | Self::TaxId | Self::NationalId | Self::Vin |
             Self::KoreaRrn | Self::AustraliaTfn | Self::AustraliaAbn | Self::IndiaAadhaar | Self::IndiaPan |
             Self::IndiaGstin | Self::IndiaVehicleReg | Self::IndiaVoterId | Self::IndiaPassport |
-            Self::BrazilCpf | Self::BrazilCnpj | Self::MexicoCurp | Self::NigeriaNin | Self::ThailandTnin |
+            Self::BrazilCpf | Self::BrazilCnpj | Self::MexicoCurp | Self::NigeriaNin | Self::NigeriaBvn | Self::NigeriaVehicleReg | Self::ThailandTnin |
             Self::SingaporeNric | Self::FinlandHetu | Self::PolandPesel | Self::ItalyFiscalCode |
             Self::SpainNif | Self::SpainNie | Self::UkNi |
             // Medical (HIPAA)

--- a/crates/octarine/src/observe/pii/types/core.rs
+++ b/crates/octarine/src/observe/pii/types/core.rs
@@ -40,6 +40,8 @@ impl PiiType {
             Self::BrazilCnpj => "brazil_cnpj",
             Self::MexicoCurp => "mexico_curp",
             Self::NigeriaNin => "nigeria_nin",
+            Self::NigeriaBvn => "nigeria_bvn",
+            Self::NigeriaVehicleReg => "nigeria_vehicle_reg",
             Self::ThailandTnin => "thailand_tnin",
             Self::SingaporeNric => "singapore_nric",
             Self::FinlandHetu => "finland_hetu",
@@ -159,6 +161,8 @@ impl PiiType {
             | Self::BrazilCnpj
             | Self::MexicoCurp
             | Self::NigeriaNin
+            | Self::NigeriaBvn
+            | Self::NigeriaVehicleReg
             | Self::ThailandTnin
             | Self::SingaporeNric
             | Self::FinlandHetu

--- a/crates/octarine/src/observe/pii/types/mapping.rs
+++ b/crates/octarine/src/observe/pii/types/mapping.rs
@@ -87,6 +87,8 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::BrazilCnpj => Self::BrazilCnpj,
             IdentifierType::MexicoCurp => Self::MexicoCurp,
             IdentifierType::NigeriaNin => Self::NigeriaNin,
+            IdentifierType::NigeriaBvn => Self::NigeriaBvn,
+            IdentifierType::NigeriaVehicleReg => Self::NigeriaVehicleReg,
             IdentifierType::ThailandTnin => Self::ThailandTnin,
             IdentifierType::SingaporeNric => Self::SingaporeNric,
             IdentifierType::FinlandHetu => Self::FinlandHetu,

--- a/crates/octarine/src/observe/pii/types/mod.rs
+++ b/crates/octarine/src/observe/pii/types/mod.rs
@@ -111,6 +111,10 @@ pub enum PiiType {
     MexicoCurp,
     /// Nigerian National Identification Number (NIN)
     NigeriaNin,
+    /// Nigerian Bank Verification Number (BVN, 11 digits)
+    NigeriaBvn,
+    /// Nigerian vehicle registration plate (XXX-NNN-XX current, AA999-AAA legacy)
+    NigeriaVehicleReg,
     /// Thai National Identification Number (TNIN, mod-11 check digit)
     ThailandTnin,
     /// Singapore NRIC / FIN

--- a/crates/octarine/src/observe/pii/types/tests.rs
+++ b/crates/octarine/src/observe/pii/types/tests.rs
@@ -179,6 +179,8 @@ fn test_country_specific_government_classifications() {
         PiiType::BrazilCnpj,
         PiiType::MexicoCurp,
         PiiType::NigeriaNin,
+        PiiType::NigeriaBvn,
+        PiiType::NigeriaVehicleReg,
         PiiType::ThailandTnin,
         PiiType::SingaporeNric,
     ] {
@@ -399,6 +401,14 @@ fn from_identifier_type_direct_mappings() {
     assert_eq!(
         PiiType::from(IdentifierType::NigeriaNin),
         PiiType::NigeriaNin
+    );
+    assert_eq!(
+        PiiType::from(IdentifierType::NigeriaBvn),
+        PiiType::NigeriaBvn
+    );
+    assert_eq!(
+        PiiType::from(IdentifierType::NigeriaVehicleReg),
+        PiiType::NigeriaVehicleReg
     );
     assert_eq!(
         PiiType::from(IdentifierType::ThailandTnin),

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -39,9 +39,9 @@ pub(crate) use network::{email, phone, username};
 pub(crate) use personal::{
     australia_abn, australia_tfn, birthdate, brazil_cnpj, brazil_cpf, driver_license, employee_id,
     finland_hetu, india_aadhaar, india_gstin, india_pan, india_passport, india_vehicle_reg,
-    india_voter_id, italy_fiscal_code, korea_rrn, mexico_curp, national_id, nigeria_nin, passport,
-    personal_name, poland_pesel, singapore_nric, spain_nie, spain_nif, ssn, student_id, tax_id,
-    thailand_tnin, uk_ni,
+    india_voter_id, italy_fiscal_code, korea_rrn, mexico_curp, national_id, nigeria_bvn,
+    nigeria_nin, nigeria_vehicle_reg, passport, personal_name, poland_pesel, singapore_nric,
+    spain_nie, spain_nif, ssn, student_id, tax_id, thailand_tnin, uk_ni,
 };
 
 // medical, biometric, location, and vehicle modules are already accessible via pub mod declarations

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
@@ -33,7 +33,8 @@ pub(crate) use global_identifiers::{
     india_vehicle_reg, india_voter_id, korea_rrn, national_id,
 };
 pub(crate) use regional_identifiers::{
-    birthdate, brazil_cnpj, brazil_cpf, finland_hetu, italy_fiscal_code, mexico_curp, nigeria_nin,
-    personal_name, poland_pesel, singapore_nric, spain_nie, spain_nif, thailand_tnin, uk_ni,
+    birthdate, brazil_cnpj, brazil_cpf, finland_hetu, italy_fiscal_code, mexico_curp, nigeria_bvn,
+    nigeria_nin, nigeria_vehicle_reg, personal_name, poland_pesel, singapore_nric, spain_nie,
+    spain_nif, thailand_tnin, uk_ni,
 };
 pub(crate) use us_identifiers::{driver_license, employee_id, passport, ssn, student_id, tax_id};

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
@@ -114,6 +114,75 @@ pub(crate) mod nigeria_nin {
     }
 }
 
+/// Nigeria BVN (Bank Verification Number) patterns
+///
+/// Format: 11 plain digits. The unlabeled form is identical to NIN, phone
+/// numbers, and many other identifiers, so scanning uses LABELED only —
+/// analogous to `nigeria_nin`. Direct `is_nigeria_bvn()` checks still accept
+/// the bare 11-digit form.
+///
+/// Note: NIN and BVN labels are disjoint (`NIN|national identification
+/// number|NIMC` vs `BVN|bank verification|verification number`) so the two
+/// scanners do not cross-match.
+pub(crate) mod nigeria_bvn {
+    use super::*;
+
+    /// BVN standard format (11 digits, no separators)
+    pub static STANDARD: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\b\d{11}\b").expect("BUG: Invalid regex pattern"));
+
+    /// BVN with explicit label
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:BVN|bank[\s-]?verification(?:[\s-]?number)?|verification[\s-]?number)[\s:#-]*(\d{11})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    /// Returns patterns used for text scanning (LABELED only — STANDARD is
+    /// `\d{11}` which matches phone numbers, NINs, and many other 11-digit
+    /// strings).
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED]
+    }
+}
+
+/// Nigeria Vehicle Registration patterns
+///
+/// Current (post-2020) format: 3-letter LGA code + 3 digits + 2 letters
+/// (e.g. `LAG-123-AB`, `ABC456XY`). Pre-2020 legacy format: 2 letters + 3
+/// digits + `-` + 3 letters (e.g. `LA123-ABC`).
+///
+/// LGA codes (e.g. LAG, ABJ, KAN) are not enforced against a closed list —
+/// new codes are issued periodically and authoritative lists vary by source.
+pub(crate) mod nigeria_vehicle_reg {
+    use super::*;
+
+    /// Plate standard format (no separators for current; legacy keeps the
+    /// dash because `AA999AAA` is too generic to safely scan)
+    pub static STANDARD: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b(?:[A-Z]{3}\d{3}[A-Z]{2}|[A-Z]{2}\d{3}-[A-Z]{3})\b")
+            .expect("BUG: Invalid regex pattern")
+    });
+
+    /// Plate with spaces or hyphens between current-format segments
+    pub static WITH_SEPARATORS: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b[A-Z]{3}[\s-]\d{3}[\s-][A-Z]{2}\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// Plate with explicit label (current format with optional separators)
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:vehicle[\s-]?(?:registration|plate|number)?|number[\s-]?plate|plate[\s-]?(?:no\.?|number)?|reg[\s-]?no\.?)[\s:#-]*([A-Z]{3}[\s-]?\d{3}[\s-]?[A-Z]{2})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*WITH_SEPARATORS, &*STANDARD]
+    }
+}
+
 /// Thailand TNIN (National Identification Number) patterns
 ///
 /// Format: 13 digits. Display form `N-NNNN-NNNNN-NN-N`.

--- a/crates/octarine/src/primitives/identifiers/government/builder/nigeria.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/nigeria.rs
@@ -1,8 +1,10 @@
-//! Nigeria NIN operations on `GovernmentIdentifierBuilder`.
+//! Nigeria identifier operations on `GovernmentIdentifierBuilder`.
 
 use super::*;
 
 impl GovernmentIdentifierBuilder {
+    // ---- NIN ----------------------------------------------------------------
+
     /// Check if value matches Nigeria NIN format
     #[must_use]
     pub fn is_nigeria_nin(&self, value: &str) -> bool {
@@ -28,5 +30,64 @@ impl GovernmentIdentifierBuilder {
     #[must_use]
     pub fn is_test_nigeria_nin(&self, nin: &str) -> bool {
         validation::is_test_nigeria_nin(nin)
+    }
+
+    // ---- BVN ----------------------------------------------------------------
+
+    /// Check if value matches Nigeria BVN format
+    #[must_use]
+    pub fn is_nigeria_bvn(&self, value: &str) -> bool {
+        detection::is_nigeria_bvn(value)
+    }
+
+    /// Find all Nigeria BVNs in text (labeled occurrences only — see pattern docs)
+    #[must_use]
+    pub fn find_nigeria_bvns_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_nigeria_bvns_in_text(text)
+    }
+
+    /// Validate Nigeria BVN format (no checksum algorithm exists)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the BVN format is invalid
+    pub fn validate_nigeria_bvn(&self, bvn: &str) -> Result<(), Problem> {
+        validation::validate_nigeria_bvn(bvn)
+    }
+
+    /// Check if a Nigeria BVN is a test/dummy pattern
+    #[must_use]
+    pub fn is_test_nigeria_bvn(&self, bvn: &str) -> bool {
+        validation::is_test_nigeria_bvn(bvn)
+    }
+
+    // ---- Vehicle Registration -----------------------------------------------
+
+    /// Check if value matches a Nigerian vehicle registration plate
+    #[must_use]
+    pub fn is_nigeria_vehicle_registration(&self, value: &str) -> bool {
+        detection::is_nigeria_vehicle_registration(value)
+    }
+
+    /// Find all Nigerian vehicle registration plates in text
+    #[must_use]
+    pub fn find_nigeria_vehicle_registrations_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_nigeria_vehicle_registrations_in_text(text)
+    }
+
+    /// Validate a Nigerian vehicle registration plate
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the plate format does not match the current
+    /// or legacy layout.
+    pub fn validate_nigeria_vehicle_registration(&self, reg: &str) -> Result<(), Problem> {
+        validation::validate_nigeria_vehicle_registration(reg)
+    }
+
+    /// Check if a vehicle registration plate is a test/dummy pattern
+    #[must_use]
+    pub fn is_test_nigeria_vehicle_registration(&self, reg: &str) -> bool {
+        validation::is_test_nigeria_vehicle_registration(reg)
     }
 }

--- a/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
@@ -81,7 +81,11 @@ pub use india::{
 pub use korea_rrn::{find_korea_rrns_in_text, is_korea_rrn};
 pub use mexico::{find_mexico_curps_in_text, is_mexico_curp};
 pub use national_id::{find_national_ids_in_text, find_uk_nis_in_text, is_national_id, is_uk_ni};
-pub use nigeria::{find_nigeria_nins_in_text, is_nigeria_nin};
+pub use nigeria::{
+    find_nigeria_bvns_in_text, find_nigeria_nins_in_text,
+    find_nigeria_vehicle_registrations_in_text, is_nigeria_bvn, is_nigeria_nin,
+    is_nigeria_vehicle_registration,
+};
 pub use passport::{find_passports_in_text, is_passport};
 pub use singapore::{find_singapore_nrics_in_text, is_singapore_nric};
 pub use ssn::{find_ssns_in_text, is_ssn};
@@ -105,6 +109,7 @@ pub use vehicle_id::{find_vehicle_ids_in_text, is_vehicle_id};
 /// assert_eq!(detection::detect_government_identifier("not an id"), None);
 /// ```
 #[must_use]
+#[allow(clippy::cognitive_complexity)]
 pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
     if is_ssn(value) {
         Some(IdentifierType::Ssn)
@@ -134,7 +139,12 @@ pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
         Some(IdentifierType::MexicoCurp)
     } else if is_thailand_tnin(value) {
         Some(IdentifierType::ThailandTnin)
+    } else if is_nigeria_vehicle_registration(value) {
+        Some(IdentifierType::NigeriaVehicleReg)
     } else if is_nigeria_nin(value) {
+        // NIN and BVN share the same shape (`\d{11}`). The dispatcher returns
+        // NIN for any 11-digit value — callers needing BVN precision should use
+        // `find_nigeria_bvns_in_text`, which is label-gated.
         Some(IdentifierType::NigeriaNin)
     } else if is_singapore_nric(value) {
         Some(IdentifierType::SingaporeNric)
@@ -207,6 +217,8 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
     all_matches.extend(find_brazil_cnpjs_in_text(text));
     all_matches.extend(find_mexico_curps_in_text(text));
     all_matches.extend(find_nigeria_nins_in_text(text));
+    all_matches.extend(find_nigeria_bvns_in_text(text));
+    all_matches.extend(find_nigeria_vehicle_registrations_in_text(text));
     all_matches.extend(find_thailand_tnins_in_text(text));
     all_matches.extend(find_singapore_nrics_in_text(text));
     all_matches.extend(find_finland_hetus_in_text(text));

--- a/crates/octarine/src/primitives/identifiers/government/detection/nigeria.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/nigeria.rs
@@ -1,4 +1,4 @@
-//! Nigeria NIN (National Identification Number) detection
+//! Nigeria identifier detection — NIN, BVN, and vehicle registration.
 
 use super::super::super::common::patterns;
 use super::super::super::types::{IdentifierMatch, IdentifierType};
@@ -48,4 +48,188 @@ pub fn find_nigeria_nins_in_text(text: &str) -> Vec<IdentifierMatch> {
     }
 
     deduplicate_matches(matches)
+}
+
+/// Check if a value matches Nigeria BVN format (11 digits)
+///
+/// BVN shares its shape with NIN (`\d{11}`); the dispatcher cannot tell them
+/// apart without surrounding context. Callers that need precision should use
+/// the labeled finders (`find_nigeria_bvns_in_text` / `find_nigeria_nins_in_text`).
+#[must_use]
+pub fn is_nigeria_bvn(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    if value.chars().filter(|c| c.is_ascii_digit()).count() == 11
+        && value
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, '-' | ' '))
+    {
+        return true;
+    }
+    patterns::nigeria_bvn::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Nigeria BVN patterns in text (LABELED only — see pattern docs)
+#[must_use]
+pub fn find_nigeria_bvns_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::nigeria_bvn::all() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::NigeriaBvn,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+/// Check if a value matches a Nigerian vehicle registration plate
+///
+/// Accepts the current post-2020 format (`XXX-NNN-XX` with optional separators)
+/// and the pre-2020 legacy format (`AA999-AAA`).
+#[must_use]
+pub fn is_nigeria_vehicle_registration(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    patterns::nigeria_vehicle_reg::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Nigeria vehicle registration plates in text
+#[must_use]
+pub fn find_nigeria_vehicle_registrations_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::nigeria_vehicle_reg::all() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::NigeriaVehicleReg,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // ---------------- BVN ----------------
+
+    #[test]
+    fn test_is_nigeria_bvn_accepts_11_digits() {
+        assert!(is_nigeria_bvn("12345678901"));
+    }
+
+    #[test]
+    fn test_is_nigeria_bvn_with_separators() {
+        assert!(is_nigeria_bvn("123-456-789-01"));
+        assert!(is_nigeria_bvn("123 456 789 01"));
+    }
+
+    #[test]
+    fn test_is_nigeria_bvn_rejects_wrong_length() {
+        assert!(!is_nigeria_bvn("1234567890"));
+        assert!(!is_nigeria_bvn("123456789012"));
+    }
+
+    #[test]
+    fn test_is_nigeria_bvn_accepts_labeled_form() {
+        assert!(is_nigeria_bvn("BVN: 12345678901"));
+        assert!(is_nigeria_bvn("Bank Verification Number: 12345678901"));
+    }
+
+    #[test]
+    fn test_find_bvns_labeled_form() {
+        let text = "BVN: 12345678901";
+        assert_eq!(find_nigeria_bvns_in_text(text).len(), 1);
+    }
+
+    #[test]
+    fn test_find_bvns_bank_verification_label() {
+        let text = "bank verification number: 12345678901";
+        assert_eq!(find_nigeria_bvns_in_text(text).len(), 1);
+    }
+
+    #[test]
+    fn test_find_bvns_unlabeled_returns_empty() {
+        let text = "12345678901";
+        assert!(find_nigeria_bvns_in_text(text).is_empty());
+    }
+
+    #[test]
+    fn test_find_bvns_does_not_match_nin_label() {
+        // BVN scanner must not pick up a NIN-labeled value
+        let text = "NIN: 12345678901";
+        assert!(find_nigeria_bvns_in_text(text).is_empty());
+    }
+
+    #[test]
+    fn test_find_nins_does_not_match_bvn_label() {
+        // Symmetric check — NIN scanner must not pick up a BVN-labeled value
+        let text = "BVN: 12345678901";
+        assert!(find_nigeria_nins_in_text(text).is_empty());
+    }
+
+    // ---------------- Vehicle Registration ----------------
+
+    #[test]
+    fn test_is_vehicle_registration_current_format() {
+        assert!(is_nigeria_vehicle_registration("LAG123AB"));
+    }
+
+    #[test]
+    fn test_is_vehicle_registration_with_separators() {
+        assert!(is_nigeria_vehicle_registration("LAG-123-AB"));
+        assert!(is_nigeria_vehicle_registration("LAG 123 AB"));
+    }
+
+    #[test]
+    fn test_is_vehicle_registration_legacy_format() {
+        assert!(is_nigeria_vehicle_registration("LA123-ABC"));
+    }
+
+    #[test]
+    fn test_is_vehicle_registration_rejects_junk() {
+        assert!(!is_nigeria_vehicle_registration("12345"));
+        assert!(!is_nigeria_vehicle_registration("LA-123-AB")); // 2-letter LGA on current format
+    }
+
+    #[test]
+    fn test_find_vehicle_registration_labeled() {
+        let text = "plate: LAG-123-AB";
+        assert_eq!(find_nigeria_vehicle_registrations_in_text(text).len(), 1);
+    }
+
+    #[test]
+    fn test_find_vehicle_registration_standalone() {
+        // STANDARD pattern (no separators) is distinctive enough to scan
+        let text = "Spotted LAG123AB in the lot.";
+        assert_eq!(find_nigeria_vehicle_registrations_in_text(text).len(), 1);
+    }
 }

--- a/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
@@ -131,7 +131,10 @@ pub use brazil::{
 pub use mexico::{is_test_mexico_curp, validate_mexico_curp, validate_mexico_curp_with_checksum};
 
 // Re-export Nigeria functions
-pub use nigeria::{is_test_nigeria_nin, validate_nigeria_nin};
+pub use nigeria::{
+    is_test_nigeria_bvn, is_test_nigeria_nin, is_test_nigeria_vehicle_registration,
+    validate_nigeria_bvn, validate_nigeria_nin, validate_nigeria_vehicle_registration,
+};
 
 // Re-export Thailand functions
 pub use thailand::{

--- a/crates/octarine/src/primitives/identifiers/government/validation/nigeria.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/nigeria.rs
@@ -1,10 +1,17 @@
-//! Nigeria NIN (National Identification Number) validation
+//! Nigeria identifier validation — NIN, BVN, and vehicle registration.
 //!
-//! Format: 11 digits. No public checksum algorithm — format validation only.
-//! NIMC (National Identity Management Commission) issues these via the
-//! National Identity Database.
+//! Format-only checks. NIN and BVN are 11-digit identifiers with no public
+//! checksum algorithm. Vehicle registration validates against the current
+//! post-2020 layout (3 letters + 3 digits + 2 letters) and the pre-2020
+//! legacy layout (2 letters + 3 digits + 3 letters). State / LGA codes are
+//! not enforced against a closed list — issuance is ongoing and lists vary
+//! by source.
 
 use crate::primitives::types::Problem;
+
+// ============================================================================
+// NIN Validation
+// ============================================================================
 
 /// Validate Nigeria NIN format
 ///
@@ -14,16 +21,130 @@ use crate::primitives::types::Problem;
 ///
 /// Returns `Problem::Validation` if the format is invalid.
 pub fn validate_nigeria_nin(value: &str) -> Result<(), Problem> {
+    validate_eleven_digit_id(value, "NIN")
+}
+
+/// Check if a NIN is a test/dummy pattern (all-same-digit)
+#[must_use]
+pub fn is_test_nigeria_nin(value: &str) -> bool {
+    is_test_eleven_digit_id(value)
+}
+
+// ============================================================================
+// BVN Validation
+// ============================================================================
+
+/// Validate Nigeria BVN format
+///
+/// Checks: 11 digits, not all the same digit. BVN has no public checksum
+/// algorithm — format validation only.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format is invalid.
+pub fn validate_nigeria_bvn(value: &str) -> Result<(), Problem> {
+    validate_eleven_digit_id(value, "BVN")
+}
+
+/// Check if a BVN is a test/dummy pattern (all-same-digit)
+#[must_use]
+pub fn is_test_nigeria_bvn(value: &str) -> bool {
+    is_test_eleven_digit_id(value)
+}
+
+// ============================================================================
+// Vehicle Registration Validation
+// ============================================================================
+
+/// Validate Nigeria vehicle registration plate
+///
+/// Accepts two layouts after stripping whitespace/`-` and uppercasing:
+///   * Current (post-2020): 3 letters + 3 digits + 2 letters (e.g. `LAG-123-AB`)
+///   * Legacy (pre-2020):   2 letters + 3 digits + 3 letters (e.g. `LA123-ABC`)
+///
+/// LGA / state codes are not enforced against a closed list.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if neither layout matches.
+pub fn validate_nigeria_vehicle_registration(value: &str) -> Result<(), Problem> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
-        return Err(Problem::Validation("NIN cannot be empty".to_string()));
+        return Err(Problem::Validation(
+            "Vehicle registration cannot be empty".to_string(),
+        ));
     }
 
-    // NIN is plain digits; tolerate hyphens/spaces but reject letters.
+    let normalized: String = trimmed
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '-')
+        .collect::<String>()
+        .to_uppercase();
+
+    if normalized.len() != 8 {
+        return Err(Problem::Validation(format!(
+            "Vehicle registration must be 8 chars (excl. separators), got {}",
+            normalized.len()
+        )));
+    }
+
+    let chars: Vec<char> = normalized.chars().collect();
+
+    if matches_layout(&chars, &[3, 3, 2]) || matches_layout(&chars, &[2, 3, 3]) {
+        Ok(())
+    } else {
+        Err(Problem::Validation(format!(
+            "Vehicle registration '{normalized}' does not match XXX-NNN-XX or AA999-AAA layout"
+        )))
+    }
+}
+
+/// Check if a vehicle registration is a test/dummy pattern
+///
+/// Returns true when all letter positions hold the same letter AND all digit
+/// positions hold the same digit (e.g. `AAA-000-AA`, `XXX-111-XX`).
+#[must_use]
+pub fn is_test_nigeria_vehicle_registration(value: &str) -> bool {
+    let normalized: String = value
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '-')
+        .collect::<String>()
+        .to_uppercase();
+
+    if normalized.len() != 8 {
+        return false;
+    }
+
+    let chars: Vec<char> = normalized.chars().collect();
+    if !(matches_layout(&chars, &[3, 3, 2]) || matches_layout(&chars, &[2, 3, 3])) {
+        return false;
+    }
+
+    let letters: Vec<char> = chars
+        .iter()
+        .copied()
+        .filter(char::is_ascii_alphabetic)
+        .collect();
+    let digits: Vec<char> = chars.iter().copied().filter(char::is_ascii_digit).collect();
+
+    all_same_char(&letters) && all_same_char(&digits)
+}
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+/// Validate an 11-digit Nigerian identifier (NIN or BVN).
+fn validate_eleven_digit_id(value: &str, label: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation(format!("{label} cannot be empty")));
+    }
+
     for ch in trimmed.chars() {
         if !ch.is_ascii_digit() && !matches!(ch, '-' | ' ' | '\t') {
             return Err(Problem::Validation(format!(
-                "invalid character '{ch}' in NIN"
+                "invalid character '{ch}' in {label}"
             )));
         }
     }
@@ -35,23 +156,21 @@ pub fn validate_nigeria_nin(value: &str) -> Result<(), Problem> {
 
     if digits.len() != 11 {
         return Err(Problem::Validation(format!(
-            "NIN must be 11 digits, got {}",
+            "{label} must be 11 digits, got {}",
             digits.len()
         )));
     }
 
     if all_same_digit(&digits) {
-        return Err(Problem::Validation(
-            "NIN cannot have all identical digits".to_string(),
-        ));
+        return Err(Problem::Validation(format!(
+            "{label} cannot have all identical digits"
+        )));
     }
 
     Ok(())
 }
 
-/// Check if a NIN is a test/dummy pattern (all-same-digit)
-#[must_use]
-pub fn is_test_nigeria_nin(value: &str) -> bool {
+fn is_test_eleven_digit_id(value: &str) -> bool {
     let digits: Vec<u8> = value
         .chars()
         .filter_map(|c| c.to_digit(10).map(|d| d as u8))
@@ -65,6 +184,39 @@ fn all_same_digit(digits: &[u8]) -> bool {
         .is_some_and(|&first| digits.iter().all(|&d| d == first))
 }
 
+fn all_same_char(chars: &[char]) -> bool {
+    chars
+        .first()
+        .is_some_and(|&first| chars.iter().all(|&c| c == first))
+}
+
+/// Check whether `chars` follows `pattern` where each entry alternates
+/// letters / digits / letters, starting with letters.
+fn matches_layout(chars: &[char], pattern: &[usize]) -> bool {
+    if chars.len() != pattern.iter().sum::<usize>() {
+        return false;
+    }
+    let mut idx: usize = 0;
+    for (segment, &count) in pattern.iter().enumerate() {
+        let expect_letter = segment.is_multiple_of(2);
+        for _ in 0..count {
+            let Some(&ch) = chars.get(idx) else {
+                return false;
+            };
+            let ok = if expect_letter {
+                ch.is_ascii_uppercase()
+            } else {
+                ch.is_ascii_digit()
+            };
+            if !ok {
+                return false;
+            }
+            idx = idx.saturating_add(1);
+        }
+    }
+    idx == chars.len()
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -73,6 +225,8 @@ fn all_same_digit(digits: &[u8]) -> bool {
 #[allow(clippy::panic, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    // ---------------- NIN ----------------
 
     #[test]
     fn test_validate_nin_valid() {
@@ -124,5 +278,135 @@ mod tests {
     #[test]
     fn test_is_test_nigeria_nin_rejects_wrong_length() {
         assert!(!is_test_nigeria_nin("111"));
+    }
+
+    // ---------------- BVN ----------------
+
+    #[test]
+    fn test_validate_bvn_valid() {
+        assert!(validate_nigeria_bvn("12345678901").is_ok());
+    }
+
+    #[test]
+    fn test_validate_bvn_with_separators() {
+        assert!(validate_nigeria_bvn("123-456-789-01").is_ok());
+    }
+
+    #[test]
+    fn test_validate_bvn_rejects_too_short() {
+        assert!(validate_nigeria_bvn("1234567890").is_err());
+    }
+
+    #[test]
+    fn test_validate_bvn_rejects_too_long() {
+        assert!(validate_nigeria_bvn("123456789012").is_err());
+    }
+
+    #[test]
+    fn test_validate_bvn_rejects_empty() {
+        assert!(validate_nigeria_bvn("").is_err());
+    }
+
+    #[test]
+    fn test_validate_bvn_rejects_letters() {
+        assert!(validate_nigeria_bvn("12345abc901").is_err());
+    }
+
+    #[test]
+    fn test_validate_bvn_rejects_all_same() {
+        assert!(validate_nigeria_bvn("11111111111").is_err());
+        assert!(validate_nigeria_bvn("99999999999").is_err());
+    }
+
+    #[test]
+    fn test_is_test_nigeria_bvn_detects_all_same() {
+        assert!(is_test_nigeria_bvn("11111111111"));
+        assert!(is_test_nigeria_bvn("99999999999"));
+    }
+
+    #[test]
+    fn test_is_test_nigeria_bvn_rejects_real() {
+        assert!(!is_test_nigeria_bvn("12345678901"));
+    }
+
+    #[test]
+    fn test_is_test_nigeria_bvn_rejects_wrong_length() {
+        assert!(!is_test_nigeria_bvn("111"));
+    }
+
+    // ---------------- Vehicle Registration ----------------
+
+    #[test]
+    fn test_validate_vehicle_current_no_separators() {
+        assert!(validate_nigeria_vehicle_registration("LAG123AB").is_ok());
+        assert!(validate_nigeria_vehicle_registration("ABC456XY").is_ok());
+    }
+
+    #[test]
+    fn test_validate_vehicle_current_with_dashes() {
+        assert!(validate_nigeria_vehicle_registration("LAG-123-AB").is_ok());
+    }
+
+    #[test]
+    fn test_validate_vehicle_current_with_spaces() {
+        assert!(validate_nigeria_vehicle_registration("LAG 123 AB").is_ok());
+    }
+
+    #[test]
+    fn test_validate_vehicle_legacy_format() {
+        assert!(validate_nigeria_vehicle_registration("LA123-ABC").is_ok());
+        assert!(validate_nigeria_vehicle_registration("LA 123 ABC").is_ok());
+    }
+
+    #[test]
+    fn test_validate_vehicle_rejects_empty() {
+        assert!(validate_nigeria_vehicle_registration("").is_err());
+    }
+
+    #[test]
+    fn test_validate_vehicle_rejects_short_lga_on_current() {
+        // 2 letters + 3 digits + 2 letters = 7 chars, not 8
+        assert!(validate_nigeria_vehicle_registration("LA-123-AB").is_err());
+    }
+
+    #[test]
+    fn test_validate_vehicle_rejects_all_digit_lga() {
+        assert!(validate_nigeria_vehicle_registration("123-456-AB").is_err());
+    }
+
+    #[test]
+    fn test_validate_vehicle_rejects_too_many_district_digits() {
+        assert!(validate_nigeria_vehicle_registration("LAG-1234-AB").is_err());
+    }
+
+    #[test]
+    fn test_validate_vehicle_rejects_trailing_garbage() {
+        assert!(validate_nigeria_vehicle_registration("LAG-123-ABXY").is_err());
+    }
+
+    #[test]
+    fn test_validate_vehicle_normalizes_case() {
+        assert!(validate_nigeria_vehicle_registration("lag-123-ab").is_ok());
+    }
+
+    #[test]
+    fn test_is_test_vehicle_detects_dummy_current() {
+        assert!(is_test_nigeria_vehicle_registration("AAA-000-AA"));
+        assert!(is_test_nigeria_vehicle_registration("XXX111XX"));
+    }
+
+    #[test]
+    fn test_is_test_vehicle_detects_dummy_legacy() {
+        assert!(is_test_nigeria_vehicle_registration("AA000-AAA"));
+    }
+
+    #[test]
+    fn test_is_test_vehicle_rejects_real() {
+        assert!(!is_test_nigeria_vehicle_registration("LAG-123-AB"));
+    }
+
+    #[test]
+    fn test_is_test_vehicle_rejects_wrong_length() {
+        assert!(!is_test_nigeria_vehicle_registration("AAA-000"));
     }
 }

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -64,27 +64,29 @@ pub enum IdentifierType {
     Ein,   // Employer Identification Number (XX-XXXXXXX, IRS campus prefix)
     TaxId, // TIN, ITIN (EIN has its own variant)
     NationalId,
-    KoreaRrn,        // South Korea Resident Registration Number
-    AustraliaTfn,    // Australian Tax File Number
-    AustraliaAbn,    // Australian Business Number
-    IndiaAadhaar,    // Indian Aadhaar number (Verhoeff checksum)
-    IndiaPan,        // Indian Permanent Account Number
-    IndiaGstin,      // Indian Goods and Services Tax Identification Number (MOD-36 checksum)
-    IndiaVehicleReg, // Indian vehicle registration (license plate)
-    IndiaVoterId,    // Indian Voter ID (EPIC - Electors Photo Identity Card)
-    IndiaPassport,   // Indian passport (P/S/D type indicator + 7 digits)
-    BrazilCpf,       // Brazilian Cadastro de Pessoas Físicas (mod-11 dual check digits)
-    BrazilCnpj,      // Brazilian Cadastro Nacional da Pessoa Jurídica (mod-11 dual check digits)
-    MexicoCurp,      // Mexican Clave Única de Registro de Población (18 chars + check)
-    NigeriaNin,      // Nigerian National Identification Number (11 digits)
-    ThailandTnin,    // Thai National Identification Number (13 digits, mod-11 check)
-    SingaporeNric,   // Singapore NRIC/FIN
-    FinlandHetu,     // Finnish personal identity code
-    PolandPesel,     // Polish personal identity number (PESEL)
-    ItalyFiscalCode, // Italian Codice Fiscale
-    SpainNif,        // Spanish NIF (Numero de Identificacion Fiscal)
-    SpainNie,        // Spanish NIE (Numero de Identidad de Extranjero)
-    UkNi,            // UK National Insurance Number (NINO)
+    KoreaRrn,          // South Korea Resident Registration Number
+    AustraliaTfn,      // Australian Tax File Number
+    AustraliaAbn,      // Australian Business Number
+    IndiaAadhaar,      // Indian Aadhaar number (Verhoeff checksum)
+    IndiaPan,          // Indian Permanent Account Number
+    IndiaGstin,        // Indian Goods and Services Tax Identification Number (MOD-36 checksum)
+    IndiaVehicleReg,   // Indian vehicle registration (license plate)
+    IndiaVoterId,      // Indian Voter ID (EPIC - Electors Photo Identity Card)
+    IndiaPassport,     // Indian passport (P/S/D type indicator + 7 digits)
+    BrazilCpf,         // Brazilian Cadastro de Pessoas Físicas (mod-11 dual check digits)
+    BrazilCnpj,        // Brazilian Cadastro Nacional da Pessoa Jurídica (mod-11 dual check digits)
+    MexicoCurp,        // Mexican Clave Única de Registro de Población (18 chars + check)
+    NigeriaNin,        // Nigerian National Identification Number (11 digits)
+    NigeriaBvn,        // Nigerian Bank Verification Number (11 digits, no public checksum)
+    NigeriaVehicleReg, // Nigerian vehicle registration (XXX-NNN-XX current, AA999-AAA legacy)
+    ThailandTnin,      // Thai National Identification Number (13 digits, mod-11 check)
+    SingaporeNric,     // Singapore NRIC/FIN
+    FinlandHetu,       // Finnish personal identity code
+    PolandPesel,       // Polish personal identity number (PESEL)
+    ItalyFiscalCode,   // Italian Codice Fiscale
+    SpainNif,          // Spanish NIF (Numero de Identificacion Fiscal)
+    SpainNie,          // Spanish NIE (Numero de Identidad de Extranjero)
+    UkNi,              // UK National Insurance Number (NINO)
 
     // Organizational identifiers
     EmployeeId,


### PR DESCRIPTION
## Summary

Extend Nigeria identifier coverage with two new types:

- **Vehicle Registration**: current 3-3-2 format (e.g. `LAG-123-AB`) is primary; pre-2020 2-3-3 format (e.g. `LA123-ABC`) supported as legacy fallback. Validates state/LGA code is alphabetic (3 letters current, 2 letters legacy), rejects all-digit codes and trailing garbage.
- **BVN (Bank Verification Number)**: 11-digit format. Shape-identical to NIN, so unlabeled text scanning is intentionally restricted to labeled contexts (`BVN:`, `bank verification`). `is_nigeria_bvn` still accepts bare `\d{11}` for direct caller-driven validation.

Wires both through the full stack:
- `primitives/identifiers/government/{detection,validation}/nigeria.rs`
- `IdentifierType` and `PiiType` registries
- PII scanner domains + redactor
- Layer 3 builder shortcuts (`identifiers::builder::government::nigeria`)

No public checksum exists for either identifier, so no `_with_checksum` variant is added.

## Test plan

- 49 Nigeria-specific unit tests pass (`just test-filter nigeria`)
- Covers: format validation, separator handling (spaces, dashes), case normalization, BVN-vs-NIN label disambiguation, legacy vs current vehicle reg formats, test/dummy detection (all-same digits)
- `just clippy`, `just fmt-check`, `just arch-check` all clean
- Full preflight test pass (one unrelated flaky cache test passed on retry)

Closes #36