### PR TITLE
feat(observe): cache Registry::snapshot() with 1s TTL

### DIFF
--- a/crates/octarine/src/observe/metrics/aggregation/mod.rs
+++ b/crates/octarine/src/observe/metrics/aggregation/mod.rs
@@ -9,26 +9,56 @@
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use super::counters::Counter;
 use super::gauges::Gauge;
 use super::histograms::Histogram;
+
+/// Default time-to-live for cached snapshots.
+///
+/// One second is short enough to be invisible to Prometheus scrapers (typical
+/// scrape interval 15–60s) and tighter than the async dispatcher's 10s batch
+/// flush window, so the cache never serves data older than the underlying
+/// registry would have served anyway.
+const DEFAULT_SNAPSHOT_TTL: Duration = Duration::from_secs(1);
+
+/// A cached snapshot with its expiry.
+struct CachedSnapshot {
+    snapshot: MetricSnapshot,
+    expires_at: Instant,
+}
 
 /// Central registry for all metrics
 pub(crate) struct Registry {
     counters: Arc<RwLock<HashMap<String, Counter>>>,
     gauges: Arc<RwLock<HashMap<String, Gauge>>>,
     histograms: Arc<RwLock<HashMap<String, Histogram>>>,
+    snapshot_cache: Arc<RwLock<Option<CachedSnapshot>>>,
+    snapshot_ttl: Duration,
+    #[cfg(test)]
+    build_count: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl Registry {
-    /// Create a new registry
+    /// Create a new registry with the default snapshot TTL.
     pub(crate) fn new() -> Self {
+        Self::with_ttl(DEFAULT_SNAPSHOT_TTL)
+    }
+
+    /// Create a new registry with a custom snapshot TTL.
+    ///
+    /// Used by tests that need to exercise cache expiration without waiting
+    /// the full default TTL.
+    pub(crate) fn with_ttl(snapshot_ttl: Duration) -> Self {
         Self {
             counters: Arc::new(RwLock::new(HashMap::new())),
             gauges: Arc::new(RwLock::new(HashMap::new())),
             histograms: Arc::new(RwLock::new(HashMap::new())),
+            snapshot_cache: Arc::new(RwLock::new(None)),
+            snapshot_ttl,
+            #[cfg(test)]
+            build_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 
@@ -59,8 +89,49 @@ impl Registry {
             .clone()
     }
 
-    /// Get a snapshot of all metrics
+    /// Get a snapshot of all metrics.
+    ///
+    /// Snapshots are cached for `snapshot_ttl` (default 1 second) to amortize
+    /// the cost of deep-cloning every metric on each call. Concurrent calls
+    /// during a cache miss use a read-then-double-check pattern so the
+    /// underlying snapshot is built at most once per TTL window.
     pub(crate) fn snapshot(&self) -> MetricSnapshot {
+        // Fast path: a valid cached snapshot is available under the read lock.
+        {
+            let cache = self.snapshot_cache.read();
+            if let Some(cached) = cache.as_ref()
+                && Instant::now() < cached.expires_at
+            {
+                return cached.snapshot.clone();
+            }
+        }
+
+        // Slow path: take the write lock and double-check — another thread
+        // may have populated the cache while we were waiting.
+        let mut cache = self.snapshot_cache.write();
+        if let Some(cached) = cache.as_ref()
+            && Instant::now() < cached.expires_at
+        {
+            return cached.snapshot.clone();
+        }
+
+        let fresh = self.build_snapshot_uncached();
+        let now = Instant::now();
+        let expires_at = now.checked_add(self.snapshot_ttl).unwrap_or(now);
+        *cache = Some(CachedSnapshot {
+            snapshot: fresh.clone(),
+            expires_at,
+        });
+        fresh
+    }
+
+    /// Build a snapshot directly from the underlying registry, bypassing the
+    /// cache. The cache wraps this method.
+    fn build_snapshot_uncached(&self) -> MetricSnapshot {
+        #[cfg(test)]
+        self.build_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
         let counters = self.counters.read();
         let gauges = self.gauges.read();
         let histograms = self.histograms.read();
@@ -82,11 +153,27 @@ impl Registry {
         }
     }
 
+    /// Drop any cached snapshot so the next `snapshot()` call rebuilds.
+    ///
+    /// Used by `flush_for_testing()` and `clear()` to preserve the contract
+    /// that callers see the registry's current state on the next snapshot.
+    pub(crate) fn invalidate_snapshot_cache(&self) {
+        *self.snapshot_cache.write() = None;
+    }
+
     /// Clear all metrics
     pub(crate) fn clear(&self) {
         self.counters.write().clear();
         self.gauges.write().clear();
         self.histograms.write().clear();
+        self.invalidate_snapshot_cache();
+    }
+
+    /// Number of times `build_snapshot_uncached` has run on this registry.
+    /// Test-only hook for verifying stampede behavior.
+    #[cfg(test)]
+    pub(crate) fn build_count(&self) -> usize {
+        self.build_count.load(std::sync::atomic::Ordering::SeqCst)
     }
 }
 
@@ -114,3 +201,155 @@ pub struct MetricSnapshot {
 
 // Threshold monitoring is now implemented in the thresholds module
 // See: super::thresholds for ThresholdConfig, ThresholdState, etc.
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::Barrier;
+    use std::thread;
+
+    #[test]
+    fn snapshot_returns_cached_value_within_ttl() {
+        let registry = Registry::with_ttl(Duration::from_secs(60));
+        let counter = registry.counter("cached.counter");
+        counter.increment();
+
+        let first = registry.snapshot();
+        let first_value = first
+            .counters
+            .get("cached.counter")
+            .expect("counter present")
+            .value;
+        assert_eq!(first_value, 1);
+
+        // Mutate the underlying counter after the cache is warm.
+        counter.increment();
+
+        // The second snapshot must be the cached one, still showing 1.
+        let second = registry.snapshot();
+        let second_value = second
+            .counters
+            .get("cached.counter")
+            .expect("counter present")
+            .value;
+        assert_eq!(second_value, 1, "expected cached snapshot to be served");
+        assert_eq!(
+            registry.build_count(),
+            1,
+            "snapshot should be built exactly once"
+        );
+    }
+
+    #[test]
+    fn snapshot_refreshes_after_ttl() {
+        let registry = Registry::with_ttl(Duration::from_millis(20));
+        let counter = registry.counter("refresh.counter");
+        counter.increment();
+
+        let first = registry.snapshot();
+        assert_eq!(
+            first
+                .counters
+                .get("refresh.counter")
+                .expect("present")
+                .value,
+            1
+        );
+
+        counter.increment();
+
+        // Poll until the cache expires and serves the updated value.
+        // Fixed sleeps are flaky under CI coverage; see
+        // primitives/collections/cache/lru.rs::test_cache_expiration.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let value = registry
+                .snapshot()
+                .counters
+                .get("refresh.counter")
+                .expect("present")
+                .value;
+            if value == 2 {
+                break;
+            }
+            if Instant::now() > deadline {
+                panic!("timed out waiting for snapshot cache to expire");
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[test]
+    fn clear_invalidates_snapshot_cache() {
+        let registry = Registry::with_ttl(Duration::from_secs(60));
+        let counter = registry.counter("clear.counter");
+        counter.increment();
+        let _ = registry.snapshot();
+
+        registry.clear();
+        // Recreating the counter must show 0, not the stale cached 1.
+        let counter_after = registry.counter("clear.counter");
+        counter_after.increment_by(7);
+
+        let after = registry.snapshot();
+        assert_eq!(
+            after.counters.get("clear.counter").expect("present").value,
+            7,
+            "snapshot after clear must reflect post-clear state"
+        );
+    }
+
+    #[test]
+    fn invalidate_snapshot_cache_forces_rebuild() {
+        let registry = Registry::with_ttl(Duration::from_secs(60));
+        registry.counter("invalidate.counter").increment();
+
+        let _ = registry.snapshot();
+        let _ = registry.snapshot();
+        assert_eq!(registry.build_count(), 1, "second call should be cached");
+
+        registry.invalidate_snapshot_cache();
+        let _ = registry.snapshot();
+        assert_eq!(
+            registry.build_count(),
+            2,
+            "snapshot after invalidate should rebuild"
+        );
+    }
+
+    #[test]
+    fn concurrent_snapshot_no_stampede() {
+        let registry = Arc::new(Registry::with_ttl(Duration::from_secs(60)));
+        registry.counter("stampede.counter").increment();
+
+        const THREADS: usize = 16;
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let mut handles = Vec::with_capacity(THREADS);
+        for _ in 0..THREADS {
+            let registry = Arc::clone(&registry);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                registry.snapshot();
+            }));
+        }
+        for handle in handles {
+            handle.join().expect("worker thread");
+        }
+
+        // The double-check pattern means only one thread should hit the
+        // slow path. A few extra rebuilds are tolerable if the OS schedules
+        // a writer between read-lock release and write-lock acquisition,
+        // but it must never approach THREADS.
+        let builds = registry.build_count();
+        assert!(
+            (1..THREADS).contains(&builds),
+            "expected 1..{} snapshot builds under concurrency, got {}",
+            THREADS,
+            builds
+        );
+    }
+}

--- a/crates/octarine/src/observe/metrics/async_dispatch.rs
+++ b/crates/octarine/src/observe/metrics/async_dispatch.rs
@@ -135,6 +135,12 @@ impl MetricsDispatcher {
     }
 
     /// Flush all pending metrics (blocking, for testing only)
+    ///
+    /// Also invalidates the registry's snapshot cache so the next
+    /// `snapshot()` call reflects the writes that were just flushed.
+    /// Without this, tests that call `flush_for_testing()` then
+    /// `snapshot()` could be served a stale cached snapshot from an
+    /// earlier test in the same process.
     #[cfg(any(test, feature = "testing"))]
     fn flush_sync(&self) {
         let (tx, rx) = oneshot::channel();
@@ -146,6 +152,7 @@ impl MetricsDispatcher {
             // Block until flush is complete
             let _ = rx.blocking_recv();
         }
+        global().invalidate_snapshot_cache();
     }
 }
 

--- a/docs/tasks/primitives-future-integrations.md
+++ b/docs/tasks/primitives-future-integrations.md
@@ -4,21 +4,10 @@ Ideas for leveraging `primitives/common` (RingBuffer, LruCache) that require mor
 
 ## 1. Metrics Snapshot Caching (LruCache)
 
-**Location:** `src/observe/metrics/aggregation/mod.rs:62-83`
-
-**Current Issue:** `snapshot()` creates full clones of all metrics every call, which is expensive for high-frequency
-exports.
-
-**Proposed Solution:** Use LruCache to cache recent snapshots with short TTL (1-5 seconds).
-
-**Design Questions:**
-
-- What TTL is appropriate? Too short = no benefit, too long = stale data
-- Should cache be invalidated on any metric write? (defeats purpose)
-- Should we track "dirty" state and only regenerate when needed?
-- How to handle concurrent snapshot requests during regeneration?
-
-**Benefit:** Reduce allocation overhead on frequent metric exports.
+**Status:** Implemented in #4 (single-slot TTL cache rather than LruCache —
+the registry only ever produces one global snapshot, so an LRU key dimension
+adds no value). Default TTL 1s, invalidated by `Registry::clear()` and
+`flush_for_testing()`. See `src/observe/metrics/aggregation/mod.rs`.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Summary

