### PR TITLE
feat(arch-check): promote doctest-ignores to default ERROR + docs (#191 phase 3-4/4)

### DIFF
--- a/docs/development/doctest-fences.md
+++ b/docs/development/doctest-fences.md
@@ -1,0 +1,94 @@
+# Doctest Fences: `ignore` vs `no_run` vs plain `rust`
+
+Rust doctests have three fence variants. Picking the right one keeps
+examples accurate as the codebase evolves, and keeps `cargo test --doc`
+honest about which examples are actually verified.
+
+## Rule of thumb
+
+| Fence            | rustdoc behavior              | Use when                                                                     |
+| ---------------- | ----------------------------- | ---------------------------------------------------------------------------- |
+| ` ```rust ` / ` ``` ` | Compiles **and** runs    | Pure functions, no I/O, no async runtime, no panics on the happy path        |
+| ` ```no_run `    | Compiles, does **not** run    | Compiles cleanly but needs runtime state — network, filesystem, tokio reactor |
+| ` ```ignore `    | Neither compiles nor runs     | Pseudo-code, intentionally incomplete, or a pre-existing example pending adaptation |
+
+Prefer the leftmost fence that fits. A plain ` ```rust ` example is the
+strongest guarantee — the doctest runs on every `just test-docs`, so the
+example cannot quietly rot. ` ```no_run ` is the next-best — type and import
+correctness are still verified at compile time. ` ```ignore ` is the escape
+hatch.
+
+## Why this matters
+
+` ```ignore ` silently skips compilation. A reader cannot tell whether the
+example "won't compile in principle," "shouldn't run in CI," or "the author
+hadn't decided yet." Over time, undocumented `ignore` fences accumulate and
+the example drifts out of sync with the API.
+
+The [`doctest-ignores`](../../scripts/arch_check/checks/doctest_ignores.py)
+arch-check enforces that every `ignore` fence in Layer 2/3 carries a
+justification comment within the preceding 3 doc lines. It runs on every
+`just arch-check` and gates CI as an ERROR.
+
+## Picking the right fence
+
+**Reach for ` ```rust ` (or bare ` ``` `) by default.** If the example is a
+pure call like `let s = sanitize(input)?;`, it can run. See
+`security/commands/shortcuts.rs` for five such examples on detection
+shortcuts.
+
+**Drop to ` ```no_run ` when compilation is the only honest guarantee.**
+This applies to examples that:
+
+- spawn or `.await` async work outside a runtime
+- open files, sockets, or external processes
+- depend on environment that the doctest harness does not provide
+
+The compile step still catches renames, signature drift, and missing
+imports — so prefer `no_run` over `ignore` whenever the example compiles.
+
+**Use ` ```ignore ` only when compilation would fail.** Typical triggers:
+
+- the example shows pseudo-code or a deliberately incomplete snippet
+- the example uses items not in scope without elaborate import boilerplate
+- the example exists as remediation backlog (an older `ignore` not yet
+  rewritten — `runtime/config/builder.rs` has 16 such async-builder
+  examples)
+
+Every `ignore` MUST be preceded by a doc-comment line whose body contains
+the substring `ignore` (case-insensitive). The arch-check is intentionally
+generous about phrasing — the goal is to force authors to write
+*something*, not to police wording.
+
+## Suppression
+
+Two ways to satisfy the arch-check:
+
+1. **Inline justification** — any preceding ` /// ` or ` //! ` doc line
+   within the last 3 lines whose text contains `ignore`. Examples:
+
+   ```text
+   /// Async builder — ignored because it requires a running tokio runtime.
+   /// ```ignore
+   /// ...
+   /// ```
+   ```
+
+2. **Explicit directive** — for the rare cases where the word "ignore"
+   does not naturally fit the justification:
+
+   ```text
+   // arch-check: allow doctest-ignores -- pseudo-code for documentation only
+   /// ```ignore
+   /// ...
+   /// ```
+   ```
+
+## Examples from this codebase
+
+- **Pure runnable** — `crates/octarine/src/security/commands/shortcuts.rs`
+  (five bare ` ``` ` fences on detection shortcuts).
+- **Justified `ignore`** — `crates/octarine/src/runtime/config/builder.rs`
+  (16 async-builder examples preceded by a "Pre-existing example…" line).
+- **Module-level `//!` doc** — `crates/octarine/src/data/text/shortcuts.rs`
+  (one `ignore` fence in the module overview).

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -12,6 +12,8 @@ Guidance for developing, testing, and contributing to octarine.
   unit tests, integration tests, fixtures, and timing-resilient patterns
 - [`../api/naming-conventions.md`](../api/naming-conventions.md) — prefix rules
   and API style
