### PR TITLE
docs(architecture): document solo-maintainer posture and high-risk subsystems

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,45 @@
+# CODEOWNERS — octarine
+#
+# Documents the solo-maintainer posture (see README.md "Maintenance Status").
+# Every path matches the default rule below; the explicit blocks beneath it
+# are reminders that flag the highest-risk subsystems for extra-careful
+# review on every change.
+#
+# Syntax: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+# First match in this file wins for any given path.
+
+# Default — every file in the repo
+*                                                                       @joshjhall
+
+# -----------------------------------------------------------------------------
+# High-risk subsystems (audit finding architecture-008, issue #199)
+# Domain knowledge concentrated in a single maintainer; reviewer must
+# understand the subsystem's invariants before merging.
+# -----------------------------------------------------------------------------
+
+# Memory zeroization, mlock, NIST key classification
+/crates/octarine/src/crypto/secrets/                                    @joshjhall
+/crates/octarine/src/primitives/crypto/secrets/                         @joshjhall
+
+# SOC2, HIPAA, GDPR, PCI-DSS, ISO27001 control mappings
+/crates/octarine/src/observe/compliance/                                @joshjhall
+
+# Hybrid (post-quantum + classical) encryption scheme
+/crates/octarine/src/primitives/crypto/encryption/hybrid/                @joshjhall
+
+# Provider-specific API key detection (40+ formats)
+/crates/octarine/src/primitives/identifiers/token/detection/api_keys/    @joshjhall
+
+# -----------------------------------------------------------------------------
+# Load-bearing developer guidance
+# Changes to these files affect how every future contributor — human or
+# agent — implements the rest of the codebase.
+# -----------------------------------------------------------------------------
+
+/CLAUDE.md                                                              @joshjhall
+/docs/architecture/layer-architecture.md                                 @joshjhall
+/docs/security/                                                         @joshjhall
+/.claude/skills/octarine-architecture/                                   @joshjhall
+/.claude/skills/octarine-pii-bridge/                                     @joshjhall
+/.claude/skills/octarine-observe-integration/                            @joshjhall
+/.claude/skills/octarine-identifier-checklist/                           @joshjhall

--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ Layer 3: data/, security/, identifiers/, runtime/, crypto/, io/, auth/, http/  �
 
 See [`docs/`](docs/) for detailed documentation and [`crates/octarine/examples/`](crates/octarine/examples/) for runnable examples.
 
+## Maintenance Status
+
+octarine is currently maintained by a single author
+([@joshjhall](https://github.com/joshjhall)). Domain knowledge for
+specialized subsystems — memory zeroization, compliance control mappings,
+post-quantum encryption, and provider-specific token detection — is
+concentrated in this maintainer.
+
+This posture is intentional for the pre-1.0 phase. Before tagging `1.0`,
+the following high-risk subsystems are targeted for third-party review:
+
+- `crypto/secrets/*` — memory zeroization, mlock, NIST key classification
+- `observe/compliance/*` — SOC2, HIPAA, GDPR, PCI-DSS, ISO 27001 control
+  mappings
+- `primitives/crypto/encryption/hybrid/*` — hybrid (post-quantum +
+  classical) encryption scheme
+- `primitives/identifiers/token/detection/api_keys/*` — provider-specific
+  token format detection
+
+See [`.github/CODEOWNERS`](.github/CODEOWNERS) for the review-required
+path list and [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contributor
+on-ramp (dev setup, commit format, SemVer policy).
+
 ## License
 
 Dual-licensed under either of:


### PR DESCRIPTION
## Summary

Closes #199 (audit finding `architecture-008`, severity/low,
effort/medium) by making the solo-maintainer posture explicit and
committing publicly to pre-1.0 third-party review of the highest-risk
subsystems.

- **README.md**: new `## Maintenance Status` section between Architecture
  and License, naming the at-risk subsystems and linking to CODEOWNERS
  and CONTRIBUTING.md.
- **.github/CODEOWNERS**: default `* @joshjhall` rule plus explicit
  reminders for the four audit-flagged high-risk subsystems
  (`crypto/secrets`, `observe/compliance`, `crypto/encryption/hybrid`,
  `identifiers/token/detection/api_keys`) and load-bearing developer
  guidance (CLAUDE.md, layer-architecture.md, docs/security/, key
  `octarine-*` skills).

CONTRIBUTING.md already covers dev setup, commit format, and SemVer
policy — the audit's onboarding action item is already met. Skipped the
ADR suggestion: `docs/architecture/` doesn't use ADR format, and the
pre-1.0 review plan will firm up closer to 1.0.

## Test plan

Documentation-only change.

- [x] `just lint-md` — clean (rumdl, 80 files)
- [x] CODEOWNERS path-existence check — all 12 explicit paths resolve
- [x] Commit message validated by conform (`commit-msg` lefthook hook)
- [x] Manual review of README render — new section sits between
  Architecture and License, internal links resolve

Closes #199