`Registry::snapshot()` previously deep-cloned every counter, gauge, and
histogram on each call. The only production caller is
`PrometheusExporter::render()`, invoked once per scrape (typically every
15-60s), so the caller is fully tolerant of 1s of staleness.

This PR adds a single-slot `RwLock<Option<CachedSnapshot>>` to `Registry`
with a 1s default TTL. The cache uses a read-then-double-check pattern so
concurrent scrapers do not stampede the rebuild path. `clear()` and
`flush_for_testing()` both invalidate the cache so existing test contracts
hold unchanged.

### Design notes

- **Single-slot, not LruCache** (despite the issue title): the registry
  only ever produces one global snapshot — there is no key dimension to
  vary over. An LRU with capacity 1 would work but is misleading.
- **Time-based invalidation only**: writes are already async-batched with
  a 10s flush window, so a 1s TTL is strictly tighter than any
  write-driven invalidation could achieve. Skipping write-driven
  invalidation also keeps the hot write path lock-free of cache state.
- **TTL not exposed as config**: Layer 3 has no metrics-level config
  struct today; adding one is out of scope for this issue.

### Concurrency invariant

The new `concurrent_snapshot_no_stampede` test spawns 16 threads racing
on a cold cache and asserts `build_snapshot_uncached` runs at most
`THREADS - 1` times (and at least once). In practice it runs ~1 time;
the upper bound tolerates rare OS schedule races between read-lock
release and write-lock acquisition.

## Test plan

- [x] `just test-mod observe::metrics::aggregation` — 5 new unit tests pass
- [x] `just test-filter test_counter_functionality|test_gauge_functionality|test_histogram_functionality|test_timer_functionality|test_global_convenience_functions` — 5 existing integration tests still pass
- [x] `just clippy` clean
- [x] `just fmt-check` clean
- [x] `just arch-check` clean

## SemVer impact

None. `Registry` is `pub(crate)`. The public `snapshot()` keeps its
signature and observable behavior (snapshots may be up to 1s stale, but
that was already true given the 10s async flush window).

Closes #4