+- [`./doctest-fences.md`](./doctest-fences.md) — when to use ` ```rust `,
+  ` ```no_run `, or ` ```ignore ` for doctest examples
 
 ## Common Commands
 

--- a/scripts/arch_check/checks/__init__.py
+++ b/scripts/arch_check/checks/__init__.py
@@ -65,8 +65,9 @@ def _run_doctest_ignores(*, staged_only: bool, root: Path) -> Iterator[Finding]:
 # Order matters: bash executes checks in this exact sequence.
 # DEFAULT_CHECKS is the set that runs when arch-check is invoked with no
 # arguments (the gating set used by `just preflight` and CI). CHECK_ORDER
-# is the full registry of valid check names — checks not in DEFAULT_CHECKS
-# can still be invoked explicitly (e.g. `just arch-check doctest-ignores`).
+# is the full registry of valid check names — they currently match, but
+# the split lets future opt-in checks land without touching the default
+# gate.
 DEFAULT_CHECKS: list[str] = [
     "layer-boundary",
     "unwrapped-fn",
@@ -76,13 +77,10 @@ DEFAULT_CHECKS: list[str] = [
     "type-visibility",
     "builder-visibility",
     "file-length",
-]
-
-CHECK_ORDER: list[str] = [
-    *DEFAULT_CHECKS,
-    # Opt-in checks (not in default run until their remediation completes):
     "doctest-ignores",
 ]
+
+CHECK_ORDER: list[str] = [*DEFAULT_CHECKS]
 
 CHECKS: dict[str, CheckRunner] = {
     "layer-boundary": _run_layer_boundary,

--- a/scripts/arch_check/checks/doctest_ignores.py
+++ b/scripts/arch_check/checks/doctest_ignores.py
@@ -16,9 +16,10 @@ the substring `ignore` (case-insensitive) — e.g.
 This is intentionally generous: the goal is to force authors to write
 *something*, not to police phrasing.
 
-This check is not part of the default `CHECK_ORDER` run; it's invoked
-explicitly via `just arch-check doctest-ignores`. It will move into the
-default set once remediation reaches zero findings (see issue #191).
+This check is part of the default gating set (ERROR severity); a new
+unjustified ```ignore fence will fail `just arch-check` and CI. See
+`docs/development/doctest-fences.md` for the ignore vs no_run vs plain
+rust decision guide.
 """
 
 from __future__ import annotations
@@ -83,7 +84,7 @@ def run(*, files: Iterable[Path], root: Path) -> Iterator[Finding]:
                 recent = comment_window[-_LOOKBACK:]
                 if not _has_justification(recent):
                     yield Finding(
-                        severity="WARN",
+                        severity="ERROR",
                         check="doctest-ignores",
                         rel_path=rel(path, root),
                         line=lineno,

--- a/tests/arch_check/test_doctest_ignores.py
+++ b/tests/arch_check/test_doctest_ignores.py
@@ -1,7 +1,7 @@
 """Tests for the doctest-ignores check.
 
 Rules under test:
-1. Bare ```ignore on a doc-comment fence yields a WARN finding.
+1. Bare ```ignore on a doc-comment fence yields an ERROR finding.
 2. A justification comment within the preceding 3 doc lines suppresses it.
 3. An `// arch-check: allow doctest-ignores` directive suppresses it.
 4. Files under `primitives/` and `testing/` are skipped entirely.
@@ -20,7 +20,7 @@ def _files(tmp_repo: Path, rel: str) -> list[Path]:
     return [tmp_repo / "crates/octarine/src" / rel]
 
 
-def test_bare_ignore_yields_warning(write_rs, tmp_repo: Path):
+def test_bare_ignore_yields_error(write_rs, tmp_repo: Path):
     content = (
         "/// Example using the API.\n"
         "///\n"
@@ -33,7 +33,7 @@ def test_bare_ignore_yields_warning(write_rs, tmp_repo: Path):
     findings = list(doctest_ignores.run(files=_files(tmp_repo, "data/foo.rs"), root=tmp_repo))
     assert len(findings) == 1
     f = findings[0]
-    assert f.severity == "WARN"
+    assert f.severity == "ERROR"
     assert f.check == "doctest-ignores"
     assert f.line == 3
     assert "unexplained" in f.message


### PR DESCRIPTION
## Summary

Final two phases of #191 — promotes the `doctest-ignores` arch-check from opt-in WARN to default-gating ERROR, and ships a one-page guide on choosing between ```` ```rust ````, ```` ```no_run ````, and ```` ```ignore ```` fences.

Phases 1 (#393, opt-in check) and 2 (#394, justified 338 fences across 134 files) shipped the lint and remediated the existing violations. `just arch-check doctest-ignores` on `main` currently returns **0 findings** — the remediation is done and the lint is safe to default-gate.

## What changes

- `scripts/arch_check/checks/__init__.py` — move `doctest-ignores` into `DEFAULT_CHECKS`; drop the now-empty "opt-in checks" trailer block from `CHECK_ORDER`.
- `scripts/arch_check/checks/doctest_ignores.py` — `severity="WARN"` → `"ERROR"`; refresh the module docstring to reflect default-gating behavior.
- `tests/arch_check/test_doctest_ignores.py` — rename `test_bare_ignore_yields_warning` → `_yields_error`, flip the severity assertion. Other 10 tests assert only on count/line and pass unchanged.
- `docs/development/doctest-fences.md` *(new, ~75 lines)* — rule-of-thumb table for ```` ```rust ```` / ```` ```no_run ```` / ```` ```ignore ````, a "Why this matters" section, decision guidance, suppression syntax, and three real codebase examples.
- `docs/development/index.md` — link the new page in Start Here.

No Rust source touched; this PR is Python + Markdown only.

## Test plan

- [x] `just arch-check-test` — 76 passed (including the renamed `_yields_error`)
- [x] `just arch-check` (default run, now includes `doctest-ignores`) — exits 0, clean
- [x] `just lint-md` — 81 files clean (new doc included)
- [x] `just test-docs` — 247 passed (unchanged baseline)
- [x] `just spell` / `just fmt-check` — clean
- [x] Pre-push hooks (clippy + cargo test) — clean
- [x] **Smoke test** — added a stray ```` ```ignore ```` fence (no justification) to a Layer 3 file, confirmed `just arch-check` prints `[ERROR] doctest-ignores` and exits `1`. Reverted.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)