### PR TITLE
fix(ci): install cargo-nextest in nightly test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,5 +445,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: nightly
+      - uses: taiki-e/install-action@cargo-nextest
       - uses: taiki-e/install-action@just
       - run: just test


### PR DESCRIPTION
## Summary
- The nightly test job calls `just test`, which uses `cargo nextest`, but the workflow only installed `just`, not `cargo-nextest`. The job exited immediately with `no such command: nextest`.
- The job is `continue-on-error: true`, so this didn't block PRs — but it meant the nightly test never actually ran.

## Test plan
- [ ] CI runs the nightly job to completion (Test (nightly) shows real test results, not an install-action failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)