### PR TITLE
feat(runtime): cache auto-generated correlation IDs per thread

### DIFF
--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -231,6 +231,10 @@ rexpect = "0.7"
 name = "pii_redaction"
 harness = false
 
+[[bench]]
+name = "correlation_id"
+harness = false
+
 [[test]]
 name = "metrics_integration"
 required-features = ["testing"]

--- a/crates/octarine/benches/correlation_id.rs
+++ b/crates/octarine/benches/correlation_id.rs
@@ -1,0 +1,76 @@
+//! Performance benchmarks for correlation ID lookup paths
+//!
+//! Documents the four code paths through `primitives::runtime::correlation_id()`:
+//!
+//! - `cold_fallback` — `clear_correlation_id()` + `correlation_id()` per
+//!   iteration. Forces UUID generation every call (worst case).
+//! - `cached_fallback` — single `clear_correlation_id()` outside the loop,
+//!   then `correlation_id()` in the loop. After the seeding change this
+//!   should match `thread_local_hit` (both are thread-local reads).
+//! - `thread_local_hit` — explicit `set_correlation_id()`, then loop. The
+//!   classic sync-with-context fast path.
+//! - `task_local_hit` — inside a `with_correlation_id()` async scope. The
+//!   classic async fast path.
+//!
+//! Run with: `cargo bench --bench correlation_id`
+
+#![allow(clippy::panic, clippy::expect_used, clippy::print_stdout, missing_docs)]
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use octarine::runtime::r#async::{
+    clear_correlation_id, correlation_id, set_correlation_id, with_correlation_id,
+};
+use std::hint::black_box;
+use tokio::runtime::Runtime;
+use uuid::Uuid;
+
+fn bench_cold_fallback(c: &mut Criterion) {
+    c.bench_function("correlation_id/cold_fallback", |b| {
+        b.iter(|| {
+            // Clear before every call forces the fallback to generate a UUID.
+            clear_correlation_id();
+            black_box(correlation_id())
+        });
+    });
+    clear_correlation_id();
+}
+
+fn bench_cached_fallback(c: &mut Criterion) {
+    c.bench_function("correlation_id/cached_fallback", |b| {
+        // Seed once via the fallback path; subsequent calls hit thread-local.
+        clear_correlation_id();
+        let _ = correlation_id();
+        b.iter(|| black_box(correlation_id()));
+    });
+    clear_correlation_id();
+}
+
+fn bench_thread_local_hit(c: &mut Criterion) {
+    c.bench_function("correlation_id/thread_local_hit", |b| {
+        set_correlation_id(Uuid::new_v4());
+        b.iter(|| black_box(correlation_id()));
+    });
+    clear_correlation_id();
+}
+
+fn bench_task_local_hit(c: &mut Criterion) {
+    // task_local requires a tokio runtime
+    let rt = Runtime::new().expect("failed to build tokio runtime");
+    c.bench_function("correlation_id/task_local_hit", |b| {
+        let id = Uuid::new_v4();
+        b.iter(|| {
+            rt.block_on(with_correlation_id(id, async {
+                black_box(correlation_id())
+            }))
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_cold_fallback,
+    bench_cached_fallback,
+    bench_thread_local_hit,
+    bench_task_local_hit,
+);
+criterion_main!(benches);

--- a/crates/octarine/src/primitives/runtime/async/context.rs
+++ b/crates/octarine/src/primitives/runtime/async/context.rs
@@ -40,6 +40,14 @@ thread_local! {
     /// Thread-local correlation ID for sync code
     static THREAD_CORRELATION_ID: RefCell<Option<Uuid>> = const { RefCell::new(None) };
 
+    /// Thread-local cache for auto-generated correlation IDs
+    ///
+    /// Separate from THREAD_CORRELATION_ID so callers can still distinguish
+    /// "explicitly configured" from "auto-generated" via `try_correlation_id()`
+    /// (which checks only the explicit cell). `correlation_id()` consults
+    /// both — explicit first, then this cache, then generates and stores here.
+    static THREAD_CORRELATION_FALLBACK: RefCell<Option<Uuid>> = const { RefCell::new(None) };
+
     /// Thread-local tenant ID for sync code
     static THREAD_TENANT_ID: RefCell<Option<String>> = const { RefCell::new(None) };
 
@@ -70,6 +78,27 @@ pub(crate) fn get_thread_correlation_id() -> Option<Uuid> {
 pub(crate) fn clear_thread_correlation_id() {
     THREAD_CORRELATION_ID.with(|cell| {
         *cell.borrow_mut() = None;
+    });
+    // Also clear the fallback cache so the next correlation_id() call
+    // generates a fresh ID instead of returning a stale cached one.
+    THREAD_CORRELATION_FALLBACK.with(|cell| {
+        *cell.borrow_mut() = None;
+    });
+}
+
+/// Get the cached fallback correlation ID (auto-generated, not explicit)
+///
+/// Used internally by `correlation_id()` only. NOT visible to
+/// `try_correlation_id()`, which must distinguish explicit configuration
+/// from implicit generation.
+pub(crate) fn get_thread_correlation_fallback() -> Option<Uuid> {
+    THREAD_CORRELATION_FALLBACK.with(|cell| *cell.borrow())
+}
+
+/// Cache a fallback correlation ID in thread-local storage
+pub(crate) fn set_thread_correlation_fallback(id: Uuid) {
+    THREAD_CORRELATION_FALLBACK.with(|cell| {
+        *cell.borrow_mut() = Some(id);
     });
 }
 

--- a/crates/octarine/src/primitives/runtime/async/mod.rs
+++ b/crates/octarine/src/primitives/runtime/async/mod.rs
@@ -83,7 +83,8 @@ pub use context::{TaskContext, TaskLocal};
 // Re-export context internal functions for parent module shortcut functions
 pub(crate) use context::{
     clear_thread_context, clear_thread_correlation_id, clear_thread_session_id,
-    clear_thread_tenant_id, clear_thread_user_id, get_thread_correlation_id, get_thread_session_id,
-    get_thread_tenant_id, get_thread_user_id, set_thread_correlation_id, set_thread_session_id,
+    clear_thread_tenant_id, clear_thread_user_id, get_thread_correlation_fallback,
+    get_thread_correlation_id, get_thread_session_id, get_thread_tenant_id, get_thread_user_id,
+    set_thread_correlation_fallback, set_thread_correlation_id, set_thread_session_id,
     set_thread_tenant_id, set_thread_user_id,
 };

--- a/crates/octarine/src/primitives/runtime/mod.rs
+++ b/crates/octarine/src/primitives/runtime/mod.rs
@@ -82,7 +82,8 @@ pub(crate) mod http;
 use r#async::{
     TaskContext, TaskLocal, clear_thread_context, clear_thread_correlation_id,
     clear_thread_session_id, clear_thread_tenant_id, clear_thread_user_id,
-    get_thread_correlation_id, get_thread_session_id, get_thread_tenant_id, get_thread_user_id,
+    get_thread_correlation_fallback, get_thread_correlation_id, get_thread_session_id,
+    get_thread_tenant_id, get_thread_user_id, set_thread_correlation_fallback,
     set_thread_correlation_id, set_thread_session_id, set_thread_tenant_id, set_thread_user_id,
 };
 
@@ -97,13 +98,30 @@ use r#async::{
 ///
 /// Checks in order:
 /// 1. Task-local storage (for async code)
-/// 2. Thread-local storage (for sync code)
-/// 3. Generates a new UUID if neither is set
+/// 2. Thread-local storage (for sync code, explicitly set)
+/// 3. Thread-local fallback cache (auto-generated, populated on first miss)
+/// 4. Generates a new UUID, stores it in the fallback cache, and returns it
 ///
 /// # Performance
 ///
-/// This function is designed to be fast (<100ns) when context is set.
-/// UUID generation is only used as a fallback.
+/// This function is O(1) for the common cases (task-local hit, thread-local
+/// hit, fallback cache hit). The first call on a thread with no explicit
+/// context setup generates one UUID and caches it; every subsequent call on
+/// the same thread is then a thread-local read.
+///
+/// # Semantic Continuity
+///
+/// Because the fallback path caches its generated UUID per-thread, multiple
+/// events emitted from the same thread without explicit context setup share
+/// a correlation ID. This gives implicit trace continuity to code that
+/// hasn't wired up an HTTP middleware or `TaskContextBuilder` scope. To
+/// reset the implicit ID (for example between logical operations on a
+/// long-lived worker thread) call `clear_correlation_id()`.
+///
+/// The fallback cache is intentionally invisible to `try_correlation_id()`
+/// so callers can still distinguish "explicitly configured" from
+/// "auto-generated" — useful for HTTP error responses that should only
+/// include a request ID when one was actually set via middleware.
 ///
 /// # Example
 ///
@@ -119,19 +137,34 @@ pub fn correlation_id() -> Uuid {
         return ctx.correlation_id;
     }
 
-    // Second, try thread-local (for sync code)
+    // Second, try thread-local — explicitly set via set_correlation_id().
     if let Some(id) = get_thread_correlation_id() {
         return id;
     }
 
-    // Fallback: generate new UUID
-    Uuid::new_v4()
+    // Third, try the per-thread fallback cache. This is populated by a
+    // previous call to correlation_id() on this thread and gives semantic
+    // continuity to events emitted without explicit context setup.
+    if let Some(id) = get_thread_correlation_fallback() {
+        return id;
+    }
+
+    // Fourth, generate a new UUID and seed the fallback cache so subsequent
+    // calls on this thread return the same ID. Avoids repeated UUID
+    // generation in the common "no context configured" case.
+    let id = Uuid::new_v4();
+    set_thread_correlation_fallback(id);
+    id
 }
 
 /// Get the current correlation ID if one is set
 ///
 /// Unlike `correlation_id()`, this returns `None` if no context is set
-/// rather than generating a new UUID.
+/// rather than generating a new UUID. It also does NOT observe the
+/// per-thread fallback cache, so it is the right choice when you need to
+/// know whether the caller explicitly configured a correlation ID (for
+/// example, an HTTP error handler that should only include a request ID
+/// when middleware has set one).
 ///
 /// # Example
 ///
@@ -452,12 +485,11 @@ mod shortcut_tests {
         // Clear any existing context
         clear_correlation_id();
 
-        // Without context set, should generate new UUID each time
+        // Calling correlation_id() seeds thread-local with a generated UUID.
+        // After clear_correlation_id(), the next call generates a fresh one.
         let _id1 = correlation_id();
         clear_correlation_id();
         let _id2 = correlation_id();
-        // These are likely different (generated UUIDs)
-        // We can't assert inequality because they're random
 
         // Set a specific ID
         let specific_id = Uuid::new_v4();
@@ -467,6 +499,94 @@ mod shortcut_tests {
         // Clear and verify fallback behavior
         clear_correlation_id();
         assert!(try_correlation_id().is_none());
+    }
+
+    #[test]
+    fn test_correlation_id_fallback_is_cached() {
+        // Without explicit setup, two consecutive calls on the same thread
+        // must return the SAME UUID. The first call seeds thread-local;
+        // the second is a thread-local hit.
+        clear_correlation_id();
+
+        let id_first = correlation_id();
+        let id_second = correlation_id();
+
+        assert_eq!(
+            id_first, id_second,
+            "fallback path must cache via thread-local"
+        );
+
+        // clear_correlation_id() resets the cache; next call generates a
+        // fresh ID, distinct from the previously cached one.
+        clear_correlation_id();
+        let id_after_clear = correlation_id();
+        assert_ne!(
+            id_first, id_after_clear,
+            "clear_correlation_id() must reset the fallback cache"
+        );
+
+        clear_correlation_id();
+    }
+
+    #[test]
+    fn test_correlation_id_fallback_seeds_try_get() {
+        // The per-thread fallback cache MUST be invisible to
+        // try_correlation_id() so callers can distinguish "explicitly
+        // configured" from "auto-generated". This is the contract that
+        // lets HTTP error handlers (http/error.rs) decide whether to
+        // include a request_id in the response body.
+        clear_correlation_id();
+
+        assert!(try_correlation_id().is_none());
+
+        // Take the fallback path — caches generated ID, but does NOT
+        // populate the explicit thread-local slot.
+        let _generated = correlation_id();
+        assert!(
+            try_correlation_id().is_none(),
+            "fallback cache must NOT make try_correlation_id() return Some"
+        );
+
+        clear_correlation_id();
+    }
+
+    #[test]
+    fn test_correlation_id_fast_path_unchanged() {
+        // When thread-local IS explicitly set, correlation_id() must still
+        // return it directly without re-seeding or generating.
+        clear_correlation_id();
+
+        let explicit = Uuid::new_v4();
+        set_correlation_id(explicit);
+
+        assert_eq!(correlation_id(), explicit);
+        assert_eq!(correlation_id(), explicit); // stable across calls
+        assert_eq!(try_correlation_id(), Some(explicit));
+
+        clear_correlation_id();
+    }
+
+    #[tokio::test]
+    async fn test_task_local_still_takes_precedence_after_fallback_seed() {
+        // Seeding thread-local via the fallback path must NOT affect
+        // task-local precedence. Inside with_correlation_id() the task-local
+        // value wins; outside the scope the seeded thread-local value is
+        // still visible.
+        clear_correlation_id();
+
+        let seeded = correlation_id();
+        let task_id = Uuid::new_v4();
+        assert_ne!(seeded, task_id);
+
+        with_correlation_id(task_id, async {
+            assert_eq!(correlation_id(), task_id);
+        })
+        .await;
+
+        // Back out of the task scope, the seeded thread-local value persists.
+        assert_eq!(correlation_id(), seeded);
+
+        clear_correlation_id();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `correlation_id()` now caches auto-generated UUIDs in a per-thread fallback cell, so consecutive calls without explicit context setup share an ID instead of regenerating a UUID v4 every time.
- The fallback cache is **invisible to `try_correlation_id()`**, which continues to return `None` when nothing has been explicitly configured — preserves the contract that lets HTTP error responses distinguish "request_id from middleware" vs "auto-generated".
- `clear_correlation_id()` clears both cells.
- Adds a criterion benchmark documenting the four lookup paths (`benches/correlation_id.rs`).

## Why not LruCache?

The source doc (`docs/tasks/primitives-future-integrations.md` §2) proposed `LruCache + task-local`. Investigation showed `TaskContext` already caches per-task (O(1) field read) and thread-local already caches per-thread when seeded. The missing piece was that the fallback path **didn't cache itself** — every event without explicit setup regenerated a UUID and discarded it. A simple per-thread fallback cell solves the actual problem with zero new types, no eviction logic, and no locking overhead.

## Behavior change

- Two consecutive `correlation_id()` calls on the same thread without explicit setup → previously two different UUIDs, now the same UUID. Restores semantic trace continuity for events emitted from sync utilities, worker threads, and tests.
- `try_correlation_id()` behavior is unchanged.
- Pre-1.0 (currently `0.x` beta) — no `#[deprecated]` shim needed.

## Test plan

- [x] 4 new unit tests in `primitives::runtime::shortcut_tests` covering caching, fast-path stability, task-local precedence, and the `try_correlation_id()` contract
- [x] `cargo nextest run --profile ci --workspace --all-features` — 7439 passed, 0 failed
- [x] `just clippy` — clean
- [x] `just arch-check` — clean
- [x] `just test-docs` — 242 passed
- [x] Benchmark compiles (`cargo bench --bench correlation_id --no-run`)
- [x] Regression-tested `test_error_body_has_correct_structure` (HTTP error response) — this caught the first design iteration where seeding the explicit `THREAD_CORRELATION_ID` cell broke the "is anything explicitly configured?" contract; the split-cell design fixes it

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)