### PR TITLE
docs(ci): add GitHub issue templates for bug, feature, and task

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug report
+about: Report something that worked before and is now broken
+title: ""
+labels: ["type/bug", "severity/medium"]
+assignees: []
+---
+
+<!--
+Triage hints (these comments disappear after you submit):
+- Adjust the severity/* label if this is not severity/medium
+  (critical / high / medium / low — see CLAUDE.md or .claude/skills/file-issue/label-guide.md).
+- Add an effort/* label once the affected files are known
+  (trivial / small / medium / large).
+- Add a component/* label if one already exists for the affected area.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what is broken and the impact. -->
+
+## Problem
+
+<!-- Describe the incorrect current behavior. Include error output, stack
+traces, or screenshots if useful. -->
+
+## Steps to Reproduce
+
+1. <!-- Step 1 -->
+2. <!-- Step 2 -->
+3. <!-- Observed: description of incorrect behavior -->
+
+## Expected Behavior
+
+<!-- What should happen instead. -->
+
+## Proposed Solution
+
+<!-- Optional. If you have a fix in mind, sketch it here so the implementer
+can plan without further clarification. -->
+
+## Acceptance Criteria
+
+- [ ] <!-- Concrete, testable criterion -->
+- [ ] <!-- Each checkbox = one verifiable behavior or state -->
+
+## Affected Files
+
+- `path/to/file.rs` — <!-- what is wrong here -->
+
+## Context
+
+<!-- Environment (OS, rustc version, octarine version, feature flags),
+related issues (#N), and anything else useful. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,48 @@
+---
+name: Feature request
+about: Propose a new capability or enhancement
+title: ""
+labels: ["type/feature", "severity/medium"]
+assignees: []
+---
+
+<!--
+Triage hints (these comments disappear after you submit):
+- Adjust the severity/* label if this is not severity/medium
+  (critical / high / medium / low — see CLAUDE.md or .claude/skills/file-issue/label-guide.md).
+- Add an effort/* label once the affected files are known
+  (trivial / small / medium / large).
+- Add a component/* label if one already exists for the affected area.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what is missing and why it is worth adding. -->
+
+## Problem
+
+<!-- What can't be done today, or what is awkward to do today. -->
+
+## User Story
+
+As a <!-- role -->, I want <!-- capability --> so that <!-- benefit -->.
+
+## Proposed Solution
+
+<!-- Expected approach. Be specific enough that an agent can plan
+implementation without further clarification. If alternatives were
+considered, note why this one was chosen. -->
+
+## Acceptance Criteria
+
+- [ ] <!-- Concrete, testable criterion -->
+- [ ] <!-- Each checkbox = one verifiable behavior or state -->
+
+## Affected Files
+
+- `path/to/file.rs` — <!-- what changes here -->
+- `path/to/directory/` — <!-- scope of changes -->
+
+## Context
+
+<!-- Background, related issues (#N), upstream/downstream constraints. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,51 @@
+---
+name: Task
+about: Refactor, docs, tests, chore, operations, or other non-bug / non-feature work
+title: ""
+labels: ["severity/medium"]
+assignees: []
+---
+
+<!--
+Triage hints (these comments disappear after you submit):
+- This template does not pre-apply a type/* label because Task covers
+  multiple types. Add the appropriate one after submitting:
+    type/refactor   — restructuring without behavior change
+    type/docs       — documentation-only change
+    type/test       — test addition or fix
+    type/operations — CI, tooling, deployment, infrastructure
+- Adjust the severity/* label if this is not severity/medium
+  (critical / high / medium / low).
+- Add an effort/* label once the affected files are known
+  (trivial / small / medium / large).
+- Add a component/* label if one already exists for the affected area.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what needs to change and why. -->
+
+## Problem
+
+<!-- Current state. For refactors: what is wrong with the current structure.
+For docs/tests/chores: the gap or maintenance burden being addressed. -->
+
+## Proposed Solution
+
+<!-- Expected approach. For refactors, describe the target state. Be
+specific enough that an agent can plan implementation without further
+clarification. -->
+
+## Acceptance Criteria
+
+- [ ] <!-- Concrete, testable criterion -->
+- [ ] <!-- Each checkbox = one verifiable behavior or state -->
+
+## Affected Files
+
+- `path/to/file.rs` — <!-- what changes here -->
+- `path/to/directory/` — <!-- scope of changes -->
+
+## Context
+
+<!-- Background, related issues (#N), constraints. -->


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/` with three Markdown templates (Bug, Feature, Task) plus a `config.yml` that disables blank issues.
- Each template's frontmatter auto-applies the relevant existing labels so issues filed via the GitHub UI land in `/next-issue`'s priority loop without manual triage.
- H2 sections (`## Summary`, `## Problem`, `## Acceptance Criteria`, `## Affected Files`, ...) match the parse anchors that the `file-issue` / `next-issue` skills already expect, so manually-filed and agent-filed issues look identical to downstream tooling.

### Label application

| Template | Auto-applied | Filer-applied after submit |
| --- | --- | --- |
| `bug_report.md` | `type/bug`, `severity/medium` | `effort/*`, `component/*`, adjust `severity/*` |
| `feature_request.md` | `type/feature`, `severity/medium` | `effort/*`, `component/*`, adjust `severity/*` |
| `task.md` | `severity/medium` | `type/*` (docs/refactor/test/operations), `effort/*`, `component/*`, adjust `severity/*` |

`task.md` deliberately omits `type/*` — it covers five different existing type labels and a default would be wrong as often as right. HTML-comment triage hints in each body remind the filer to set it after submission.

### Format choice

Markdown templates (`.md` + YAML frontmatter), **not** GitHub Issue Forms (`.yml`). Issue Forms render label sections as `### H3` headings, which would break the H2 anchors that `~/.claude/skills/file-issue/templates.md` defines. The cost of the Markdown approach is no client-side form validation — acceptable for a small-team workflow where the body schema matters more than the input UX.

## Test plan

- [x] YAML frontmatter parses cleanly via `yq` on all three `.md` templates and `config.yml`.
- [x] Every label referenced in frontmatter (`type/bug`, `type/feature`, `severity/medium`) exists on the repo.
- [x] H2 header ordering in each template matches `~/.claude/skills/file-issue/templates.md` (Base Template + type-specific sections in the documented order).
- [x] `lefthook` pre-commit checks pass (rumdl, dprint, gitleaks, conform).
- [ ] Post-merge: visit `/issues/new/choose` to confirm the chooser renders three templates and blank issues are disabled.

Closes #7