### PR TITLE
feat(identifiers): add framework database credential detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to octarine will be documented in this file.
 
 ### Added
 
+- feat(identifiers): add framework database credential detection (#30)
+  - JDBC variants: Oracle thin (`jdbc:oracle:thin:user/pass@host`) and SQL Server semicolon format (`jdbc:sqlserver://host;user=X;password=Y`) extend the existing `is_connection_string_with_credentials` / `find_connection_strings_in_text` story
+  - New umbrella functions `is_framework_credential_present` / `find_framework_credentials_in_text` (+ Layer 3 builder methods and shortcuts) detect credentials in Django `'PASSWORD': 'value'` settings, Rails `password: value` YAML, `.env` keys (`DB_PASSWORD`, `MYSQL_PASSWORD`, `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `MONGO_PASSWORD`, `DATABASE_PASSWORD`, `POSTGRESQL_PASSWORD`), and Docker Compose env (`MYSQL_ROOT_PASSWORD`, `POSTGRES_PASSWORD`, `MONGO_INITDB_ROOT_PASSWORD`, `RABBITMQ_DEFAULT_PASS`, `REDIS_PASSWORD`)
+  - Redaction primitives `redact_framework_credential` / `redact_framework_credentials_in_text` preserve the key and replace the value with `****`; `redact_connection_string` extended to handle Oracle thin (`user/****@host`)
+  - PII scanner (`scan_for_pii`) maps framework matches to `PiiType::ConnectionString` — no new PII type variants needed
+  - Commented-out credentials (`# DB_PASSWORD=secret`) are also flagged since comments can be uncommented
+
 - feat(identifiers): add international postal codes (DE, FR, AU, JP, IN, NL, BR) (#37)
   - Per-country detection functions: `is_german_postal_code`, `is_french_postal_code`, `is_australian_postal_code`, `is_japanese_postal_code`, `is_indian_postal_code`, `is_dutch_postal_code`, `is_brazilian_postal_code`
   - `PostalCodeType` gains `GermanPostal`, `FrenchPostal`, `AustralianPostal`, `JapanesePostal`, `IndianPostal`, `DutchPostal`, `BrazilianPostal` variants

--- a/crates/octarine/src/identifiers/builder/credentials.rs
+++ b/crates/octarine/src/identifiers/builder/credentials.rs
@@ -330,6 +330,74 @@ impl CredentialsBuilder {
     }
 
     // =========================================================================
+    // Framework Credential Detection Methods
+    // =========================================================================
+
+    /// Check if text contains framework-style credential assignments
+    ///
+    /// Detects Django settings.py, Rails YAML, `.env`, and Docker Compose
+    /// password patterns. Commented-out credentials are also flagged.
+    #[must_use]
+    pub fn is_framework_credential_present(&self, text: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_framework_credential_present(text);
+
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+
+            if result {
+                increment_by(metric_names::secrets_found(), 1);
+                observe::warn(
+                    "framework_credential_detected",
+                    "Framework-style credential detected in text",
+                );
+            }
+        }
+
+        result
+    }
+
+    /// Find all framework-style credential matches in text
+    #[must_use]
+    pub fn find_framework_credentials_in_text(&self, text: &str) -> Vec<CredentialMatch> {
+        let matches = self.inner.find_framework_credentials_in_text(text);
+
+        if self.emit_events && !matches.is_empty() {
+            increment_by(metric_names::secrets_found(), matches.len() as u64);
+            observe::warn(
+                "framework_credentials_in_text",
+                format!("Found {} framework credential(s)", matches.len()),
+            );
+        }
+
+        matches
+    }
+
+    /// Redact the value of a framework credential while preserving the key
+    #[must_use]
+    pub fn redact_framework_credential(&self, value: &str) -> String {
+        self.inner.redact_framework_credential(value)
+    }
+
+    /// Redact all framework-style credentials in text
+    #[must_use]
+    pub fn redact_framework_credentials_in_text<'a>(&self, text: &'a str) -> Cow<'a, str> {
+        let result = self.inner.redact_framework_credentials_in_text(text);
+
+        if self.emit_events && result != text {
+            observe::info(
+                "framework_credentials_redacted",
+                "Framework credentials redacted from text",
+            );
+        }
+
+        result
+    }
+
+    // =========================================================================
     // Weak Pattern Detection Methods
     // =========================================================================
 
@@ -566,5 +634,53 @@ mod tests {
         let builder = CredentialsBuilder::silent();
         assert!(builder.is_weak_passphrase("correct horse battery staple"));
         assert!(!builder.is_weak_passphrase("purple elephant dancing gracefully"));
+    }
+
+    // ========================================================================
+    // Framework credential detection (issue #30)
+    // ========================================================================
+
+    #[test]
+    fn test_is_framework_credential_present_layer3() {
+        let builder = CredentialsBuilder::silent();
+        assert!(builder.is_framework_credential_present("DB_PASSWORD=secret"));
+        assert!(builder.is_framework_credential_present("'PASSWORD': 'sv'"));
+        assert!(!builder.is_framework_credential_present("APP_HOST=localhost"));
+    }
+
+    #[test]
+    fn test_find_framework_credentials_in_text_layer3() {
+        let builder = CredentialsBuilder::silent();
+        let matches =
+            builder.find_framework_credentials_in_text("DB_PASSWORD=secret\nREDIS_PASSWORD=foo");
+        assert_eq!(matches.len(), 2);
+        assert!(matches.iter().all(|m| m.label == "env_db_password"));
+    }
+
+    #[test]
+    fn test_redact_framework_credential_layer3() {
+        let builder = CredentialsBuilder::silent();
+        assert_eq!(
+            builder.redact_framework_credential("DB_PASSWORD=secret"),
+            "DB_PASSWORD=****"
+        );
+    }
+
+    #[test]
+    fn test_redact_framework_credentials_in_text_layer3() {
+        let builder = CredentialsBuilder::silent();
+        let text = "MYSQL_PASSWORD=secret123\nAPP_HOST=localhost";
+        let result = builder.redact_framework_credentials_in_text(text);
+        assert!(result.contains("MYSQL_PASSWORD=****"));
+        assert!(result.contains("APP_HOST=localhost"));
+        assert!(!result.contains("secret123"));
+    }
+
+    #[test]
+    fn test_redact_connection_string_jdbc_oracle_layer3() {
+        let builder = CredentialsBuilder::silent();
+        let result = builder.redact_connection_string("jdbc:oracle:thin:scott/tiger@h:1521:o");
+        assert!(result.contains("scott/****@"));
+        assert!(!result.contains("tiger"));
     }
 }

--- a/crates/octarine/src/identifiers/shortcuts/credentials.rs
+++ b/crates/octarine/src/identifiers/shortcuts/credentials.rs
@@ -37,3 +37,72 @@ pub fn redact_connection_strings(text: &str) -> String {
         .redact_connection_strings_in_text(text)
         .to_string()
 }
+
+/// Check if text contains framework-style credentials (Django, Rails YAML, .env, Docker Compose)
+#[must_use]
+pub fn is_framework_credential(text: &str) -> bool {
+    CredentialsBuilder::new().is_framework_credential_present(text)
+}
+
+/// Find all framework-style credential matches in text
+#[must_use]
+pub fn find_framework_credentials(text: &str) -> Vec<CredentialMatch> {
+    CredentialsBuilder::new().find_framework_credentials_in_text(text)
+}
+
+/// Redact the value of a framework credential while preserving the key
+#[must_use]
+pub fn redact_framework_credential(value: &str) -> String {
+    CredentialsBuilder::new().redact_framework_credential(value)
+}
+
+/// Redact all framework-style credentials in text
+#[must_use]
+pub fn redact_framework_credentials(text: &str) -> String {
+    CredentialsBuilder::new()
+        .redact_framework_credentials_in_text(text)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_is_connection_string_with_credentials_shortcut() {
+        assert!(is_connection_string_with_credentials("postgres://u:p@h/db"));
+        assert!(!is_connection_string_with_credentials("hello world"));
+    }
+
+    #[test]
+    fn test_is_framework_credential_shortcut() {
+        assert!(is_framework_credential("DB_PASSWORD=secret"));
+        assert!(is_framework_credential("'PASSWORD': 'sv'"));
+        assert!(!is_framework_credential("APP_HOST=localhost"));
+    }
+
+    #[test]
+    fn test_find_framework_credentials_shortcut() {
+        let matches = find_framework_credentials("DB_PASSWORD=secret");
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("one match");
+        assert_eq!(first.value, "secret");
+    }
+
+    #[test]
+    fn test_redact_framework_credential_shortcut() {
+        assert_eq!(
+            redact_framework_credential("DB_PASSWORD=secret"),
+            "DB_PASSWORD=****"
+        );
+    }
+
+    #[test]
+    fn test_redact_framework_credentials_shortcut() {
+        let text = "DB_PASSWORD=secret\nAPP_HOST=localhost";
+        let result = redact_framework_credentials(text);
+        assert!(result.contains("DB_PASSWORD=****"));
+        assert!(result.contains("APP_HOST=localhost"));
+    }
+}

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -415,6 +415,15 @@ pub(super) fn scan_tokens(text: &str, pii_types: &mut Vec<PiiType>) {
         pii_types.push(PiiType::ConnectionString);
     }
 
+    // Framework-style credentials (Django, Rails YAML, .env, Docker Compose).
+    // Mapped to ConnectionString since they identify the same kind of secret —
+    // database access credentials in application configuration.
+    if credential.is_framework_credential_present(text)
+        && !pii_types.contains(&PiiType::ConnectionString)
+    {
+        pii_types.push(PiiType::ConnectionString);
+    }
+
     if credential.is_passwords_present(text) {
         pii_types.push(PiiType::Password);
     }

--- a/crates/octarine/src/observe/pii/scanner/mod.rs
+++ b/crates/octarine/src/observe/pii/scanner/mod.rs
@@ -304,6 +304,27 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_for_pii_framework_credentials_env() {
+        let text = "DB_PASSWORD=secret123";
+        let types = scan_for_pii(text);
+        assert!(types.contains(&PiiType::ConnectionString));
+    }
+
+    #[test]
+    fn test_scan_for_pii_framework_credentials_docker_compose() {
+        let text = "environment:\n  - MYSQL_ROOT_PASSWORD=hunter2";
+        let types = scan_for_pii(text);
+        assert!(types.contains(&PiiType::ConnectionString));
+    }
+
+    #[test]
+    fn test_scan_for_pii_framework_credentials_django() {
+        let text = "DATABASES = {'default': {'PASSWORD': 'sv'}}";
+        let types = scan_for_pii(text);
+        assert!(types.contains(&PiiType::ConnectionString));
+    }
+
+    #[test]
     fn test_scan_for_pii_biometric_template_iso_19794() {
         // ISO/IEC 19794 template with FMR header marker and 54 base64-like chars.
         // scan_biometric is off by default; enable it explicitly.

--- a/crates/octarine/src/primitives/identifiers/common/patterns/network/credential_patterns.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/network/credential_patterns.rs
@@ -422,3 +422,58 @@ pub static CONNECTION_STRING_DB_URL: Lazy<Regex> = Lazy::new(|| {
     )
     .expect("BUG: Invalid regex pattern")
 });
+
+/// JDBC Oracle thin driver connection string with slash-separated credentials
+/// Example: "jdbc:oracle:thin:scott/tiger@dbhost:1521:orcl"
+pub static CONNECTION_STRING_JDBC_ORACLE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)jdbc:oracle:[a-z]+:[^/\s:@]+/[^@\s]+@[^\s]+")
+        .expect("BUG: Invalid regex pattern")
+});
+
+/// JDBC SQL Server connection string with semicolon-separated user/password params
+/// Example: "jdbc:sqlserver://host:1433;databaseName=db;user=sa;password=secret"
+pub static CONNECTION_STRING_JDBC_SQLSERVER: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)jdbc:sqlserver://[^\s;]+(?:;[^;\s]+)*;(?:password|pwd)=[^;\s]+")
+        .expect("BUG: Invalid regex pattern")
+});
+
+/// Django settings.py PASSWORD dict-literal entry
+/// Matches both single-quoted and double-quoted forms.
+/// Example: `'PASSWORD': 'secret_value'` or `"PASSWORD": "secret_value"`
+/// Capture groups: (1) single-quoted value, (2) double-quoted value (exactly
+/// one of the two will be non-empty for any given match).
+pub static FRAMEWORK_DJANGO_PASSWORD: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?:'PASSWORD'\s*:\s*'([^']+)'|"PASSWORD"\s*:\s*"([^"]+)")"#)
+        .expect("BUG: Invalid regex pattern")
+});
+
+/// Rails / generic YAML `password: value` entries
+/// Capture groups: (1) value. Allows optional `#` to flag commented lines.
+/// Example: `  password: secret_value` or `# password: secret_value`
+pub static FRAMEWORK_RAILS_YAML_PASSWORD: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?im)^[ \t]*#?[ \t]*password[ \t]*:[ \t]+(\S+)")
+        .expect("BUG: Invalid regex pattern")
+});
+
+/// .env file database password keys
+/// Capture groups: (1) key name, (2) value.
+/// Matches: DB_PASSWORD, DATABASE_PASSWORD, REDIS_PASSWORD, MYSQL_PASSWORD,
+/// POSTGRES_PASSWORD, POSTGRESQL_PASSWORD, MONGO_PASSWORD.
+/// Allows optional `#` to flag commented lines.
+pub static FRAMEWORK_ENV_DB_PASSWORD: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?m)^[ \t]*#?[ \t]*(DB_PASSWORD|DATABASE_PASSWORD|REDIS_PASSWORD|MYSQL_PASSWORD|POSTGRES_PASSWORD|POSTGRESQL_PASSWORD|MONGO_PASSWORD)[ \t]*=[ \t]*(\S+)"
+    )
+    .expect("BUG: Invalid regex pattern")
+});
+
+/// Docker Compose root-password environment variables
+/// Capture groups: (1) key name, (2) value.
+/// Matches both `KEY=value` (compose list-with-dash form) and `KEY: value`
+/// (compose dict form). Allows optional `#` to flag commented lines.
+pub static FRAMEWORK_DOCKER_COMPOSE_PASSWORD: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?m)^[ \t]*#?[ \t]*-?[ \t]*(MYSQL_ROOT_PASSWORD|POSTGRES_PASSWORD|MONGO_INITDB_ROOT_PASSWORD|RABBITMQ_DEFAULT_PASS|REDIS_PASSWORD)[ \t]*[=:][ \t]*(\S+)"
+    )
+    .expect("BUG: Invalid regex pattern")
+});

--- a/crates/octarine/src/primitives/identifiers/credentials/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/credentials/builder.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 
-use super::{detection, redaction, sanitization, validation};
+use super::{detection, framework, redaction, sanitization, validation};
 
 /// Builder for credential identifier operations
 ///
@@ -129,6 +129,38 @@ impl CredentialIdentifierBuilder {
     #[must_use]
     pub fn redact_connection_strings_in_text<'a>(&self, text: &'a str) -> Cow<'a, str> {
         sanitization::redact_connection_strings_in_text(text)
+    }
+
+    // Framework credential detection methods
+
+    /// Check if text contains framework-style credential assignments
+    ///
+    /// Detects Django settings.py, Rails YAML, `.env`, and Docker Compose
+    /// password patterns. Commented-out credentials are also flagged.
+    #[must_use]
+    pub fn is_framework_credential_present(&self, text: &str) -> bool {
+        framework::is_framework_credential_present(text)
+    }
+
+    /// Find all framework-style credential matches in text
+    #[must_use]
+    pub fn find_framework_credentials_in_text(
+        &self,
+        text: &str,
+    ) -> Vec<detection::CredentialMatch> {
+        framework::find_framework_credentials_in_text(text)
+    }
+
+    /// Redact the value of a framework credential while preserving the key
+    #[must_use]
+    pub fn redact_framework_credential(&self, value: &str) -> String {
+        sanitization::redact_framework_credential(value)
+    }
+
+    /// Redact all framework-style credentials in text
+    #[must_use]
+    pub fn redact_framework_credentials_in_text<'a>(&self, text: &'a str) -> Cow<'a, str> {
+        sanitization::redact_framework_credentials_in_text(text)
     }
 
     // Validation methods

--- a/crates/octarine/src/primitives/identifiers/credentials/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/credentials/detection.rs
@@ -429,14 +429,17 @@ const DB_SCHEMES: &[&str] = &[
 /// Check if value is a connection string with embedded credentials
 ///
 /// Detects URL-based connection strings (postgres://, mysql://, etc.),
-/// MSSQL key-value format (Server=...;Password=...), and JDBC with
-/// password parameters.
+/// MSSQL key-value format (Server=...;Password=...), JDBC with `?password=`
+/// query parameters, JDBC Oracle thin (`scott/tiger@host`), and JDBC SQL
+/// Server semicolon format.
 #[must_use]
 pub fn is_connection_string_with_credentials(value: &str) -> bool {
     let trimmed = value.trim();
     network::CONNECTION_STRING_DB_URL.is_match(trimmed)
         || network::CONNECTION_STRING_MSSQL.is_match(trimmed)
         || network::CONNECTION_STRING_JDBC.is_match(trimmed)
+        || network::CONNECTION_STRING_JDBC_ORACLE.is_match(trimmed)
+        || network::CONNECTION_STRING_JDBC_SQLSERVER.is_match(trimmed)
 }
 
 /// Check if value is a database connection string (URL-based)
@@ -482,6 +485,34 @@ pub fn find_connection_strings_in_text(text: &str) -> Vec<CredentialMatch> {
 
     // JDBC connection strings
     for m in network::CONNECTION_STRING_JDBC.find_iter(text) {
+        let start = m.start();
+        if !matches.iter().any(|existing| existing.start == start) {
+            matches.push(CredentialMatch {
+                start,
+                end: m.end(),
+                value: m.as_str().to_string(),
+                credential_type: CredentialType::Generic,
+                label: "connection_string".to_string(),
+            });
+        }
+    }
+
+    // JDBC Oracle thin (slash-separated credentials, no '?')
+    for m in network::CONNECTION_STRING_JDBC_ORACLE.find_iter(text) {
+        let start = m.start();
+        if !matches.iter().any(|existing| existing.start == start) {
+            matches.push(CredentialMatch {
+                start,
+                end: m.end(),
+                value: m.as_str().to_string(),
+                credential_type: CredentialType::Generic,
+                label: "connection_string".to_string(),
+            });
+        }
+    }
+
+    // JDBC SQL Server (semicolon-separated params)
+    for m in network::CONNECTION_STRING_JDBC_SQLSERVER.find_iter(text) {
         let start = m.start();
         if !matches.iter().any(|existing| existing.start == start) {
             matches.push(CredentialMatch {
@@ -1140,5 +1171,62 @@ mod tests {
         // Real passphrases should not match
         assert!(!is_weak_passphrase("purple elephant dancing gracefully"));
         assert!(!is_weak_passphrase("my favorite coffee shop downtown"));
+    }
+
+    // ========================================================================
+    // JDBC variant detection (issue #30)
+    // ========================================================================
+
+    #[test]
+    fn test_jdbc_oracle_thin_detected() {
+        assert!(is_connection_string_with_credentials(
+            "jdbc:oracle:thin:scott/tiger@dbhost:1521:orcl"
+        ));
+        assert!(is_connection_string_with_credentials(
+            "jdbc:oracle:oci:user/p@ssw0rd@host:1521:sid"
+        ));
+        // No credentials -> should not match Oracle thin pattern
+        assert!(!is_connection_string_with_credentials(
+            "jdbc:oracle:thin:@host:1521:orcl"
+        ));
+    }
+
+    #[test]
+    fn test_jdbc_sqlserver_semicolon_detected() {
+        assert!(is_connection_string_with_credentials(
+            "jdbc:sqlserver://server:1433;user=sa;password=secret"
+        ));
+        assert!(is_connection_string_with_credentials(
+            "jdbc:sqlserver://server;databaseName=db;pwd=hunter2"
+        ));
+        // Missing password -> no match
+        assert!(!is_connection_string_with_credentials(
+            "jdbc:sqlserver://server;user=sa;databaseName=db"
+        ));
+    }
+
+    #[test]
+    fn test_find_connection_strings_includes_new_jdbc_variants() {
+        let text = "primary: jdbc:oracle:thin:scott/tiger@h:1521:o\n\
+                    replica: jdbc:sqlserver://r;user=sa;password=x";
+        let matches = find_connection_strings_in_text(text);
+        assert_eq!(matches.len(), 2);
+        assert!(matches.iter().all(|m| m.label == "connection_string"));
+    }
+
+    // ========================================================================
+    // Framework credential detection routing (issue #30)
+    // ========================================================================
+    //
+    // Framework-specific detection lives in the `framework` sibling module;
+    // its tests are co-located there. The test below verifies that DATABASE_URL
+    // (a common .env-style key carrying a URL) still routes through the
+    // existing URL-based connection-string detection rather than the
+    // framework detector.
+
+    #[test]
+    fn test_database_url_still_routes_through_connection_string() {
+        let text = "DATABASE_URL=postgres://u:p@h/db";
+        assert!(is_connection_string_with_credentials(text));
     }
 }

--- a/crates/octarine/src/primitives/identifiers/credentials/framework.rs
+++ b/crates/octarine/src/primitives/identifiers/credentials/framework.rs
@@ -1,0 +1,278 @@
+//! Framework-style credential detection
+//!
+//! Detects database credentials in application framework config formats:
+//! Django settings.py `'PASSWORD': '...'`, Rails / generic YAML
+//! `password: ...`, `.env` keys (`DB_PASSWORD`, `MYSQL_PASSWORD`, etc.),
+//! and Docker Compose env vars (`MYSQL_ROOT_PASSWORD`, `POSTGRES_PASSWORD`,
+//! etc.).
+//!
+//! Sibling to [`super::detection`]'s connection-string detection, which
+//! handles URL-style connection strings (postgres://, mysql://, …) and
+//! JDBC variants.
+//!
+//! Commented-out credentials (`# DB_PASSWORD=secret`) are flagged because
+//! comments can be uncommented.
+
+use super::super::common::patterns::network;
+use super::super::types::{CredentialMatch, CredentialType};
+
+/// Check if text contains framework-style credential assignments
+///
+/// Detects Django settings.py, Rails / generic YAML, `.env`, and Docker
+/// Compose password patterns. Commented-out credentials are also flagged.
+#[must_use]
+pub fn is_framework_credential_present(text: &str) -> bool {
+    // Cheap pre-filter: every supported format contains "PASSWORD",
+    // "password", or the "PASS" stem (for RABBITMQ_DEFAULT_PASS).
+    let has_keyword =
+        text.contains("PASSWORD") || text.contains("password") || text.contains("PASS");
+    if !has_keyword {
+        return false;
+    }
+
+    network::FRAMEWORK_DJANGO_PASSWORD.is_match(text)
+        || network::FRAMEWORK_RAILS_YAML_PASSWORD.is_match(text)
+        || network::FRAMEWORK_ENV_DB_PASSWORD.is_match(text)
+        || network::FRAMEWORK_DOCKER_COMPOSE_PASSWORD.is_match(text)
+}
+
+/// Find all framework-style credential matches in text
+///
+/// Returns matches with format-specific labels:
+/// - `"django_password"` — Django settings.py PASSWORD entries
+/// - `"rails_yaml_password"` — Rails / generic YAML `password:` entries
+/// - `"env_db_password"` — `.env` file database password keys
+/// - `"docker_compose_password"` — Docker Compose root-password env vars
+///
+/// Matches are deduped by start position (some keys like
+/// `POSTGRES_PASSWORD` are covered by both .env and Docker Compose
+/// patterns), then sorted by position.
+#[must_use]
+pub fn find_framework_credentials_in_text(text: &str) -> Vec<CredentialMatch> {
+    let mut matches = Vec::new();
+
+    // Django settings.py — group 1 (single-quoted) or group 2 (double-quoted).
+    for caps in network::FRAMEWORK_DJANGO_PASSWORD.captures_iter(text) {
+        let value_cap = caps.get(1).or_else(|| caps.get(2));
+        if let (Some(full), Some(value)) = (caps.get(0), value_cap) {
+            matches.push(CredentialMatch {
+                start: full.start(),
+                end: full.end(),
+                value: value.as_str().to_string(),
+                credential_type: CredentialType::Generic,
+                label: "django_password".to_string(),
+            });
+        }
+    }
+
+    // Rails / generic YAML — single capture group is the value.
+    for caps in network::FRAMEWORK_RAILS_YAML_PASSWORD.captures_iter(text) {
+        if let (Some(full), Some(value)) = (caps.get(0), caps.get(1)) {
+            let start = full.start();
+            if !matches.iter().any(|existing| existing.start == start) {
+                matches.push(CredentialMatch {
+                    start,
+                    end: full.end(),
+                    value: value.as_str().to_string(),
+                    credential_type: CredentialType::Generic,
+                    label: "rails_yaml_password".to_string(),
+                });
+            }
+        }
+    }
+
+    // .env file db password keys — group 1 = key, group 2 = value.
+    for caps in network::FRAMEWORK_ENV_DB_PASSWORD.captures_iter(text) {
+        if let (Some(full), Some(value)) = (caps.get(0), caps.get(2)) {
+            let start = full.start();
+            if !matches.iter().any(|existing| existing.start == start) {
+                matches.push(CredentialMatch {
+                    start,
+                    end: full.end(),
+                    value: value.as_str().to_string(),
+                    credential_type: CredentialType::Generic,
+                    label: "env_db_password".to_string(),
+                });
+            }
+        }
+    }
+
+    // Docker Compose env vars — group 1 = key, group 2 = value.
+    for caps in network::FRAMEWORK_DOCKER_COMPOSE_PASSWORD.captures_iter(text) {
+        if let (Some(full), Some(value)) = (caps.get(0), caps.get(2)) {
+            let start = full.start();
+            if !matches.iter().any(|existing| existing.start == start) {
+                matches.push(CredentialMatch {
+                    start,
+                    end: full.end(),
+                    value: value.as_str().to_string(),
+                    credential_type: CredentialType::Generic,
+                    label: "docker_compose_password".to_string(),
+                });
+            }
+        }
+    }
+
+    matches.sort_by_key(|m| m.start);
+    matches
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_is_framework_credential_present_django() {
+        assert!(is_framework_credential_present(
+            "'PASSWORD': 'secret_value'"
+        ));
+        assert!(is_framework_credential_present(
+            r#""PASSWORD": "secret_value""#
+        ));
+        // Lowercase Django key is not Django convention -> not Django pattern.
+        assert!(!is_framework_credential_present("'password': 'x'"));
+    }
+
+    #[test]
+    fn test_is_framework_credential_present_rails_yaml() {
+        assert!(is_framework_credential_present(
+            "production:\n  password: secret_value\n  host: db\n"
+        ));
+        // No whitespace after colon -> URL-style, not Rails YAML.
+        assert!(!is_framework_credential_present("foo password:nospace bar"));
+    }
+
+    #[test]
+    fn test_is_framework_credential_present_env_file() {
+        assert!(is_framework_credential_present("DB_PASSWORD=secret123"));
+        assert!(is_framework_credential_present("DATABASE_PASSWORD=p@ss"));
+        assert!(is_framework_credential_present("REDIS_PASSWORD=foobar"));
+        assert!(is_framework_credential_present("MYSQL_PASSWORD=barbaz"));
+        assert!(is_framework_credential_present("POSTGRES_PASSWORD=barbaz"));
+        assert!(is_framework_credential_present("POSTGRESQL_PASSWORD=baz"));
+        assert!(is_framework_credential_present("MONGO_PASSWORD=baz"));
+        // Empty value -> no match (\S+ requires at least one non-whitespace char).
+        assert!(!is_framework_credential_present("DB_PASSWORD="));
+        // Unrelated env key -> no match.
+        assert!(!is_framework_credential_present("APP_HOST=localhost"));
+    }
+
+    #[test]
+    fn test_is_framework_credential_present_docker_compose() {
+        assert!(is_framework_credential_present(
+            "environment:\n  - MYSQL_ROOT_PASSWORD=secret\n"
+        ));
+        assert!(is_framework_credential_present(
+            "environment:\n  MYSQL_ROOT_PASSWORD: secret\n"
+        ));
+        assert!(is_framework_credential_present(
+            "  - MONGO_INITDB_ROOT_PASSWORD=hunter2"
+        ));
+        // No value -> no match.
+        assert!(!is_framework_credential_present(
+            "environment:\n  - MYSQL_ROOT_PASSWORD=\n"
+        ));
+    }
+
+    #[test]
+    fn test_is_framework_credential_present_flags_commented_lines() {
+        // Issue #30: commented credentials can be uncommented, so flag them.
+        assert!(is_framework_credential_present("# DB_PASSWORD=secret"));
+        assert!(is_framework_credential_present(
+            "production:\n  # password: secret\n"
+        ));
+        assert!(is_framework_credential_present(
+            "#  - MYSQL_ROOT_PASSWORD=secret"
+        ));
+    }
+
+    #[test]
+    fn test_is_framework_credential_present_no_keyword() {
+        assert!(!is_framework_credential_present("APP_HOST=localhost"));
+        assert!(!is_framework_credential_present(
+            "{\"user\": \"alice\", \"port\": 5432}"
+        ));
+    }
+
+    #[test]
+    fn test_find_framework_credentials_django_match_labels() {
+        let matches = find_framework_credentials_in_text("config = {'PASSWORD': 'sv'}");
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("one match");
+        assert_eq!(first.label, "django_password");
+        assert_eq!(first.value, "sv");
+    }
+
+    #[test]
+    fn test_find_framework_credentials_django_double_quoted() {
+        let matches = find_framework_credentials_in_text(r#"config = {"PASSWORD": "sv-double"}"#);
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("one match");
+        assert_eq!(first.value, "sv-double");
+    }
+
+    #[test]
+    fn test_find_framework_credentials_rails_yaml() {
+        let matches = find_framework_credentials_in_text(
+            "production:\n  password: secret_value\n  host: db\n",
+        );
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("one match");
+        assert_eq!(first.label, "rails_yaml_password");
+        assert_eq!(first.value, "secret_value");
+    }
+
+    #[test]
+    fn test_find_framework_credentials_env() {
+        let matches = find_framework_credentials_in_text("DB_PASSWORD=secret123");
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("one match");
+        assert_eq!(first.label, "env_db_password");
+        assert_eq!(first.value, "secret123");
+    }
+
+    #[test]
+    fn test_find_framework_credentials_docker_compose() {
+        let matches =
+            find_framework_credentials_in_text("environment:\n  - MYSQL_ROOT_PASSWORD=hunter2\n");
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("one match");
+        assert_eq!(first.label, "docker_compose_password");
+        assert_eq!(first.value, "hunter2");
+    }
+
+    #[test]
+    fn test_find_framework_credentials_dedupes_postgres_overlap() {
+        // POSTGRES_PASSWORD is in both env and docker-compose patterns —
+        // dedupe by start position leaves one match per occurrence.
+        let matches = find_framework_credentials_in_text("POSTGRES_PASSWORD=secret\n");
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("one match");
+        assert_eq!(first.label, "env_db_password");
+    }
+
+    #[test]
+    fn test_find_framework_credentials_mixed_blob() {
+        let text = "\
+DATABASES = {'default': {'PASSWORD': 'pg_secret'}}
+DB_PASSWORD=dotenv_secret
+environment:
+  - MONGO_INITDB_ROOT_PASSWORD=mongo_secret
+production:
+  password: rails_secret
+";
+        let matches = find_framework_credentials_in_text(text);
+        assert_eq!(matches.len(), 4);
+        let labels: Vec<&str> = matches.iter().map(|m| m.label.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec![
+                "django_password",
+                "env_db_password",
+                "docker_compose_password",
+                "rails_yaml_password",
+            ]
+        );
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/credentials/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/credentials/mod.rs
@@ -124,6 +124,7 @@ pub(crate) mod redaction;
 
 // Internal modules - not directly accessible outside credentials/
 mod detection;
+mod framework;
 mod sanitization;
 mod validation;
 

--- a/crates/octarine/src/primitives/identifiers/credentials/sanitization.rs
+++ b/crates/octarine/src/primitives/identifiers/credentials/sanitization.rs
@@ -34,7 +34,9 @@ use regex::Regex;
 
 use crate::primitives::data::tokens::RedactionTokenCore;
 
+use super::super::common::patterns::network;
 use super::detection::{self, CredentialMatch, CredentialType};
+use super::framework;
 use super::redaction::{
     PassphraseRedactionStrategy, PasswordRedactionStrategy, PinRedactionStrategy,
     SecurityAnswerRedactionStrategy, TextRedactionPolicy,
@@ -208,11 +210,20 @@ static MSSQL_PASSWORD: Lazy<Regex> = Lazy::new(|| {
 static JDBC_PASSWORD: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?i)(password=)([^\s&;]+)").expect("BUG: Invalid regex pattern"));
 
+/// Regex for password in JDBC Oracle thin connection string
+/// Captures: (1) prefix up to `/`, (2) password, (3) `@host`
+static ORACLE_THIN_PASSWORD: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)(jdbc:oracle:[a-z]+:[^/\s:@]+/)([^@\s]+)(@)")
+        .expect("BUG: Invalid regex pattern")
+});
+
 /// Redact credentials in a connection string while preserving host/database
 ///
 /// - URL format: `postgres://admin:****@db.example.com/mydb`
 /// - MSSQL: `Server=db.example.com;Password=****;Database=mydb`
 /// - JDBC: `jdbc:postgresql://host/db?password=****`
+/// - JDBC SQL Server: `jdbc:sqlserver://host;user=sa;password=****`
+/// - JDBC Oracle thin: `jdbc:oracle:thin:scott/****@host:1521:orcl`
 #[must_use]
 pub fn redact_connection_string(value: &str) -> String {
     let mut result = value.to_string();
@@ -220,6 +231,13 @@ pub fn redact_connection_string(value: &str) -> String {
     // URL-based: replace user:PASSWORD@host with user:****@host
     if URL_PASSWORD.is_match(&result) {
         result = URL_PASSWORD
+            .replace_all(&result, "${1}****${3}")
+            .to_string();
+    }
+
+    // JDBC Oracle thin: replace user/PASSWORD@host with user/****@host
+    if ORACLE_THIN_PASSWORD.is_match(&result) {
+        result = ORACLE_THIN_PASSWORD
             .replace_all(&result, "${1}****${3}")
             .to_string();
     }
@@ -254,6 +272,109 @@ pub fn redact_connection_strings_in_text(text: &str) -> Cow<'_, str> {
     }
 
     Cow::Owned(result)
+}
+
+// Framework credential redaction
+
+/// Redact the value of a framework credential match while preserving the key
+///
+/// Recognizes the same shapes as `is_framework_credential_present`:
+/// - Django: `'PASSWORD': 'secret'` -> `'PASSWORD': '****'`
+/// - Rails YAML: `password: secret` -> `password: ****`
+/// - .env: `DB_PASSWORD=secret` -> `DB_PASSWORD=****`
+/// - Docker Compose: `MYSQL_ROOT_PASSWORD: secret` -> `MYSQL_ROOT_PASSWORD: ****`
+///
+/// If `value` does not match any framework pattern, it is returned unchanged.
+#[must_use]
+pub fn redact_framework_credential(value: &str) -> String {
+    let mut result = value.to_string();
+
+    // Django: replace 'PASSWORD': 'V' with 'PASSWORD': '****' (same for double quotes)
+    if network::FRAMEWORK_DJANGO_PASSWORD.is_match(&result) {
+        result = redact_framework_django(&result);
+    }
+
+    // Rails YAML: replace `password: V` with `password: ****` (preserve indent and `#`)
+    if network::FRAMEWORK_RAILS_YAML_PASSWORD.is_match(&result) {
+        result = redact_framework_rails_yaml(&result);
+    }
+
+    // .env: replace `KEY=V` with `KEY=****`
+    if network::FRAMEWORK_ENV_DB_PASSWORD.is_match(&result) {
+        result = redact_framework_env(&result);
+    }
+
+    // Docker Compose: replace `KEY=V` or `KEY: V` with same separator + `****`
+    if network::FRAMEWORK_DOCKER_COMPOSE_PASSWORD.is_match(&result) {
+        result = redact_framework_docker_compose(&result);
+    }
+
+    result
+}
+
+/// Redact all framework-style credentials in text
+#[must_use]
+pub fn redact_framework_credentials_in_text(text: &str) -> Cow<'_, str> {
+    let matches = framework::find_framework_credentials_in_text(text);
+    if matches.is_empty() {
+        return Cow::Borrowed(text);
+    }
+
+    let mut result = text.to_string();
+
+    // Replace from end to start to preserve positions. Each match covers the
+    // full key=value (or key: value) span — pass that whole slice to
+    // `redact_framework_credential` so its regexes can locate the value.
+    for m in matches.iter().rev() {
+        if let Some(full_match) = text.get(m.start..m.end) {
+            let redacted = redact_framework_credential(full_match);
+            result.replace_range(m.start..m.end, &redacted);
+        }
+    }
+
+    Cow::Owned(result)
+}
+
+fn redact_framework_django(value: &str) -> String {
+    // Two alternations: '…'…'…' and "…"…"…". Replace the inner value.
+    let single = Lazy::new(|| {
+        Regex::new(r"('PASSWORD'\s*:\s*')([^']+)(')").expect("BUG: Invalid regex pattern")
+    });
+    let double = Lazy::new(|| {
+        Regex::new(r#"("PASSWORD"\s*:\s*")([^"]+)(")"#).expect("BUG: Invalid regex pattern")
+    });
+    let mut result = single.replace_all(value, "${1}****${3}").to_string();
+    result = double.replace_all(&result, "${1}****${3}").to_string();
+    result
+}
+
+fn redact_framework_rails_yaml(value: &str) -> String {
+    // Capture the prefix (indent + optional `#` + key + `:` + whitespace) and replace the value.
+    static RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?im)(^[ \t]*#?[ \t]*password[ \t]*:[ \t]+)(\S+)")
+            .expect("BUG: Invalid regex pattern")
+    });
+    RE.replace_all(value, "${1}****").to_string()
+}
+
+fn redact_framework_env(value: &str) -> String {
+    static RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?m)(^[ \t]*#?[ \t]*(?:DB_PASSWORD|DATABASE_PASSWORD|REDIS_PASSWORD|MYSQL_PASSWORD|POSTGRES_PASSWORD|POSTGRESQL_PASSWORD|MONGO_PASSWORD)[ \t]*=[ \t]*)(\S+)",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+    RE.replace_all(value, "${1}****").to_string()
+}
+
+fn redact_framework_docker_compose(value: &str) -> String {
+    static RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?m)(^[ \t]*#?[ \t]*-?[ \t]*(?:MYSQL_ROOT_PASSWORD|POSTGRES_PASSWORD|MONGO_INITDB_ROOT_PASSWORD|RABBITMQ_DEFAULT_PASS|REDIS_PASSWORD)[ \t]*[=:][ \t]*)(\S+)",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+    RE.replace_all(value, "${1}****").to_string()
 }
 
 #[cfg(test)]
@@ -432,5 +553,99 @@ mod tests {
         assert!(result.contains("[PIN]"));
         assert!(!result.contains("secret"));
         assert!(!result.contains("1234"));
+    }
+
+    // ========================================================================
+    // JDBC variant + framework redaction (issue #30)
+    // ========================================================================
+
+    #[test]
+    fn test_redact_connection_string_jdbc_oracle_thin() {
+        let result = redact_connection_string("jdbc:oracle:thin:scott/tiger@dbhost:1521:orcl");
+        assert!(result.contains("scott/****@"));
+        assert!(!result.contains("tiger"));
+        assert!(result.contains("dbhost:1521:orcl"));
+    }
+
+    #[test]
+    fn test_redact_connection_string_jdbc_sqlserver() {
+        let result =
+            redact_connection_string("jdbc:sqlserver://server:1433;user=sa;password=secret");
+        assert!(result.contains("password=****"));
+        assert!(!result.contains("secret"));
+        // MSSQL_PASSWORD covers password=… semicolon form too (case-insensitive).
+        assert!(result.contains("user=sa"));
+    }
+
+    #[test]
+    fn test_redact_framework_credential_django() {
+        assert_eq!(
+            redact_framework_credential("'PASSWORD': 'secret'"),
+            "'PASSWORD': '****'"
+        );
+        assert_eq!(
+            redact_framework_credential(r#""PASSWORD": "secret""#),
+            r#""PASSWORD": "****""#
+        );
+    }
+
+    #[test]
+    fn test_redact_framework_credential_env() {
+        assert_eq!(
+            redact_framework_credential("DB_PASSWORD=secret123"),
+            "DB_PASSWORD=****"
+        );
+        assert_eq!(
+            redact_framework_credential("REDIS_PASSWORD=foobar"),
+            "REDIS_PASSWORD=****"
+        );
+    }
+
+    #[test]
+    fn test_redact_framework_credential_rails_yaml() {
+        assert_eq!(
+            redact_framework_credential("  password: secret"),
+            "  password: ****"
+        );
+    }
+
+    #[test]
+    fn test_redact_framework_credential_docker_compose() {
+        assert_eq!(
+            redact_framework_credential("  - MYSQL_ROOT_PASSWORD=secret"),
+            "  - MYSQL_ROOT_PASSWORD=****"
+        );
+        assert_eq!(
+            redact_framework_credential("MYSQL_ROOT_PASSWORD: secret"),
+            "MYSQL_ROOT_PASSWORD: ****"
+        );
+    }
+
+    #[test]
+    fn test_redact_framework_credentials_in_text_mixed() {
+        let text = "\
+DATABASES = {'default': {'PASSWORD': 'pg_secret'}}
+DB_PASSWORD=dotenv_secret
+";
+        let result = redact_framework_credentials_in_text(text);
+        assert!(!result.contains("pg_secret"));
+        assert!(!result.contains("dotenv_secret"));
+        assert!(result.contains("****"));
+        assert!(result.contains("DB_PASSWORD"));
+        assert!(result.contains("PASSWORD"));
+    }
+
+    #[test]
+    fn test_redact_framework_credentials_in_text_no_match() {
+        let text = "APP_HOST=localhost\nAPP_PORT=3000\n";
+        let result = redact_framework_credentials_in_text(text);
+        assert_eq!(result, text);
+    }
+
+    #[test]
+    fn test_redact_framework_credential_idempotent() {
+        let once = redact_framework_credential("DB_PASSWORD=secret");
+        let twice = redact_framework_credential(&once);
+        assert_eq!(once, twice);
     }
 }


### PR DESCRIPTION
## Summary

Extends credential detection beyond URL-style connection strings to cover the framework config formats called out in #30 — JDBC variants without `?password=`, Django `settings.py`, Rails `database.yml`, `.env` files, and Docker Compose env vars.

**JDBC variants** (extend existing `is_connection_string_with_credentials` / `find_connection_strings_in_text`):
- Oracle thin: `jdbc:oracle:thin:scott/tiger@host:1521:orcl`
- SQL Server semicolon: `jdbc:sqlserver://host;user=sa;password=secret`

**Framework configs** (new `framework` submodule, umbrella `is_framework_credential_present` / `find_framework_credentials_in_text`):
- Django: `'PASSWORD': 'secret'` / `"PASSWORD": "secret"` → label `django_password`
- Rails / generic YAML: `password: secret` → label `rails_yaml_password`
- `.env` DB keys: `DB_PASSWORD`, `DATABASE_PASSWORD`, `MYSQL_PASSWORD`, `POSTGRES_PASSWORD`, `POSTGRESQL_PASSWORD`, `REDIS_PASSWORD`, `MONGO_PASSWORD` → label `env_db_password`
- Docker Compose env: `MYSQL_ROOT_PASSWORD`, `POSTGRES_PASSWORD`, `MONGO_INITDB_ROOT_PASSWORD`, `RABBITMQ_DEFAULT_PASS`, `REDIS_PASSWORD` → label `docker_compose_password`

**Redaction**:
- `redact_framework_credential` / `redact_framework_credentials_in_text` preserve the key and replace the value with `****`
- `redact_connection_string` extended for JDBC Oracle thin (`scott/****@host`)

**Layer 3 + scanner wiring**:
- 4 new methods on `CredentialsBuilder` with observe metric instrumentation
- 4 new shortcut functions (`is_framework_credential`, `find_framework_credentials`, `redact_framework_credential`, `redact_framework_credentials`)
- PII scanner maps framework matches to `PiiType::ConnectionString` (guarded to avoid double-pushing when both URL and framework detection fire) — no new PII type variants needed

**Per-issue requirement**: commented-out credentials (`# DB_PASSWORD=secret`) are flagged because comments can be uncommented.

**Module split**: framework detection lives in a new `primitives/identifiers/credentials/framework.rs` sibling to `detection.rs` to keep `detection.rs` under the 800 prod-LOC arch-check ceiling.

## Test plan

- [x] 42 new tests across detection / framework / sanitization / Layer 3 builder / shortcuts / PII scanner
- [x] `just test-mod credentials` — 202 credential tests pass
- [x] `just test-mod scanner` — 39 scanner tests pass (including 3 new framework-credential scanner tests)
- [x] `just test` — 7435 nextest + 242 doctests pass
- [x] `just fmt-check` clean
- [x] `just clippy` clean
- [x] `just arch-check` clean (file sizes under 800 LOC ceiling)

Closes #30