### PR TITLE
feat(identifiers): add 8 developer-platform token detectors

### DIFF
--- a/crates/octarine/src/identifiers/builder/token/detection.rs
+++ b/crates/octarine/src/identifiers/builder/token/detection.rs
@@ -204,6 +204,54 @@ impl TokenBuilder {
         self.inner.is_gitlab_token(value)
     }
 
+    /// Check if value is a Heroku modern API token
+    #[must_use]
+    pub fn is_heroku_token(&self, value: &str) -> bool {
+        self.inner.is_heroku_token(value)
+    }
+
+    /// Check if value is a Linear API key
+    #[must_use]
+    pub fn is_linear_token(&self, value: &str) -> bool {
+        self.inner.is_linear_token(value)
+    }
+
+    /// Check if value is a Doppler token (service/CLI/SCM/service-account)
+    #[must_use]
+    pub fn is_doppler_token(&self, value: &str) -> bool {
+        self.inner.is_doppler_token(value)
+    }
+
+    /// Check if value is a Netlify Personal Access Token
+    #[must_use]
+    pub fn is_netlify_token(&self, value: &str) -> bool {
+        self.inner.is_netlify_token(value)
+    }
+
+    /// Check if value is a Fly.io macaroon-based token
+    #[must_use]
+    pub fn is_fly_io_token(&self, value: &str) -> bool {
+        self.inner.is_fly_io_token(value)
+    }
+
+    /// Check if value is a Render API key
+    #[must_use]
+    pub fn is_render_token(&self, value: &str) -> bool {
+        self.inner.is_render_token(value)
+    }
+
+    /// Check if value is a PlanetScale service token
+    #[must_use]
+    pub fn is_planetscale_token(&self, value: &str) -> bool {
+        self.inner.is_planetscale_token(value)
+    }
+
+    /// Check if value is a Supabase Personal Access Token
+    #[must_use]
+    pub fn is_supabase_token(&self, value: &str) -> bool {
+        self.inner.is_supabase_token(value)
+    }
+
     /// Check if value is a 1Password service account token
     #[must_use]
     pub fn is_onepassword_token(&self, value: &str) -> bool {

--- a/crates/octarine/src/identifiers/shortcuts/token.rs
+++ b/crates/octarine/src/identifiers/shortcuts/token.rs
@@ -106,6 +106,58 @@ pub fn is_bearer_token(value: &str) -> bool {
     TokenBuilder::new().is_bearer_token(value)
 }
 
+// ============================================================
+// DEVELOPER-PLATFORM TOKEN SHORTCUTS
+// ============================================================
+
+/// Check if value is a Heroku modern API token (HRKU-AA prefix)
+#[must_use]
+pub fn is_heroku_token(value: &str) -> bool {
+    TokenBuilder::new().is_heroku_token(value)
+}
+
+/// Check if value is a Linear API key (lin_api_ prefix)
+#[must_use]
+pub fn is_linear_token(value: &str) -> bool {
+    TokenBuilder::new().is_linear_token(value)
+}
+
+/// Check if value is a Doppler token (service/CLI/SCM/service-account)
+#[must_use]
+pub fn is_doppler_token(value: &str) -> bool {
+    TokenBuilder::new().is_doppler_token(value)
+}
+
+/// Check if value is a Netlify Personal Access Token (nfp_ prefix)
+#[must_use]
+pub fn is_netlify_token(value: &str) -> bool {
+    TokenBuilder::new().is_netlify_token(value)
+}
+
+/// Check if value is a Fly.io macaroon-based token (FlyV1 prefix)
+#[must_use]
+pub fn is_fly_io_token(value: &str) -> bool {
+    TokenBuilder::new().is_fly_io_token(value)
+}
+
+/// Check if value is a Render API key (rnd_ prefix)
+#[must_use]
+pub fn is_render_token(value: &str) -> bool {
+    TokenBuilder::new().is_render_token(value)
+}
+
+/// Check if value is a PlanetScale service token (pscale_tkn_ prefix)
+#[must_use]
+pub fn is_planetscale_token(value: &str) -> bool {
+    TokenBuilder::new().is_planetscale_token(value)
+}
+
+/// Check if value is a Supabase Personal Access Token (sbp_ prefix)
+#[must_use]
+pub fn is_supabase_token(value: &str) -> bool {
+    TokenBuilder::new().is_supabase_token(value)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
@@ -185,5 +237,36 @@ mod tests {
         assert!(validate_session_id("short").is_err());
         // Obvious test session IDs are rejected
         assert!(validate_session_id("test_session_12345678").is_err());
+    }
+
+    #[test]
+    fn test_developer_platform_token_shortcuts() {
+        assert!(is_heroku_token(&format!("HRKU-AA{}", "a".repeat(58))));
+        assert!(!is_heroku_token("not-a-token"));
+
+        assert!(is_linear_token(&format!("lin_api_{}", "A".repeat(40))));
+        assert!(!is_linear_token("lin_api_short"));
+
+        assert!(is_doppler_token(&format!("dp.st.{}", "a".repeat(40))));
+        assert!(is_doppler_token(&format!("dp.sa.{}", "a".repeat(40))));
+        assert!(!is_doppler_token(&format!("dp.xx.{}", "a".repeat(40))));
+
+        assert!(is_netlify_token(&format!("nfp_{}", "a".repeat(40))));
+        assert!(!is_netlify_token("nfp_short"));
+
+        assert!(is_fly_io_token(&format!("FlyV1 {}", "a".repeat(100))));
+        assert!(!is_fly_io_token("FlyV1 short"));
+
+        assert!(is_render_token(&format!("rnd_{}", "A".repeat(32))));
+        assert!(!is_render_token("rnd_short"));
+
+        assert!(is_planetscale_token(&format!(
+            "pscale_tkn_{}",
+            "A".repeat(40)
+        )));
+        assert!(!is_planetscale_token("pscale_tkn_short"));
+
+        assert!(is_supabase_token(&format!("sbp_{}", "a".repeat(40))));
+        assert!(!is_supabase_token("sbp_short"));
     }
 }

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -151,7 +151,15 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             | PiiType::OpenAiKey
             | PiiType::DiscordToken
             | PiiType::SlackToken
-            | PiiType::TwilioToken => redact_api_keys(&result, profile),
+            | PiiType::TwilioToken
+            | PiiType::HerokuToken
+            | PiiType::LinearToken
+            | PiiType::DopplerToken
+            | PiiType::NetlifyToken
+            | PiiType::FlyIoToken
+            | PiiType::RenderToken
+            | PiiType::PlanetScaleToken
+            | PiiType::SupabaseToken => redact_api_keys(&result, profile),
             // Government IDs
             PiiType::Ssn => redact_ssns(&result, profile),
             PiiType::DriverLicense => redact_driver_licenses(&result, profile),

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -455,6 +455,14 @@ fn token_type_to_pii(t: TokenType) -> Option<PiiType> {
         TokenType::DiscordToken => PiiType::DiscordToken,
         TokenType::SlackToken => PiiType::SlackToken,
         TokenType::TwilioToken => PiiType::TwilioToken,
+        TokenType::HerokuToken => PiiType::HerokuToken,
+        TokenType::LinearToken => PiiType::LinearToken,
+        TokenType::DopplerToken => PiiType::DopplerToken,
+        TokenType::NetlifyToken => PiiType::NetlifyToken,
+        TokenType::FlyIoToken => PiiType::FlyIoToken,
+        TokenType::RenderToken => PiiType::RenderToken,
+        TokenType::PlanetScaleToken => PiiType::PlanetScaleToken,
+        TokenType::SupabaseToken => PiiType::SupabaseToken,
         // Already handled by sibling dispatches in scan_tokens — return
         // None to avoid double-emission.
         TokenType::Jwt

--- a/crates/octarine/src/observe/pii/types/classification.rs
+++ b/crates/octarine/src/observe/pii/types/classification.rs
@@ -43,7 +43,9 @@ impl PiiType {
             Self::DatabricksToken | Self::VaultToken | Self::CloudflareOriginCaKey |
             Self::NpmToken | Self::PyPiToken | Self::NuGetKey | Self::ArtifactoryToken | Self::DockerHubToken |
             Self::TelegramToken | Self::SendGridToken | Self::OpenAiKey |
-            Self::DiscordToken | Self::SlackToken | Self::TwilioToken
+            Self::DiscordToken | Self::SlackToken | Self::TwilioToken |
+            Self::HerokuToken | Self::LinearToken | Self::DopplerToken | Self::NetlifyToken |
+            Self::FlyIoToken | Self::RenderToken | Self::PlanetScaleToken | Self::SupabaseToken
         )
     }
 
@@ -154,6 +156,14 @@ impl PiiType {
                 | Self::DiscordToken
                 | Self::SlackToken
                 | Self::TwilioToken
+                | Self::HerokuToken
+                | Self::LinearToken
+                | Self::DopplerToken
+                | Self::NetlifyToken
+                | Self::FlyIoToken
+                | Self::RenderToken
+                | Self::PlanetScaleToken
+                | Self::SupabaseToken
         )
     }
 }

