### PR TITLE
feat(arch-check): add opt-in doctest-ignores check (#191 phase 1/4)

### DIFF
--- a/scripts/arch_check/checks/__init__.py
+++ b/scripts/arch_check/checks/__init__.py
@@ -8,6 +8,7 @@ from typing import Callable, Iterator
 from scripts.arch_check.core import Finding, iter_files
 from scripts.arch_check.checks import (
     builder_visibility,
+    doctest_ignores,
     file_length,
     layer_boundary,
     naming_prefix,
@@ -56,8 +57,17 @@ def _run_file_length(*, staged_only: bool, root: Path) -> Iterator[Finding]:
     yield from file_length.run(staged_only=staged_only, root=root)
 
 
+def _run_doctest_ignores(*, staged_only: bool, root: Path) -> Iterator[Finding]:
+    files = iter_files(subdir=None, staged_only=staged_only, root=root)
+    yield from doctest_ignores.run(files=files, root=root)
+
+
 # Order matters: bash executes checks in this exact sequence.
-CHECK_ORDER: list[str] = [
+# DEFAULT_CHECKS is the set that runs when arch-check is invoked with no
+# arguments (the gating set used by `just preflight` and CI). CHECK_ORDER
+# is the full registry of valid check names — checks not in DEFAULT_CHECKS
+# can still be invoked explicitly (e.g. `just arch-check doctest-ignores`).
+DEFAULT_CHECKS: list[str] = [
     "layer-boundary",
     "unwrapped-fn",
     "naming-prefix",
@@ -66,6 +76,12 @@ CHECK_ORDER: list[str] = [
     "type-visibility",
     "builder-visibility",
     "file-length",
+]
+
+CHECK_ORDER: list[str] = [
+    *DEFAULT_CHECKS,
+    # Opt-in checks (not in default run until their remediation completes):
+    "doctest-ignores",
 ]
 
 CHECKS: dict[str, CheckRunner] = {
@@ -77,4 +93,5 @@ CHECKS: dict[str, CheckRunner] = {
     "type-visibility": _run_type_visibility,
     "builder-visibility": _run_builder_visibility,
     "file-length": _run_file_length,
+    "doctest-ignores": _run_doctest_ignores,
 }

--- a/scripts/arch_check/checks/doctest_ignores.py
+++ b/scripts/arch_check/checks/doctest_ignores.py
@@ -1,0 +1,103 @@
+"""Check: unexplained ```ignore on public-API doctests (Layer 2/3 only).
+
+A doctest fence annotated with ```ignore (or ```rust,ignore) silently opts
+out of compilation. Without a justification comment, a reader cannot tell
+whether the example "won't compile," "shouldn't run in CI," or "the author
+hadn't decided yet."
+
+Rule: in any Layer 2/3 file (not `/primitives/`, not `/testing/`), an
+```ignore fence must be accompanied by an explanatory comment within the
+preceding 3 lines, OR carry an `// arch-check: allow doctest-ignores`
+directive (mirrors `unwrapped_fn.py`).
+
+A justification comment is any preceding line whose comment body contains
+the substring `ignore` (case-insensitive) — e.g.
+``/// Requires a tokio runtime — ignored because async I/O``.
+This is intentionally generous: the goal is to force authors to write
+*something*, not to police phrasing.
+
+This check is not part of the default `CHECK_ORDER` run; it's invoked
+explicitly via `just arch-check doctest-ignores`. It will move into the
+default set once remediation reaches zero findings (see issue #191).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from scripts.arch_check.core import Finding, rel
+
+# Matches: optional indent, doc-comment prefix, ```ignore or ```rust,ignore
+_IGNORE_FENCE = re.compile(r"^\s*//[!/] *```(?:rust,)?ignore\s*$")
+
+# Any comment line — doc (`///`, `//!`) or plain (`//`). Used to scan back
+# through a contiguous comment block. Blank lines are also tolerated.
+_COMMENT_LINE = re.compile(r"^\s*//")
+
+# Suppression directive (mirrors unwrapped_fn.py convention)
+_DIRECTIVE = re.compile(r"//\s*arch-check:\s*allow\s+doctest-ignores\b")
+
+# How many preceding comment lines we scan for a justification
+_LOOKBACK = 3
+
+
+def _has_justification(prev_lines: list[str]) -> bool:
+    """True if any recent comment line justifies the ignore."""
+    for line in prev_lines:
+        if _DIRECTIVE.search(line):
+            return True
+        # Doc comment whose text mentions "ignore" counts as justification.
+        # Strip the prefix so the fence's own `///` doesn't satisfy itself.
+        stripped = line.lstrip()
+        if stripped.startswith("///"):
+            body = stripped[3:]
+        elif stripped.startswith("//!"):
+            body = stripped[3:]
+        else:
+            # Plain `//` comment — only directive (handled above) suppresses.
+            continue
+        if "ignore" in body.lower():
+            return True
+    return False
+
+
+def run(*, files: Iterable[Path], root: Path) -> Iterator[Finding]:
+    for path in files:
+        path_str = str(path)
+        if "/primitives/" in path_str or "/testing/" in path_str:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        lines = text.splitlines()
+        # Window of the most recent comment lines (doc or plain). A code
+        # line resets it so a fence cannot inherit justification from a
+        # different item upstream.
+        comment_window: list[str] = []
+        for lineno, line in enumerate(lines, start=1):
+            if _IGNORE_FENCE.match(line):
+                recent = comment_window[-_LOOKBACK:]
+                if not _has_justification(recent):
+                    yield Finding(
+                        severity="WARN",
+                        check="doctest-ignores",
+                        rel_path=rel(path, root),
+                        line=lineno,
+                        message=(
+                            "unexplained ```ignore on doctest; add a "
+                            "justification comment or use ```no_run / "
+                            "plain ```rust if the example can run"
+                        ),
+                    )
+                comment_window.append(line)
+            elif _COMMENT_LINE.match(line):
+                comment_window.append(line)
+            elif not line.strip():
+                # Blank lines neither contribute nor reset.
+                continue
+            else:
+                comment_window = []

--- a/scripts/arch_check/cli.py
+++ b/scripts/arch_check/cli.py
@@ -13,7 +13,7 @@ import traceback
 from pathlib import Path
 from typing import Sequence
 
-from scripts.arch_check.checks import CHECK_ORDER, CHECKS
+from scripts.arch_check.checks import CHECK_ORDER, CHECKS, DEFAULT_CHECKS
 from scripts.arch_check.core import Finding, format_finding, repo_root
 
 
@@ -22,7 +22,8 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
         prog="arch_check",
         description=(
             "Architecture enforcement checks for octarine. "
-            "By default runs all checks on all .rs files in crates/octarine/src."
+            "By default runs the gating checks on all .rs files in "
+            "crates/octarine/src; opt-in checks must be requested explicitly."
         ),
     )
     parser.add_argument(
@@ -45,7 +46,7 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
-    selected = args.checks or CHECK_ORDER
+    selected = args.checks or DEFAULT_CHECKS
     root = repo_root()
 
     errors = 0

--- a/tests/arch_check/test_doctest_ignores.py
+++ b/tests/arch_check/test_doctest_ignores.py
@@ -1,0 +1,182 @@
+"""Tests for the doctest-ignores check.
+
+Rules under test:
+1. Bare ```ignore on a doc-comment fence yields a WARN finding.
+2. A justification comment within the preceding 3 doc lines suppresses it.
+3. An `// arch-check: allow doctest-ignores` directive suppresses it.
+4. Files under `primitives/` and `testing/` are skipped entirely.
+5. ```rust,ignore and indented (inside `impl`) fences are also caught.
+6. Plain ```rust and ```no_run fences are NOT flagged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.arch_check.checks import doctest_ignores
+
+
+def _files(tmp_repo: Path, rel: str) -> list[Path]:
+    return [tmp_repo / "crates/octarine/src" / rel]
+
+
+def test_bare_ignore_yields_warning(write_rs, tmp_repo: Path):
+    content = (
+        "/// Example using the API.\n"
+        "///\n"
+        "/// ```ignore\n"
+        "/// let x = foo();\n"
+        "/// ```\n"
+        "pub fn foo() {}\n"
+    )
+    write_rs("data/foo.rs", content)
+    findings = list(doctest_ignores.run(files=_files(tmp_repo, "data/foo.rs"), root=tmp_repo))
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.severity == "WARN"
+    assert f.check == "doctest-ignores"
+    assert f.line == 3
+    assert "unexplained" in f.message
+
+
+def test_justification_in_preceding_line_suppresses(write_rs, tmp_repo: Path):
+    content = (
+        "/// Example using the API.\n"
+        "/// Ignored because it requires a running tokio runtime.\n"
+        "/// ```ignore\n"
+        "/// foo().await;\n"
+        "/// ```\n"
+        "pub fn foo() {}\n"
+    )
+    write_rs("data/foo.rs", content)
+    assert list(doctest_ignores.run(files=_files(tmp_repo, "data/foo.rs"), root=tmp_repo)) == []
+
+
+def test_directive_suppresses(write_rs, tmp_repo: Path):
+    content = (
+        "/// Example.\n"
+        "// arch-check: allow doctest-ignores -- unstable API under construction\n"
+        "/// ```ignore\n"
+        "/// foo();\n"
+        "/// ```\n"
+        "pub(crate) fn foo() {}\n"
+    )
+    write_rs("data/foo.rs", content)
+    assert list(doctest_ignores.run(files=_files(tmp_repo, "data/foo.rs"), root=tmp_repo)) == []
+
+
+def test_rust_ignore_variant_yields_warning(write_rs, tmp_repo: Path):
+    # `rust,ignore` is a legal rustdoc form and must be caught too.
+    content = (
+        "/// Example.\n"
+        "///\n"
+        "/// ```rust,ignore\n"
+        "/// let x = foo();\n"
+        "/// ```\n"
+        "pub fn foo() {}\n"
+    )
+    write_rs("data/foo.rs", content)
+    findings = list(doctest_ignores.run(files=_files(tmp_repo, "data/foo.rs"), root=tmp_repo))
+    assert len(findings) == 1
+    assert findings[0].line == 3
+
+
+def test_indented_fence_yields_warning(write_rs, tmp_repo: Path):
+    # Inside an `impl` block, doc comments have leading whitespace.
+    content = (
+        "pub struct Thing;\n"
+        "\n"
+        "impl Thing {\n"
+        "    /// Example.\n"
+        "    ///\n"
+        "    /// ```ignore\n"
+        "    /// Thing.do_it();\n"
+        "    /// ```\n"
+        "    pub fn do_it(&self) {}\n"
+        "}\n"
+    )
+    write_rs("data/foo.rs", content)
+    findings = list(doctest_ignores.run(files=_files(tmp_repo, "data/foo.rs"), root=tmp_repo))
+    assert len(findings) == 1
+    assert findings[0].line == 6
+
+
+def test_plain_rust_fence_not_flagged(write_rs, tmp_repo: Path):
+    content = (
+        "/// Example.\n"
+        "///\n"
+        "/// ```rust\n"
+        "/// let x = 1;\n"
+        "/// ```\n"
+        "pub fn foo() {}\n"
+    )
+    write_rs("data/foo.rs", content)
+    assert list(doctest_ignores.run(files=_files(tmp_repo, "data/foo.rs"), root=tmp_repo)) == []
+
+
+def test_no_run_fence_not_flagged(write_rs, tmp_repo: Path):
+    content = (
+        "/// Example.\n"
+        "///\n"
+        "/// ```no_run\n"
+        "/// foo();\n"
+        "/// ```\n"
+        "pub fn foo() {}\n"
+    )
+    write_rs("data/foo.rs", content)
+    assert list(doctest_ignores.run(files=_files(tmp_repo, "data/foo.rs"), root=tmp_repo)) == []
+
+
+def test_primitives_files_skipped(write_rs, tmp_repo: Path):
+    content = (
+        "/// ```ignore\n"
+        "/// foo();\n"
+        "/// ```\n"
+        "pub(crate) fn foo() {}\n"
+    )
+    write_rs("primitives/foo.rs", content)
+    assert list(doctest_ignores.run(files=_files(tmp_repo, "primitives/foo.rs"), root=tmp_repo)) == []
+
+
+def test_testing_files_skipped(write_rs, tmp_repo: Path):
+    content = "/// ```ignore\n/// foo();\n/// ```\npub fn foo() {}\n"
+    write_rs("testing/foo.rs", content)
+    assert list(doctest_ignores.run(files=_files(tmp_repo, "testing/foo.rs"), root=tmp_repo)) == []
+
+
+def test_module_level_inner_doc_comment(write_rs, tmp_repo: Path):
+    # `//!` module-level doc comments must also be caught.
+    content = (
+        "//! Module overview.\n"
+        "//!\n"
+        "//! ```ignore\n"
+        "//! use crate::foo;\n"
+        "//! ```\n"
+    )
+    write_rs("data/mod_doc.rs", content)
+    findings = list(doctest_ignores.run(files=_files(tmp_repo, "data/mod_doc.rs"), root=tmp_repo))
+    assert len(findings) == 1
+    assert findings[0].line == 3
+
+
+def test_two_unrelated_fences_each_evaluated(write_rs, tmp_repo: Path):
+    # First fence has a justification (suppressed); second does not (flagged).
+    # Separating the two doc blocks with an item resets the doc window so
+    # the second fence cannot inherit the first's justification.
+    content = (
+        "/// Ignored because async I/O.\n"
+        "/// ```ignore\n"
+        "/// foo().await;\n"
+        "/// ```\n"
+        "pub fn foo() {}\n"
+        "\n"
+        "/// Plain doc.\n"
+        "/// ```ignore\n"
+        "/// bar();\n"
+        "/// ```\n"
+        "pub fn bar() {}\n"
+    )
+    write_rs("data/foo.rs", content)
+    findings = list(doctest_ignores.run(files=_files(tmp_repo, "data/foo.rs"), root=tmp_repo))
+    assert len(findings) == 1
+    assert findings[0].line == 8


### PR DESCRIPTION
## Summary

First of four phases addressing #191 — adds a new `arch-check` lint that catches unexplained ` ```ignore ` (and ` ```rust,ignore `) doctest fences on Layer 2/3 public-API doc comments, including indented fences inside `impl` blocks.

The check is **opt-in** for now. Introduces `DEFAULT_CHECKS` (the existing eight gating checks, run by `just arch-check` / preflight / CI) alongside `CHECK_ORDER` (the full registry, includes opt-ins). `doctest-ignores` lives only in `CHECK_ORDER`, so it's invocable via `just arch-check doctest-ignores` but does not red-light CI for the **338 pre-existing violations** waiting on Phases 2-3 remediation.

Suppression mirrors `unwrapped_fn.py`:
- a comment within the preceding 3 lines whose body contains `"ignore"` (case-insensitive), **or**
- an `// arch-check: allow doctest-ignores -- {reason}` directive

## Phased rollout

This PR is part 1 of 4 — issue #191 stays open until Phase 4 lands.

1. **Phase 1 (this PR)** — Add the lint as opt-in.
2. **Phase 2** — Strip `ignore` from pure-function fences (let them actually run as doctests). Pilot: `data/text/shortcuts.rs` (15 fences).
3. **Phase 3** — Convert async/I/O fences to ` ```no_run ` + one-line justification (e.g. `// Async I/O — requires a tokio runtime`).
4. **Phase 4** — Promote `doctest-ignores` into `DEFAULT_CHECKS`, upgrade severity to ERROR, add a docs note on ignore vs no_run vs plain rust. Final PR carries `Closes #191`.

## Test plan

- [x] `just arch-check-test` — 76 passed (11 new tests for doctest-ignores)
- [x] `just arch-check` (default run) — exits 0 cleanly, no output (no regression in the gating set)
- [x] `just arch-check doctest-ignores` — reports 338 WARN findings across 134 Layer 2/3 files (the work-list for Phases 2-3)
- [x] `just fmt-check`, `just lint-md`, `just test-docs` — all green
- [x] Pre-push clippy + cargo test — green

## Pre-review notes

- No Rust source touched; this PR is Python + Markdown only.
- The 338-finding scan output is **expected** and intentional — it's the work-list for the next two PRs in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)