### PR TITLE
feat(ci): automate crates.io publishing and GitHub Release on tag push

### DIFF
--- a/.claude/skills/octarine-release/SKILL.md
+++ b/.claude/skills/octarine-release/SKILL.md
@@ -13,8 +13,8 @@ enforced. See `docs/releases/` for the operator-facing reference.
 
 ## Pre-1.0 SemVer Policy
 
-Octarine is on `0.x` and not yet published to crates.io. While we're pre-1.0,
-we follow the [Cargo SemVer convention](https://doc.rust-lang.org/cargo/reference/semver.html)
+Octarine is on `0.x`. While we're pre-1.0, we follow the
+[Cargo SemVer convention](https://doc.rust-lang.org/cargo/reference/semver.html)
 for `0.y.z`:
 
 | Version part | Meaning while 0.x | After 1.0 |
@@ -108,9 +108,16 @@ just release <type>              # Run preflight-full, bump versions, sweep
 # Review the new CHANGELOG entry — look for the "TODO: review" marker.
 # Amend the commit if curation is needed.
 
-git push && git push --tags
-gh release create vX.Y.Z [--prerelease] --generate-notes
+git push && git push --tags      # The release workflow takes over from here
 ```
+
+Once the tag is pushed, the
+[release workflow](../../../.github/workflows/release.yml) publishes all
+three workspace crates to crates.io in dependency order and creates a
+GitHub Release with the CHANGELOG section as the body. Pre-release tags
+(any version with a `-` suffix) are marked as pre-release. The workflow
+is idempotent — re-running on a partial failure skips crates already
+published at the target version.
 
 See `docs/releases/checklist.md` for the full step-by-step.
 
@@ -119,16 +126,19 @@ See `docs/releases/checklist.md` for the full step-by-step.
 - **`rc` from stable**: nothing to promote. The state machine errors.
   Cut a beta first.
 - **Forgetting `git push --tags`**: a bare `git push` ships the commit but
-  not the tag, so `gh release create` will fail.
+  not the tag, so the release workflow won't fire.
 - **Manually editing `crates/octarine-derive/Cargo.toml`**: the derive crate
   is intentionally on independent versioning. The release recipe never
-  touches it.
+  touches its version, but it does validate the workspace dep spec in
+  the root `Cargo.toml` matches — drift fails the release.
 - **Skipping `release-preview`**: the keyword bumps look obvious until they
   aren't (e.g. `minor` from a prerelease finalizes — surprising the first
   time). Preview to confirm.
 - **Mass-editing CHANGELOG entries after tag**: amending the release commit
   works only before push. After push, follow up with a plain `chore(docs):`
-  commit.
+  commit. Note that the published GitHub Release body is generated from
+  the CHANGELOG section at tag-push time — later CHANGELOG edits won't
+  propagate unless you re-run the `workflow_dispatch` event.
 
 ## Verification
 
@@ -154,4 +164,5 @@ See `docs/releases/checklist.md` for the full step-by-step.
 - Day-to-day commits (no release context)
 - `octarine-derive` versioning — that crate is independently versioned and
   not in scope here
-- Publishing to crates.io — not yet automated; track separately
+- Publishing to crates.io — fully automated by `.github/workflows/release.yml`
+  on tag push, no manual action required

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,225 @@
+name: Release
+
+# Publishes workspace crates to crates.io and creates a GitHub Release when a
+# `v*` tag is pushed. The companion local pipeline is `just release` in the
+# justfile — it bumps versions, generates the CHANGELOG entry, commits, and
+# creates the annotated tag. This workflow takes over from `git push --tags`.
+#
+# Publish ordering: `octarine-derive` and `octarine-problem` ship first
+# (no inter-dep), then `octarine` (depends on both via optional/required
+# features). Each publish job is idempotent — re-running on a partial failure
+# skips crates already on crates.io at the target version.
+#
+# Required secret: `CARGO_REGISTRY_TOKEN` (crates.io API token with publish
+# scope for all three crates). The `validate` job fails fast if it's missing.
+#
+# Security note: workflow_dispatch.inputs.tag is user-supplied — every use
+# in a `run:` block goes through an env var to prevent script injection.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)publish (e.g. v0.3.0-beta.4)"
+        required: true
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+      tag: ${{ steps.parse.outputs.tag }}
+      is_prerelease: ${{ steps.parse.outputs.is_prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Parse version from tag
+        id: parse
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          TAG="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
+            echo "::error::Tag '$TAG' is not a valid release tag (expected vX.Y.Z or vX.Y.Z-{alpha,beta,rc}.N)"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            if [[ "$VERSION" == *-* ]]; then
+              echo "is_prerelease=true"
+            else
+              echo "is_prerelease=false"
+            fi
+          } >> "$GITHUB_OUTPUT"
+          echo "Tag $TAG → version $VERSION"
+
+      - name: Assert Cargo.toml matches tag
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          WORKSPACE_VERSION=$(awk '/^\[workspace\.package\]/{f=1} f && /^version = /{gsub(/"/, "", $3); print $3; exit}' Cargo.toml)
+          if [ "$WORKSPACE_VERSION" != "$VERSION" ]; then
+            echo "::error::Tag version ($VERSION) does not match Cargo.toml workspace version ($WORKSPACE_VERSION)"
+            exit 1
+          fi
+          echo "Cargo.toml version matches tag: $VERSION"
+
+      - name: Assert CHANGELOG entry exists
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          if ! grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "::error::No '## [$VERSION]' section found in CHANGELOG.md"
+            exit 1
+          fi
+          echo "CHANGELOG entry present for $VERSION"
+
+      - name: Assert CARGO_REGISTRY_TOKEN is set
+        env:
+          TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Repository secret CARGO_REGISTRY_TOKEN is not configured. See https://crates.io/me for an API token."
+            exit 1
+          fi
+          echo "CARGO_REGISTRY_TOKEN is configured"
+
+  publish-derive:
+    name: Publish octarine-derive
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release
+      - name: Publish (skip if already on crates.io)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          DERIVE_VERSION=$(awk '/^\[package\]/{f=1} f && /^version = /{gsub(/"/, "", $3); print $3; exit}' crates/octarine-derive/Cargo.toml)
+          if cargo search octarine-derive --limit 1 | grep -qE "^octarine-derive = \"$DERIVE_VERSION\""; then
+            echo "octarine-derive $DERIVE_VERSION already on crates.io — skipping"
+            exit 0
+          fi
+          cargo publish -p octarine-derive --token "$CARGO_REGISTRY_TOKEN"
+
+  publish-problem:
+    name: Publish octarine-problem
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release
+      - name: Publish (skip if already on crates.io)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          if cargo search octarine-problem --limit 1 | grep -qE "^octarine-problem = \"$VERSION\""; then
+            echo "octarine-problem $VERSION already on crates.io — skipping"
+            exit 0
+          fi
+          cargo publish -p octarine-problem --token "$CARGO_REGISTRY_TOKEN"
+
+  publish-octarine:
+    name: Publish octarine
+    needs: [publish-derive, publish-problem, validate]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release
+      - name: Wait for deps to appear on crates.io
+        env:
+          PROBLEM_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          # crates.io's index propagation can lag a few seconds after a fresh
+          # publish. Poll for both deps before attempting the dependent publish.
+          DERIVE_VERSION=$(awk '/^\[package\]/{f=1} f && /^version = /{gsub(/"/, "", $3); print $3; exit}' crates/octarine-derive/Cargo.toml)
+          for crate_version in "octarine-derive:$DERIVE_VERSION" "octarine-problem:$PROBLEM_VERSION"; do
+            CRATE="${crate_version%:*}"
+            WANTED="${crate_version#*:}"
+            for attempt in 1 2 3 4 5 6; do
+              if cargo search "$CRATE" --limit 1 | grep -qE "^$CRATE = \"$WANTED\""; then
+                echo "$CRATE $WANTED is indexed"
+                break
+              fi
+              echo "Attempt $attempt: $CRATE $WANTED not yet indexed, waiting 15s..."
+              sleep 15
+            done
+          done
+      - name: Publish (skip if already on crates.io)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          if cargo search octarine --limit 1 | grep -qE "^octarine = \"$VERSION\""; then
+            echo "octarine $VERSION already on crates.io — skipping"
+            exit 0
+          fi
+          cargo publish -p octarine --token "$CARGO_REGISTRY_TOKEN"
+
+  github-release:
+    name: GitHub Release
+    needs: [publish-octarine, validate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+      - name: Extract CHANGELOG section
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          python3 -m scripts.release extract "$VERSION" > /tmp/release-notes.md
+          echo "── Release notes ──"
+          cat /tmp/release-notes.md
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          IS_PRERELEASE: ${{ needs.validate.outputs.is_prerelease }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — updating notes"
+            gh release edit "$TAG" --notes-file /tmp/release-notes.md $PRERELEASE_FLAG
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file /tmp/release-notes.md $PRERELEASE_FLAG
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to octarine will be documented in this file.
 
 ## [Unreleased]
 
+### CI
+
+- feat(ci): automate crates.io publishing and GitHub Release on tag push (#112)
+  - New `.github/workflows/release.yml` triggered on `v*` tags (and `workflow_dispatch` for re-runs) validates the tag against `Cargo.toml` and `CHANGELOG.md`, then publishes `octarine-derive`, `octarine-problem`, and `octarine` in dependency order. Each publish step is idempotent — re-running on a partial failure skips crates already on crates.io at the target version.
+  - Adds `scripts/release/changelog.py` `extract` subcommand that pulls a CHANGELOG section by version (used as the GitHub Release body, with the operator-only `<!-- TODO: review -->` marker stripped).
+  - Root `Cargo.toml` workspace deps now carry `version = ...` alongside `path = ...` so `cargo publish` accepts them. The `just release` recipe keeps these specs in lockstep with each crate's `[package].version` and fails fast if `octarine-derive`'s workspace dep drifts from its independently-versioned crate manifest.
+  - Operator's manual `gh release create` / `cargo publish` steps removed from docs and the release skill.
+
 ### Added
 
 - feat(identifiers): add framework database credential detection (#30)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,11 @@ clap = { version = "4.0", features = ["derive", "env"] }
 reqwest = { version = "0.13", features = ["json", "rustls"], default-features = false }
 
 # Internal crates
-octarine = { path = "crates/octarine" }
-octarine-derive = { path = "crates/octarine-derive" }
-octarine-problem = { path = "crates/octarine-problem" }
+# `version` alongside `path` is required so `cargo publish` accepts the
+# workspace. Kept in sync with each crate manifest by `just release`.
+octarine = { path = "crates/octarine", version = "0.3.0-beta.3" }
+octarine-derive = { path = "crates/octarine-derive", version = "0.1.0" }
+octarine-problem = { path = "crates/octarine-problem", version = "0.3.0-beta.3" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -16,12 +16,16 @@ Release process documentation for octarine.
 ```bash
 just release-preview <type>      # Read-only smoke test
 just release <type>              # Real release: preflight, bump, tag
-git push && git push --tags
-gh release create v<X.Y.Z> [--prerelease] --generate-notes
+git push && git push --tags      # The release workflow takes over from here
 ```
 
 Where `<type>` is one of `major | minor | patch | beta | rc` (computed) or a
 literal version like `0.4.0` or `0.4.0-beta.1`.
+
+Once the tag is pushed, the
+[release workflow](../../.github/workflows/release.yml) publishes all three
+crates to crates.io and creates the GitHub Release automatically. Pre-release
+tags (those with a `-` suffix) are marked as pre-release.
 
 ## See also
 

--- a/docs/releases/checklist.md
+++ b/docs/releases/checklist.md
@@ -18,9 +18,14 @@ In order:
    non-empty so unrelated edits don't get rolled into the release commit.
 4. **Runs `just preflight-full`** — fmt-check, clippy, shellcheck,
    arch-check, all tests, and perf tests.
-5. **Updates Cargo.toml versions** — root `Cargo.toml`, plus
-   `crates/octarine/Cargo.toml` if it carries a literal version (skipped
-   when `version.workspace = true`).
+5. **Updates Cargo.toml versions** — root `Cargo.toml`
+   (`[workspace.package]` and the `octarine` / `octarine-problem`
+   `[workspace.dependencies]` specs), plus `crates/octarine/Cargo.toml`
+   and `crates/octarine-problem/Cargo.toml` if they carry literal
+   versions (skipped when `version.workspace = true`).
+   `crates/octarine-derive/Cargo.toml` is **not** touched (independent
+   versioning), but the recipe verifies the workspace dep spec for
+   `octarine-derive` matches its crate manifest and bails on drift.
 6. **Sweeps doc references** — rewrites `vX.Y.Z` → `vNEW` in:
    - `README.md`
    - `CONTRIBUTING.md`
@@ -36,9 +41,9 @@ In order:
    Prepends an HTML comment marker `<!-- TODO: review and curate before
    push -->` so the operator sees it in the diff. See
    [`changelog-format.md`](changelog-format.md) for the schema.
-9. **Commits as `release: vX.Y.Z`** — staging Cargo.toml, Cargo.lock,
-   CHANGELOG.md, and any of the 5 doc files that changed. Retries once if
-   lefthook reformats.
+9. **Commits as `release: vX.Y.Z`** — staging Cargo.toml,
+   crates/*/Cargo.toml, Cargo.lock, CHANGELOG.md, and any of the doc
+   files that changed. Retries once if lefthook reformats.
 10. **Tags `vX.Y.Z`** — annotated tag with message `Release vX.Y.Z`.
 
 ## What you do manually
@@ -68,18 +73,31 @@ git push                    # commit
 git push --tags             # the annotated tag — easy to forget
 ```
 
-A bare `git push` ships the commit but not the tag, so `gh release create`
-will fail with "tag does not exist" until you push tags.
+A bare `git push` ships the commit but not the tag, so the release
+workflow won't fire.
 
-### GitHub release
+### After the push: the workflow takes over
 
-```bash
-gh release create vX.Y.Z [--prerelease] --generate-notes
-```
+The `.github/workflows/release.yml` workflow triggers on any `v*` tag
+push. It:
 
-Use `--prerelease` for any version with a `-` suffix (alpha/beta/rc).
-`--generate-notes` writes the GitHub release body from the same commit
-range; you can edit it via the web UI afterwards.
+1. Validates the tag matches `Cargo.toml`, `CHANGELOG.md` has the
+   expected section, and `CARGO_REGISTRY_TOKEN` is configured.
+2. Publishes `octarine-derive` and `octarine-problem` to crates.io in
+   parallel.
+3. Publishes `octarine` (waits for the two dep crates to index first).
+4. Creates a GitHub Release at `vX.Y.Z` with the CHANGELOG section as
+   the body. Pre-release versions (anything with a `-` suffix) are
+   marked as pre-release.
+
+Monitor the run at:
+<https://github.com/joshjhall/octarine/actions/workflows/release.yml>
+
+If a publish step fails partway through, just re-run the workflow — each
+publish job is idempotent and skips crates already on crates.io at the
+target version. You can also manually re-trigger via the
+`workflow_dispatch` event with an existing tag, useful when the
+workflow ran on an outdated commit or its CI flake needs replaying.
 
 ## Recommended pre-merge dry run
 
@@ -119,9 +137,10 @@ future work:
   pointers. Edit manually if their meaning changes.
 - **`crates/octarine-derive`** versions independently. Bumping the workspace
   does not touch it. Coordinate manually if the two crates need a coupled
-  release.
-- **`cargo publish`** to crates.io is not yet automated. Octarine is git-
-  dependency-only at present.
+  release. The release recipe validates that the version in
+  `crates/octarine-derive/Cargo.toml` matches the spec in the root
+  `Cargo.toml [workspace.dependencies]` block — drift there will fail
+  fast with a clear error.
 - **Recipe pause for CHANGELOG curation** — the recipe does not pause
   between writing the CHANGELOG and tagging. The TODO marker is the prompt
   to review-and-amend before push, not before tag.

--- a/justfile
+++ b/justfile
@@ -411,15 +411,36 @@ release ARG:
         VERSION=$(python3 -m scripts.release bump "$ARG" --current "$CURRENT")
     fi
 
-    # Workspace member sync: octarine must inherit the workspace version OR
-    # already match it literally. octarine-derive is intentionally untouched
-    # (independent versioning policy).
+    # Workspace member sync: octarine and octarine-problem must inherit the
+    # workspace version OR already match it literally. octarine-derive is
+    # intentionally untouched (independent versioning policy) but its
+    # workspace-deps spec in root Cargo.toml must match its crate manifest
+    # — drift there would break `cargo publish`.
     OCTARINE_LINE=$(/usr/bin/awk '/^version/{print; exit}' crates/octarine/Cargo.toml)
     if [[ "$OCTARINE_LINE" != *"workspace = true"* ]] \
        && [[ "$OCTARINE_LINE" != "version = \"$CURRENT\""* ]]; then
         echo "ERROR: crates/octarine/Cargo.toml version is out of sync with workspace" >&2
         echo "       workspace: $CURRENT" >&2
         echo "       crate:     $OCTARINE_LINE" >&2
+        exit 1
+    fi
+
+    PROBLEM_LINE=$(/usr/bin/awk '/^version/{print; exit}' crates/octarine-problem/Cargo.toml)
+    if [[ "$PROBLEM_LINE" != *"workspace = true"* ]] \
+       && [[ "$PROBLEM_LINE" != "version = \"$CURRENT\""* ]]; then
+        echo "ERROR: crates/octarine-problem/Cargo.toml version is out of sync with workspace" >&2
+        echo "       workspace: $CURRENT" >&2
+        echo "       crate:     $PROBLEM_LINE" >&2
+        exit 1
+    fi
+
+    DERIVE_CRATE_VERSION=$(/usr/bin/awk '/^version/{gsub(/^version = "|"$/, "", $0); print; exit}' crates/octarine-derive/Cargo.toml)
+    DERIVE_WS_VERSION=$(/usr/bin/awk '/^octarine-derive = /{match($0, /version = "[^"]+"/); print substr($0, RSTART+11, RLENGTH-12); exit}' Cargo.toml)
+    if [ "$DERIVE_CRATE_VERSION" != "$DERIVE_WS_VERSION" ]; then
+        echo "ERROR: octarine-derive version drift between manifest and workspace deps" >&2
+        echo "       crates/octarine-derive/Cargo.toml: $DERIVE_CRATE_VERSION" >&2
+        echo "       Cargo.toml [workspace.dependencies]: $DERIVE_WS_VERSION" >&2
+        echo "       Fix by editing Cargo.toml so workspace dep matches the crate manifest." >&2
         exit 1
     fi
 
@@ -447,6 +468,16 @@ release ARG:
         sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/octarine/Cargo.toml
         echo "  crates/octarine/Cargo.toml → $VERSION"
     fi
+    if [[ "$PROBLEM_LINE" != *"workspace = true"* ]]; then
+        sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/octarine-problem/Cargo.toml
+        echo "  crates/octarine-problem/Cargo.toml → $VERSION"
+    fi
+    # Workspace dep specs in root Cargo.toml carry literal versions alongside
+    # `path = ...` so `cargo publish` accepts the workspace. Keep them in
+    # lockstep with the crate manifests they point to. octarine-derive is
+    # independently versioned and never touched here.
+    sed -i "s|^octarine = { path = \"crates/octarine\", version = \"[^\"]*\" }|octarine = { path = \"crates/octarine\", version = \"$VERSION\" }|" Cargo.toml
+    sed -i "s|^octarine-problem = { path = \"crates/octarine-problem\", version = \"[^\"]*\" }|octarine-problem = { path = \"crates/octarine-problem\", version = \"$VERSION\" }|" Cargo.toml
     echo "  Cargo.toml → $VERSION"
 
     # Sweep version references in human-readable docs. The list is
@@ -539,13 +570,13 @@ release ARG:
     # Lefthook hooks may fix formatting (e.g., trailing newlines). If the first
     # commit fails because hooks modified files, re-stage and retry once.
     echo "── Committing ──"
-    git add Cargo.toml crates/octarine/Cargo.toml Cargo.lock CHANGELOG.md
+    git add Cargo.toml crates/octarine/Cargo.toml crates/octarine-problem/Cargo.toml Cargo.lock CHANGELOG.md
     for f in "${DOC_FILES[@]}"; do
         if [ -f "$f" ]; then git add "$f"; fi
     done
     if ! git commit -m "release: v$VERSION"; then
         echo "  Lefthook hooks modified files, retrying..."
-        git add Cargo.toml crates/octarine/Cargo.toml Cargo.lock CHANGELOG.md
+        git add Cargo.toml crates/octarine/Cargo.toml crates/octarine-problem/Cargo.toml Cargo.lock CHANGELOG.md
         for f in "${DOC_FILES[@]}"; do
             if [ -f "$f" ]; then git add "$f"; fi
         done
@@ -555,11 +586,6 @@ release ARG:
     echo "  Tagged v$VERSION"
 
     # Determine if pre-release
-    PRERELEASE_FLAG=""
-    if [[ "$VERSION" == *-* ]]; then
-        PRERELEASE_FLAG=" --prerelease"
-    fi
-
     echo ""
     echo "═══ Release v$VERSION ready ═══"
     echo ""
@@ -568,7 +594,10 @@ release ARG:
     echo ""
     echo "Next steps:"
     echo "  git push && git push --tags"
-    echo "  gh release create v$VERSION$PRERELEASE_FLAG --generate-notes"
+    echo ""
+    echo "The release workflow takes over from there — it publishes all three"
+    echo "crates to crates.io and creates a GitHub Release. Monitor it at:"
+    echo "  https://github.com/joshjhall/octarine/actions/workflows/release.yml"
 
 # Preview a release without touching disk. Prints the proposed version, the
 # doc files that would be rewritten, and a snapshot of commits since the last

--- a/scripts/release/changelog.py
+++ b/scripts/release/changelog.py
@@ -1,0 +1,60 @@
+"""CHANGELOG section extraction for release automation.
+
+The release workflow uses `extract(version)` to pull the matching
+`## [VERSION] - DATE` block out of `CHANGELOG.md` and emit it as the
+GitHub Release body. The extractor strips the operator-only
+`<!-- TODO: review and curate before push -->` marker that `just release`
+prepends as a curation prompt — it would be confusing in a published
+release body.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class ChangelogError(Exception):
+    """Raised when a CHANGELOG section cannot be located or parsed."""
+
+
+# Operator-only marker inserted by `just release` for human curation. The
+# extractor strips it so it never appears in a published GitHub Release.
+_TODO_MARKER = "<!-- TODO: review and curate before push -->"
+
+
+def extract(version: str, changelog: Path | str = Path("CHANGELOG.md")) -> str:
+    """Return the CHANGELOG body for `version`.
+
+    Locates the line `## [VERSION] - DATE` and returns everything up to (but
+    not including) the next `## ` heading, stripped of leading/trailing blank
+    lines and the curation TODO marker.
+
+    Raises `ChangelogError` if the file is missing or the section is absent.
+    """
+    path = Path(changelog)
+    if not path.exists():
+        raise ChangelogError(f"CHANGELOG not found at {path}")
+
+    needle = f"## [{version}]"
+    in_section = False
+    captured: list[str] = []
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if in_section:
+            # Stop at the next top-level section (either another version
+            # or the [Unreleased] header — both start with "## ").
+            if line.startswith("## "):
+                break
+            captured.append(line)
+            continue
+        if line.startswith(needle):
+            in_section = True
+
+    if not in_section:
+        raise ChangelogError(f"No section for version {version!r} in {path}")
+
+    body = "\n".join(captured).strip("\n")
+    # Strip the operator-only TODO marker (and its trailing blank line).
+    body = body.replace(_TODO_MARKER + "\n\n", "").replace(_TODO_MARKER + "\n", "")
+    body = body.replace(_TODO_MARKER, "")
+    return body.strip("\n")

--- a/scripts/release/cli.py
+++ b/scripts/release/cli.py
@@ -1,12 +1,14 @@
 """CLI for the release helper.
 
-Two subcommands:
+Three subcommands:
 
 - `bump <kind> --current X.Y.Z` — print the computed next version to stdout.
   The `release` justfile recipe captures this with `$(...)` to drive
   Cargo.toml updates.
 - `parse X.Y.Z` — validate a version string; exits 0 on success, non-zero
   with a message on failure. Used by `release` for literal-version input.
+- `extract X.Y.Z` — print the CHANGELOG section for `X.Y.Z` to stdout.
+  Used by the release workflow as the GitHub Release body.
 
 All errors print to stderr and exit non-zero, so failures are visible in the
 recipe output without polluting the captured stdout.
@@ -18,6 +20,7 @@ import argparse
 import sys
 from typing import Sequence
 
+from scripts.release.changelog import ChangelogError, extract
 from scripts.release.version import VersionError, bump, parse
 
 BUMP_KINDS = ("major", "minor", "patch", "beta", "rc")
@@ -47,6 +50,17 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     parse_p.add_argument("version", help="Version string to validate.")
 
+    extract_p = sub.add_parser(
+        "extract",
+        help="Print the CHANGELOG section for the given version.",
+    )
+    extract_p.add_argument("version", help="Version whose section to extract.")
+    extract_p.add_argument(
+        "--changelog",
+        default="CHANGELOG.md",
+        help="Path to CHANGELOG.md (default: CHANGELOG.md).",
+    )
+
     return parser.parse_args(argv)
 
 
@@ -63,7 +77,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             v = parse(args.version)
             print(v.format())
             return 0
-    except VersionError as e:
+        if args.command == "extract":
+            print(extract(args.version, args.changelog))
+            return 0
+    except (VersionError, ChangelogError) as e:
         print(f"release: {e}", file=sys.stderr)
         return 1
 

--- a/tests/release/test_changelog.py
+++ b/tests/release/test_changelog.py
@@ -1,0 +1,91 @@
+"""Tests for the CHANGELOG section extractor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.release.changelog import ChangelogError, extract
+
+
+_SAMPLE = """\
+# Changelog
+
+All notable changes to octarine will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- feat(foo): new thing
+
+## [0.3.0-beta.3] - 2026-04-28
+
+<!-- TODO: review and curate before push -->
+
+### Fixed
+
+- fix(observe): metrics instrumentation
+
+### Changed
+
+- chore(deps): bundle dependabot bumps
+
+## [0.3.0-beta.2] - 2026-04-25
+
+### Added
+
+- feat(identifiers): UK NINO
+"""
+
+
+@pytest.fixture
+def changelog(tmp_path: Path) -> Path:
+    f = tmp_path / "CHANGELOG.md"
+    f.write_text(_SAMPLE, encoding="utf-8")
+    return f
+
+
+def test_extract_returns_section_body(changelog: Path) -> None:
+    body = extract("0.3.0-beta.3", changelog)
+    assert "### Fixed" in body
+    assert "fix(observe): metrics instrumentation" in body
+    assert "### Changed" in body
+
+
+def test_extract_strips_todo_marker(changelog: Path) -> None:
+    body = extract("0.3.0-beta.3", changelog)
+    assert "TODO: review" not in body
+
+
+def test_extract_stops_at_next_version(changelog: Path) -> None:
+    body = extract("0.3.0-beta.3", changelog)
+    assert "0.3.0-beta.2" not in body
+    assert "UK NINO" not in body
+
+
+def test_extract_last_section_works(changelog: Path) -> None:
+    body = extract("0.3.0-beta.2", changelog)
+    assert "UK NINO" in body
+
+
+def test_extract_unreleased_works(changelog: Path) -> None:
+    body = extract("Unreleased", changelog)
+    assert "feat(foo): new thing" in body
+
+
+def test_extract_missing_version_raises(changelog: Path) -> None:
+    with pytest.raises(ChangelogError, match="No section for version"):
+        extract("9.9.9", changelog)
+
+
+def test_extract_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(ChangelogError, match="CHANGELOG not found"):
+        extract("0.3.0", tmp_path / "does-not-exist.md")
+
+
+def test_extract_trims_trailing_blank_lines(changelog: Path) -> None:
+    body = extract("0.3.0-beta.3", changelog)
+    assert not body.startswith("\n")
+    assert not body.endswith("\n")


### PR DESCRIPTION
## Summary

Phase 2 of the release process (Phase 1 was #111 / PR #295). On `v*` tag push, the new `.github/workflows/release.yml` workflow:

1. **Validates** the tag matches `Cargo.toml`, the `CHANGELOG.md` section exists, and `CARGO_REGISTRY_TOKEN` is configured.
2. **Publishes** `octarine-derive` and `octarine-problem` to crates.io in parallel, then `octarine` (with deps-indexed polling).
3. **Creates** a GitHub Release at `vX.Y.Z` with the matching CHANGELOG section as the body. Pre-release versions (anything with `-`) are flagged as such.

Each publish step is idempotent — re-running on a partial failure skips crates already at the target version. A `workflow_dispatch` trigger is included for manual re-runs.

## Supporting changes

- **`Cargo.toml`**: workspace deps now carry `version =` alongside `path =` so `cargo publish` accepts them. The `just release` recipe keeps these specs in lockstep with each crate's `[package].version` and fails fast if `octarine-derive`'s workspace dep drifts from its independently-versioned crate manifest.
- **`scripts/release/changelog.py` + `extract` subcommand**: pulls a CHANGELOG section by version. Used as the GitHub Release body. Strips the operator-only `<!-- TODO: review -->` marker.
- **Docs and skill**: manual `gh release create` / `cargo publish` steps removed from `docs/releases/checklist.md`, `docs/releases/README.md`, and `.claude/skills/octarine-release/SKILL.md`.

## Pre-publish setup required (one-time)

Before the first real release, the repo owner must add a **`CARGO_REGISTRY_TOKEN`** secret in repository settings (crates.io API token with publish scope for all three crates). The `validate` job fails fast with a clear error if it's missing.

## Test plan

- [x] `just release-test` — 64 pytest cases pass (56 existing + 8 new for the extract subcommand)
- [x] `cargo publish --dry-run -p octarine-derive` — packaging + verification succeeds
- [x] `cargo publish --dry-run -p octarine-problem` — packaging + verification succeeds
- [x] `cargo publish --dry-run -p octarine` — packages successfully; fails at the dep-resolution step (expected, since `octarine-derive` is not on crates.io yet — the workflow's wait-for-deps step handles this in CI)
- [x] `actionlint .github/workflows/release.yml` — clean
- [x] `just clippy`, `just fmt-check`, `just lint-md`, `just lint-deps`, `just arch-check` — all pass
- [x] `python3 -m scripts.release extract 0.3.0-beta.3` against the real CHANGELOG — extracts cleanly
- [x] Lefthook pre-commit hooks (taplo, dprint, actionlint, rumdl, typos, gitleaks, etc.) — all pass

## Security

The workflow uses env vars (not inline `${{ }}` expansion) for any user-controlled input (`workflow_dispatch.inputs.tag`), per GitHub's script-injection guidance.

## Out of scope (Phase 3, tracked in #113)

- `cargo audit` / `cargo deny` gates before publish
- Cross-crate version coordination validation
- RC promotion workflow
- Artifact uploads (not meaningful for a library crate)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)