--- a/crates/octarine/src/observe/pii/types/core.rs
+++ b/crates/octarine/src/observe/pii/types/core.rs
@@ -124,6 +124,14 @@ impl PiiType {
             Self::DiscordToken => "discord_token",
             Self::SlackToken => "slack_token",
             Self::TwilioToken => "twilio_token",
+            Self::HerokuToken => "heroku_token",
+            Self::LinearToken => "linear_token",
+            Self::DopplerToken => "doppler_token",
+            Self::NetlifyToken => "netlify_token",
+            Self::FlyIoToken => "fly_io_token",
+            Self::RenderToken => "render_token",
+            Self::PlanetScaleToken => "planetscale_token",
+            Self::SupabaseToken => "supabase_token",
             // Credential
             Self::Password => "password",
             Self::Pin => "pin",
@@ -236,7 +244,15 @@ impl PiiType {
             | Self::OpenAiKey
             | Self::DiscordToken
             | Self::SlackToken
-            | Self::TwilioToken => "token",
+            | Self::TwilioToken
+            | Self::HerokuToken
+            | Self::LinearToken
+            | Self::DopplerToken
+            | Self::NetlifyToken
+            | Self::FlyIoToken
+            | Self::RenderToken
+            | Self::PlanetScaleToken
+            | Self::SupabaseToken => "token",
             Self::Password | Self::Pin | Self::SecurityAnswer | Self::Passphrase => "credential",
             Self::Generic => "generic",
         }

--- a/crates/octarine/src/observe/pii/types/mod.rs
+++ b/crates/octarine/src/observe/pii/types/mod.rs
@@ -293,6 +293,22 @@ pub enum PiiType {
     SlackToken,
     /// Twilio Account SID (AC...) or API Key SID (SK...)
     TwilioToken,
+    /// Heroku modern API token (HRKU-AA prefix)
+    HerokuToken,
+    /// Linear API key (lin_api_ prefix)
+    LinearToken,
+    /// Doppler service/CLI/SCM/service-account token
+    DopplerToken,
+    /// Netlify Personal Access Token (nfp_ prefix)
+    NetlifyToken,
+    /// Fly.io macaroon-based token (FlyV1 prefix)
+    FlyIoToken,
+    /// Render API key (rnd_ prefix)
+    RenderToken,
+    /// PlanetScale service token (pscale_tkn_ prefix)
+    PlanetScaleToken,
+    /// Supabase Personal Access Token (sbp_ prefix)
+    SupabaseToken,
 
     // =========================================================================
     // Credential Domain (NIST 800-63 Factor 1: Something You Know)

--- a/crates/octarine/src/primitives/identifiers/common/patterns/network/credential_patterns.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/network/credential_patterns.rs
@@ -233,6 +233,49 @@ pub static API_KEY_CLOUDFLARE_CA: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"\bv1\.0-[a-f0-9]{24}-[a-f0-9]{146}\b").expect("BUG: Invalid regex pattern")
 });
 
+/// Heroku modern API token (HRKU-AA prefix)
+/// Format: HRKU-AA[A-Za-z0-9_-]{58}
+pub static API_KEY_HEROKU: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\bHRKU-AA[A-Za-z0-9_-]{58}\b").expect("BUG: Invalid regex pattern"));
+
+/// Linear API key pattern
+/// Format: lin_api_[A-Za-z0-9]{40}
+pub static API_KEY_LINEAR: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\blin_api_[A-Za-z0-9]{40}\b").expect("BUG: Invalid regex pattern"));
+
+/// Doppler token pattern (service token, CLI token, SCM token, service-account token)
+/// Format: dp.(st|ct|scm|sa).[A-Za-z0-9_-]{40,}
+pub static API_KEY_DOPPLER: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\bdp\.(?:st|ct|scm|sa)\.[A-Za-z0-9_-]{40,}\b").expect("BUG: Invalid regex pattern")
+});
+
+/// Netlify Personal Access Token pattern
+/// Format: nfp_[A-Za-z0-9]{40,}
+pub static API_KEY_NETLIFY: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\bnfp_[A-Za-z0-9]{40,}\b").expect("BUG: Invalid regex pattern"));
+
+/// Fly.io macaroon-based token pattern
+/// Format: FlyV1 [A-Za-z0-9_-]{100,} (space separator after the FlyV1 prefix)
+pub static API_KEY_FLY_IO: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\bFlyV1\s[A-Za-z0-9_-]{100,}\b").expect("BUG: Invalid regex pattern")
+});
+
+/// Render API key pattern
+/// Format: rnd_[A-Za-z0-9]{32,}
+pub static API_KEY_RENDER: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\brnd_[A-Za-z0-9]{32,}\b").expect("BUG: Invalid regex pattern"));
+
+/// PlanetScale service token pattern
+/// Format: pscale_tkn_[A-Za-z0-9_-]{40,}
+pub static API_KEY_PLANETSCALE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\bpscale_tkn_[A-Za-z0-9_-]{40,}\b").expect("BUG: Invalid regex pattern")
+});
+
+/// Supabase Personal Access Token pattern
+/// Format: sbp_[a-f0-9]{40}
+pub static API_KEY_SUPABASE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\bsbp_[a-f0-9]{40}\b").expect("BUG: Invalid regex pattern"));
+
 /// NPM access token pattern
 /// Format: npm_[a-zA-Z0-9]{36}
 /// Example: "npm_" + 36 alnum chars

--- a/crates/octarine/src/primitives/identifiers/token/builder/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/token/builder/detection.rs
@@ -190,6 +190,46 @@ impl TokenIdentifierBuilder {
         detection::is_bitbucket_token(value)
     }
 
+    /// Check if value is a Heroku modern API token
+    pub fn is_heroku_token(&self, value: &str) -> bool {
+        detection::is_heroku_token(value)
+    }
+
+    /// Check if value is a Linear API key
+    pub fn is_linear_token(&self, value: &str) -> bool {
+        detection::is_linear_token(value)
+    }
+
+    /// Check if value is a Doppler token (service/CLI/SCM/service-account)
+    pub fn is_doppler_token(&self, value: &str) -> bool {
+        detection::is_doppler_token(value)
+    }
+
+    /// Check if value is a Netlify Personal Access Token
+    pub fn is_netlify_token(&self, value: &str) -> bool {
+        detection::is_netlify_token(value)
+    }
+
+    /// Check if value is a Fly.io macaroon-based token
+    pub fn is_fly_io_token(&self, value: &str) -> bool {
+        detection::is_fly_io_token(value)
+    }
+
+    /// Check if value is a Render API key
+    pub fn is_render_token(&self, value: &str) -> bool {
+        detection::is_render_token(value)
+    }
+
+    /// Check if value is a PlanetScale service token
+    pub fn is_planetscale_token(&self, value: &str) -> bool {
+        detection::is_planetscale_token(value)
+    }
+
+    /// Check if value is a Supabase Personal Access Token
+    pub fn is_supabase_token(&self, value: &str) -> bool {
+        detection::is_supabase_token(value)
+    }
+
     /// Check if value is a 1Password service account token
     pub fn is_onepassword_token(&self, value: &str) -> bool {
         detection::is_onepassword_token(value)

--- a/crates/octarine/src/primitives/identifiers/token/detection/api_keys/dev_platforms.rs
+++ b/crates/octarine/src/primitives/identifiers/token/detection/api_keys/dev_platforms.rs
@@ -1,0 +1,172 @@
+//! Developer-platform API key detection (Heroku, Linear, Doppler, Netlify,
+//! Fly.io, Render, PlanetScale, Supabase).
+//!
+//! Each provider has a distinctive, unambiguous prefix that makes
+//! single-token detection reliable without surrounding context. Providers
+//! that require context-aware detection (Heroku legacy UUID, Railway,
+//! Vercel) and providers whose tokens are indistinguishable from generic
+//! JWT (Supabase service-role keys) are intentionally not included here.
+
+use super::super::super::super::common::patterns;
+use super::MAX_IDENTIFIER_LENGTH;
+
+/// Check if value is a Heroku modern API token (HRKU-AA prefix).
+#[must_use]
+pub fn is_heroku_token(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.len() > MAX_IDENTIFIER_LENGTH {
+        return false;
+    }
+    patterns::network::API_KEY_HEROKU.is_match(trimmed)
+}
+
+/// Check if value is a Linear API key (lin_api_ prefix).
+#[must_use]
+pub fn is_linear_token(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.len() > MAX_IDENTIFIER_LENGTH {
+        return false;
+    }
+    patterns::network::API_KEY_LINEAR.is_match(trimmed)
+}
+
+/// Check if value is a Doppler token (service, CLI, SCM, or service-account).
+#[must_use]
+pub fn is_doppler_token(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.len() > MAX_IDENTIFIER_LENGTH {
+        return false;
+    }
+    patterns::network::API_KEY_DOPPLER.is_match(trimmed)
+}
+
+/// Check if value is a Netlify Personal Access Token (nfp_ prefix).
+#[must_use]
+pub fn is_netlify_token(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.len() > MAX_IDENTIFIER_LENGTH {
+        return false;
+    }
+    patterns::network::API_KEY_NETLIFY.is_match(trimmed)
+}
+
+/// Check if value is a Fly.io macaroon-based token (FlyV1 prefix).
+#[must_use]
+pub fn is_fly_io_token(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.len() > MAX_IDENTIFIER_LENGTH {
+        return false;
+    }
+    patterns::network::API_KEY_FLY_IO.is_match(trimmed)
+}
+
+/// Check if value is a Render API key (rnd_ prefix).
+#[must_use]
+pub fn is_render_token(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.len() > MAX_IDENTIFIER_LENGTH {
+        return false;
+    }
+    patterns::network::API_KEY_RENDER.is_match(trimmed)
+}
+
+/// Check if value is a PlanetScale service token (pscale_tkn_ prefix).
+#[must_use]
+pub fn is_planetscale_token(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.len() > MAX_IDENTIFIER_LENGTH {
+        return false;
+    }
+    patterns::network::API_KEY_PLANETSCALE.is_match(trimmed)
+}
+
+/// Check if value is a Supabase Personal Access Token (sbp_ prefix).
+#[must_use]
+pub fn is_supabase_token(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.len() > MAX_IDENTIFIER_LENGTH {
+        return false;
+    }
+    patterns::network::API_KEY_SUPABASE.is_match(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_is_heroku_token() {
+        let token = format!("HRKU-AA{}", "a".repeat(58));
+        assert!(is_heroku_token(&token));
+        assert!(!is_heroku_token(&format!("HRKU-AA{}", "a".repeat(10))));
+        assert!(!is_heroku_token(&format!("hrku-aa{}", "a".repeat(58))));
+        assert!(!is_heroku_token(""));
+    }
+
+    #[test]
+    fn test_is_linear_token() {
+        let token = format!("lin_api_{}", "A".repeat(40));
+        assert!(is_linear_token(&token));
+        assert!(!is_linear_token(&format!("lin_api_{}", "A".repeat(10))));
+        assert!(!is_linear_token(&format!("LIN_API_{}", "A".repeat(40))));
+    }
+
+    #[test]
+    fn test_is_doppler_token() {
+        assert!(is_doppler_token(&format!("dp.st.{}", "a".repeat(40))));
+        assert!(is_doppler_token(&format!("dp.ct.{}", "a".repeat(40))));
+        assert!(is_doppler_token(&format!("dp.scm.{}", "a".repeat(40))));
+        assert!(is_doppler_token(&format!("dp.sa.{}", "a".repeat(40))));
+        assert!(!is_doppler_token(&format!("dp.xx.{}", "a".repeat(40))));
+        assert!(!is_doppler_token(&format!("dp.st.{}", "a".repeat(10))));
+    }
+
+    #[test]
+    fn test_is_netlify_token() {
+        let token = format!("nfp_{}", "a".repeat(40));
+        assert!(is_netlify_token(&token));
+        assert!(!is_netlify_token(&format!("nfp_{}", "a".repeat(10))));
+        assert!(!is_netlify_token(&format!("NFP_{}", "a".repeat(40))));
+    }
+
+    #[test]
+    fn test_is_fly_io_token() {
+        let token = format!("FlyV1 {}", "a".repeat(100));
+        assert!(is_fly_io_token(&token));
+        assert!(!is_fly_io_token(&format!("FlyV1 {}", "a".repeat(10))));
+        assert!(!is_fly_io_token(&format!("FlyV2 {}", "a".repeat(100))));
+    }
+
+    #[test]
+    fn test_is_render_token() {
+        let token = format!("rnd_{}", "A".repeat(32));
+        assert!(is_render_token(&token));
+        assert!(!is_render_token(&format!("rnd_{}", "A".repeat(10))));
+        assert!(!is_render_token(&format!("RND_{}", "A".repeat(32))));
+    }
+
+    #[test]
+    fn test_is_planetscale_token() {
+        let token = format!("pscale_tkn_{}", "A".repeat(40));
+        assert!(is_planetscale_token(&token));
+        assert!(!is_planetscale_token(&format!(
+            "pscale_tkn_{}",
+            "A".repeat(10)
+        )));
+        assert!(!is_planetscale_token(&format!(
+            "pscale_pw_{}",
+            "A".repeat(40)
+        )));
+    }
+
+    #[test]
+    fn test_is_supabase_token() {
+        let token = format!("sbp_{}", "a".repeat(40));
+        assert!(is_supabase_token(&token));
+        // Wrong charset (uppercase) — sbp_ is hex-only
+        assert!(!is_supabase_token(&format!("sbp_{}", "A".repeat(40))));
+        // Too short
+        assert!(!is_supabase_token(&format!("sbp_{}", "a".repeat(10))));
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/token/detection/api_keys/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/token/detection/api_keys/mod.rs
@@ -19,6 +19,7 @@
 mod ai;
 mod aws;
 mod data_platforms;
+mod dev_platforms;
 mod email_marketing;
 mod generic;
 mod google;
@@ -33,6 +34,7 @@ mod source_control;
 pub use ai::*;
 pub use aws::*;
 pub use data_platforms::*;
+pub use dev_platforms::*;
 pub use email_marketing::*;
 pub use generic::*;
 pub use google::*;
@@ -258,6 +260,36 @@ pub fn detect_api_key_provider(key: &str) -> Option<ApiKeyProvider> {
         return Some(ApiKeyProvider::Bitbucket);
     }
 
+    // Developer-platform tokens (prefix-based, unambiguous)
+    if key.starts_with("HRKU-AA") {
+        return Some(ApiKeyProvider::Heroku);
+    }
+    if key_lower.starts_with("lin_api_") {
+        return Some(ApiKeyProvider::Linear);
+    }
+    if key_lower.starts_with("dp.st.")
+        || key_lower.starts_with("dp.ct.")
+        || key_lower.starts_with("dp.scm.")
+        || key_lower.starts_with("dp.sa.")
+    {
+        return Some(ApiKeyProvider::Doppler);
+    }
+    if key_lower.starts_with("nfp_") {
+        return Some(ApiKeyProvider::Netlify);
+    }
+    if key.starts_with("FlyV1 ") {
+        return Some(ApiKeyProvider::FlyIo);
+    }
+    if key_lower.starts_with("rnd_") {
+        return Some(ApiKeyProvider::Render);
+    }
+    if key_lower.starts_with("pscale_tkn_") {
+        return Some(ApiKeyProvider::PlanetScale);
+    }
+    if key_lower.starts_with("sbp_") {
+        return Some(ApiKeyProvider::Supabase);
+    }
+
     // Generic/unknown provider
     Some(ApiKeyProvider::Generic)
 }
@@ -300,6 +332,14 @@ pub fn is_api_key(value: &str) -> bool {
         || patterns::network::API_KEY_OPENAI_LEGACY.is_match(trimmed)
         || patterns::network::API_KEY_OPENAI_PROJECT.is_match(trimmed)
         || patterns::network::API_KEY_OPENAI_ORG.is_match(trimmed)
+        || patterns::network::API_KEY_HEROKU.is_match(trimmed)
+        || patterns::network::API_KEY_LINEAR.is_match(trimmed)
+        || patterns::network::API_KEY_DOPPLER.is_match(trimmed)
+        || patterns::network::API_KEY_NETLIFY.is_match(trimmed)
+        || patterns::network::API_KEY_FLY_IO.is_match(trimmed)
+        || patterns::network::API_KEY_RENDER.is_match(trimmed)
+        || patterns::network::API_KEY_PLANETSCALE.is_match(trimmed)
+        || patterns::network::API_KEY_SUPABASE.is_match(trimmed)
         || (trimmed.len() <= MAX_AZURE_KEY_LENGTH
             && patterns::network::API_KEY_AZURE.is_match(trimmed))
 }
@@ -737,6 +777,78 @@ mod tests {
         assert_eq!(
             detect_api_key_provider(&format!("org-{}", "a".repeat(24))),
             Some(ApiKeyProvider::OpenAi)
+        );
+    }
+
+    // ========================================================================
+    // detect_api_key_provider — developer-platform tokens
+    // ========================================================================
+
+    #[test]
+    fn test_detect_heroku_provider() {
+        assert_eq!(
+            detect_api_key_provider(&format!("HRKU-AA{}", "a".repeat(58))),
+            Some(ApiKeyProvider::Heroku)
+        );
+    }
+
+    #[test]
+    fn test_detect_linear_provider() {
+        assert_eq!(
+            detect_api_key_provider(&format!("lin_api_{}", "A".repeat(40))),
+            Some(ApiKeyProvider::Linear)
+        );
+    }
+
+    #[test]
+    fn test_detect_doppler_provider() {
+        assert_eq!(
+            detect_api_key_provider(&format!("dp.st.{}", "a".repeat(40))),
+            Some(ApiKeyProvider::Doppler)
+        );
+        assert_eq!(
+            detect_api_key_provider(&format!("dp.sa.{}", "a".repeat(40))),
+            Some(ApiKeyProvider::Doppler)
+        );
+    }
+
+    #[test]
+    fn test_detect_netlify_provider() {
+        assert_eq!(
+            detect_api_key_provider(&format!("nfp_{}", "a".repeat(40))),
+            Some(ApiKeyProvider::Netlify)
+        );
+    }
+
+    #[test]
+    fn test_detect_fly_io_provider() {
+        assert_eq!(
+            detect_api_key_provider(&format!("FlyV1 {}", "a".repeat(100))),
+            Some(ApiKeyProvider::FlyIo)
+        );
+    }
+
+    #[test]
+    fn test_detect_render_provider() {
+        assert_eq!(
+            detect_api_key_provider(&format!("rnd_{}", "A".repeat(32))),
+            Some(ApiKeyProvider::Render)
+        );
+    }
+
+    #[test]
+    fn test_detect_planetscale_provider() {
+        assert_eq!(
+            detect_api_key_provider(&format!("pscale_tkn_{}", "A".repeat(40))),
+            Some(ApiKeyProvider::PlanetScale)
+        );
+    }
+
+    #[test]
+    fn test_detect_supabase_provider() {
+        assert_eq!(
+            detect_api_key_provider(&format!("sbp_{}", "a".repeat(40))),
+            Some(ApiKeyProvider::Supabase)
         );
     }
 

--- a/crates/octarine/src/primitives/identifiers/token/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/token/detection/mod.rs
@@ -49,13 +49,15 @@ pub use api_keys::{
     detect_api_key_provider, is_api_key, is_artifactory_token, is_aws_access_key,
     is_aws_secret_key, is_aws_session_token, is_azure_connection_string, is_azure_key,
     is_bearer_token, is_bitbucket_token, is_brevo_key, is_cloudflare_ca_key, is_databricks_token,
-    is_discord_token, is_discord_webhook, is_docker_hub_token, is_firebase_fcm_key, is_gcp_api_key,
-    is_gcp_oauth_client_secret, is_gcp_service_account, is_gcp_service_account_email,
-    is_github_token, is_gitlab_token, is_mailchimp_key, is_mailgun_key, is_npm_token, is_nuget_key,
-    is_onepassword_token, is_onepassword_vault_ref, is_openai_key, is_paypal_token, is_pypi_token,
-    is_resend_key, is_sendgrid_key, is_shopify_token, is_slack_token, is_slack_webhook,
-    is_square_token, is_stripe_key, is_telegram_bot_token, is_test_api_key, is_twilio_account_sid,
-    is_twilio_api_key_sid, is_url_with_credentials, is_vault_token,
+    is_discord_token, is_discord_webhook, is_docker_hub_token, is_doppler_token,
+    is_firebase_fcm_key, is_fly_io_token, is_gcp_api_key, is_gcp_oauth_client_secret,
+    is_gcp_service_account, is_gcp_service_account_email, is_github_token, is_gitlab_token,
+    is_heroku_token, is_linear_token, is_mailchimp_key, is_mailgun_key, is_netlify_token,
+    is_npm_token, is_nuget_key, is_onepassword_token, is_onepassword_vault_ref, is_openai_key,
+    is_paypal_token, is_planetscale_token, is_pypi_token, is_render_token, is_resend_key,
+    is_sendgrid_key, is_shopify_token, is_slack_token, is_slack_webhook, is_square_token,
+    is_stripe_key, is_supabase_token, is_telegram_bot_token, is_test_api_key,
+    is_twilio_account_sid, is_twilio_api_key_sid, is_url_with_credentials, is_vault_token,
 };
 
 // Re-export SSH functions
@@ -187,6 +189,30 @@ pub fn detect_token_type(value: &str) -> Option<TokenType> {
     }
     if is_openai_key(trimmed) {
         return Some(TokenType::OpenAiKey);
+    }
+    if is_heroku_token(trimmed) {
+        return Some(TokenType::HerokuToken);
+    }
+    if is_linear_token(trimmed) {
+        return Some(TokenType::LinearToken);
+    }
+    if is_doppler_token(trimmed) {
+        return Some(TokenType::DopplerToken);
+    }
+    if is_netlify_token(trimmed) {
+        return Some(TokenType::NetlifyToken);
+    }
+    if is_fly_io_token(trimmed) {
+        return Some(TokenType::FlyIoToken);
+    }
+    if is_render_token(trimmed) {
+        return Some(TokenType::RenderToken);
+    }
+    if is_planetscale_token(trimmed) {
+        return Some(TokenType::PlanetScaleToken);
+    }
+    if is_supabase_token(trimmed) {
+        return Some(TokenType::SupabaseToken);
     }
     if is_aws_access_key(trimmed) {
         return Some(TokenType::AwsAccessKey);
@@ -325,7 +351,15 @@ pub fn detect_token_identifier(value: &str) -> Option<IdentifierType> {
         | TokenType::TwilioToken
         | TokenType::SendGridToken
         | TokenType::OpenAiKey
-        | TokenType::BitbucketToken => IdentifierType::ApiKey,
+        | TokenType::BitbucketToken
+        | TokenType::HerokuToken
+        | TokenType::LinearToken
+        | TokenType::DopplerToken
+        | TokenType::NetlifyToken
+        | TokenType::FlyIoToken
+        | TokenType::RenderToken
+        | TokenType::PlanetScaleToken
+        | TokenType::SupabaseToken => IdentifierType::ApiKey,
     })
 }
 

--- a/crates/octarine/src/primitives/identifiers/token/detection/types.rs
+++ b/crates/octarine/src/primitives/identifiers/token/detection/types.rs
@@ -73,6 +73,22 @@ pub enum ApiKeyProvider {
     OpenAi,
     /// Bitbucket Cloud app passwords (ATBB...)
     Bitbucket,
+    /// Heroku modern API token (`HRKU-AA[A-Za-z0-9_-]{58}`)
+    Heroku,
+    /// Linear API key (`lin_api_[A-Za-z0-9]{40}`)
+    Linear,
+    /// Doppler tokens (`dp.{st,ct,scm,sa}.[A-Za-z0-9_-]{40,}`)
+    Doppler,
+    /// Netlify Personal Access Token (`nfp_[A-Za-z0-9]{40,}`)
+    Netlify,
+    /// Fly.io macaroon-based token (`FlyV1 [A-Za-z0-9_-]{100,}`)
+    FlyIo,
+    /// Render API key (`rnd_[A-Za-z0-9]{32,}`)
+    Render,
+    /// PlanetScale service token (`pscale_tkn_[A-Za-z0-9_-]{40,}`)
+    PlanetScale,
+    /// Supabase Personal Access Token (`sbp_[a-f0-9]{40}`)
+    Supabase,
     /// Generic or unknown provider
     Generic,
 }
@@ -111,6 +127,14 @@ impl std::fmt::Display for ApiKeyProvider {
             Self::SendGrid => write!(f, "SendGrid"),
             Self::OpenAi => write!(f, "OpenAI"),
             Self::Bitbucket => write!(f, "Bitbucket"),
+            Self::Heroku => write!(f, "Heroku"),
+            Self::Linear => write!(f, "Linear"),
+            Self::Doppler => write!(f, "Doppler"),
+            Self::Netlify => write!(f, "Netlify"),
+            Self::FlyIo => write!(f, "Fly.io"),
+            Self::Render => write!(f, "Render"),
+            Self::PlanetScale => write!(f, "PlanetScale"),
+            Self::Supabase => write!(f, "Supabase"),
             Self::Generic => write!(f, "Generic"),
         }
     }
@@ -309,4 +333,20 @@ pub enum TokenType {
     OpenAiKey,
     /// Bitbucket Cloud App Password (ATBB...)
     BitbucketToken,
+    /// Heroku modern API token (HRKU-AA prefix)
+    HerokuToken,
+    /// Linear API key (lin_api_ prefix)
+    LinearToken,
+    /// Doppler service/CLI/SCM/service-account token
+    DopplerToken,
+    /// Netlify Personal Access Token (nfp_ prefix)
+    NetlifyToken,
+    /// Fly.io macaroon-based token (FlyV1 prefix)
+    FlyIoToken,
+    /// Render API key (rnd_ prefix)
+    RenderToken,
+    /// PlanetScale service token (pscale_tkn_ prefix)
+    PlanetScaleToken,
+    /// Supabase Personal Access Token (sbp_ prefix)
+    SupabaseToken,
 }


### PR DESCRIPTION
## Summary

Adds detection for 8 prefix-detectable developer-platform tokens that the
PII scanner currently misses or buckets into the generic `ApiKey` variant:

| Provider     | Prefix                                  |
| ------------ | --------------------------------------- |
| Heroku       | `HRKU-AA[A-Za-z0-9_-]{58}`              |
| Linear       | `lin_api_[A-Za-z0-9]{40}`               |
| Doppler      | `dp.{st,ct,scm,sa}.[A-Za-z0-9_-]{40,}`  |
| Netlify      | `nfp_[A-Za-z0-9]{40,}`                  |
| Fly.io       | `FlyV1 [A-Za-z0-9_-]{100,}` (macaroon)  |
| Render       | `rnd_[A-Za-z0-9]{32,}`                  |
| PlanetScale  | `pscale_tkn_[A-Za-z0-9_-]{40,}`         |
| Supabase PAT | `sbp_[a-f0-9]{40}`                      |

Each provider is wired all the way through the stack:

- regex pattern in `primitives/identifiers/common/patterns/network/credential_patterns.rs`
- detector in new `primitives/identifiers/token/detection/api_keys/dev_platforms.rs`
- prefix branch in `detect_api_key_provider`, `is_api_key`, `detect_token_type`, `detect_token_identifier`
- new `ApiKeyProvider`, `TokenType`, and `PiiType` variants
- primitives builder + Layer 3 builder methods + public shortcuts
- PII scanner mapping (`token_type_to_pii`), classifier (`is_secret` + `is_high_risk`), and redactor (routes through generic `redact_api_keys`)

## Deferred (intentionally out of scope for #27)

Issue lists 10 providers, this PR ships 8. Skipped:

- **Heroku legacy UUID, Railway, Vercel** — UUID-shaped or low-entropy tokens that require context-aware detection (e.g. "heroku" keyword proximity). The existing `detect_api_key_provider` is strictly prefix-based and bolting on context detection would expand effort/small into something much larger. Will file a follow-up if there's demand.
- **Supabase service-role JWT** — indistinguishable from any other JWT without payload parsing; generic `Jwt` detection already covers it.

## Test plan

- [x] `just fmt` clean
- [x] `just clippy` clean (zero warnings)
- [x] `just test-mod token::detection` — 118/118 passing
- [x] `just test-mod token::detection::api_keys::dev_platforms` — 8/8 detector tests
- [x] `just test-filter developer_platform` — shortcut integration test
- [x] `just arch-check` — layer boundaries respected
- [x] Per-provider positive + wrong-prefix-negative + too-short-negative coverage in `dev_platforms.rs`
- [x] Dispatcher tests in `api_keys/mod.rs` for all 8 providers

Closes #27