### PR TITLE
feat(identifiers): PSL validation for email + URL, plus bare-URL detection via linkify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "addr"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
+dependencies = [
+ "psl",
+ "psl-types",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,6 +2445,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +2754,7 @@ dependencies = [
 name = "octarine"
 version = "0.3.0-beta.3"
 dependencies = [
+ "addr",
  "aes-gcm",
  "arbitrary",
  "argon2",
@@ -2767,6 +2787,7 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "libc",
+ "linkify",
  "local-ip-address",
  "ml-kem",
  "nix 0.31.3",
@@ -3410,6 +3431,21 @@ checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "psl"
+version = "2.1.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fbd4d9b2eb0b6e0cbd654bce70243f460cbc8dc92df6747e3fb911ce1cd4a8"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "quanta"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ url = { version = "2.0", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Public Suffix List for email + DNS validation (closest Rust analog to Python's tldextract)
+addr = "0.15"
+# Bare-URL extraction from prose with prose-aware boundary handling
+linkify = "0.10"
+
 # CLI
 clap = { version = "4.0", features = ["derive", "env"] }
 

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -37,6 +37,12 @@ unicode-security = "0.1"
 # URL and network validation
 url = { workspace = true }
 
+# Public Suffix List validation for emails and bare DNS names (optional, gated by `email-strict` / `url-strict`)
+addr = { workspace = true, optional = true }
+
+# Bare-URL extraction from prose (optional, gated by `url-strict`)
+linkify = { workspace = true, optional = true }
+
 # Unique identifiers
 uuid = { workspace = true }
 
@@ -177,13 +183,19 @@ libc = "0.2"
 rexpect = { version = "0.7", optional = true }
 
 [features]
-default = ["console", "full", "derive"]
+default = ["console", "full", "derive", "email-strict", "url-strict"]
 console = ["dep:console"]
 cli = ["dep:clap", "dep:indicatif", "console"]
 full = ["observe", "security", "cli"]
 derive = ["dep:octarine-derive"]
 observe = []
 security = []
+# Strict email TLD validation via the Mozilla Public Suffix List.
+# Adds ~250KB of embedded PSL data. Disable for embedded/wasm callers.
+email-strict = ["dep:addr"]
+# Bare-URL detection in prose (e.g., "visit example.com") via linkify + url::Url::parse,
+# plus bare-host acceptance in is_url via the Public Suffix List.
+url-strict = ["dep:addr", "dep:linkify"]
 database = ["dep:graphql-parser"]
 formats = ["dep:quick-xml", "dep:serde_yaml"]
 postgres = ["database", "dep:sqlx", "sqlx?/postgres"]

--- a/crates/octarine/src/primitives/identifiers/network/detection/url.rs
+++ b/crates/octarine/src/primitives/identifiers/network/detection/url.rs
@@ -11,6 +11,27 @@ use super::common::{
 };
 
 // ============================================================================
+// PSL Bare-Host Validation
+// ============================================================================
+
+/// Validate a bare hostname against the Public Suffix List.
+///
+/// Used under `url-strict` to accept bare URLs (`example.com`, `www.example.com`)
+/// while rejecting prose tokens that contain a dot (`map.contains`,
+/// `foo.notatld`).
+///
+/// The host is lowercased before consulting the PSL because DNS names are
+/// case-insensitive (RFC 1035 § 2.3.3) but `addr`'s matcher is
+/// case-sensitive against the lowercase PSL.
+#[cfg(feature = "url-strict")]
+fn is_bare_host_valid(host: &str) -> bool {
+    let lower = host.to_ascii_lowercase();
+    addr::parse_domain_name(&lower)
+        .map(|d| d.has_known_suffix())
+        .unwrap_or(false)
+}
+
+// ============================================================================
 // Single-Value Detection
 // ============================================================================
 
@@ -21,17 +42,35 @@ use super::common::{
 /// - FTP
 /// - WebSocket (ws://, wss://)
 /// - Generic URLs with other schemes
+///
+/// Under the default `url-strict` feature, also accepts bare hosts whose TLD
+/// is on the Public Suffix List (e.g., `example.com`, `www.example.com`).
 #[must_use]
 pub fn is_url(value: &str) -> bool {
     let trimmed = value.trim();
     if exceeds_safe_length(trimmed, MAX_IDENTIFIER_LENGTH) {
         return false;
     }
-    patterns::network::URL_HTTP.is_match(trimmed)
+
+    let scheme_match = patterns::network::URL_HTTP.is_match(trimmed)
         || patterns::network::URL_FTP.is_match(trimmed)
         || patterns::network::URL_WSS.is_match(trimmed)
         || patterns::network::URL_WS.is_match(trimmed)
-        || patterns::network::URL_GENERIC.is_match(trimmed)
+        || patterns::network::URL_GENERIC.is_match(trimmed);
+    if scheme_match {
+        return true;
+    }
+
+    // Bare-host fallback under `url-strict` only — preserves today's
+    // "scheme required" behavior for callers that opt out.
+    #[cfg(feature = "url-strict")]
+    {
+        is_bare_host_valid(trimmed)
+    }
+    #[cfg(not(feature = "url-strict"))]
+    {
+        false
+    }
 }
 
 // ============================================================================
@@ -39,6 +78,49 @@ pub fn is_url(value: &str) -> bool {
 // ============================================================================
 
 /// Find all URLs in text
+///
+/// Under the default `url-strict` feature, uses `linkify` for prose-aware
+/// boundary detection (e.g., trims trailing punctuation, balances parens)
+/// and accepts bare URLs. Candidates are post-filtered through
+/// `url::Url::parse` (scheme-prefixed) or the Public Suffix List
+/// (bare hosts) to reject prose tokens like `map.contains`.
+///
+/// Under `not(url-strict)`, falls back to the original regex-based scan.
+#[cfg(feature = "url-strict")]
+#[must_use]
+pub fn find_urls_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut finder = linkify::LinkFinder::new();
+    finder.url_must_have_scheme(false);
+    finder.kinds(&[linkify::LinkKind::Url]);
+
+    let mut matches = Vec::new();
+    for link in finder.links(text) {
+        let candidate = link.as_str();
+        let valid = if candidate.contains("://") {
+            url::Url::parse(candidate).is_ok()
+        } else {
+            is_bare_host_valid(candidate)
+        };
+        if !valid {
+            continue;
+        }
+        matches.push(IdentifierMatch::new(
+            link.start(),
+            link.end(),
+            candidate.to_string(),
+            IdentifierType::Url,
+            DetectionConfidence::Medium, // URLs are context-dependent
+        ));
+    }
+    deduplicate_matches(matches)
+}
+
+/// Find all URLs in text (regex fallback under `not(url-strict)`).
+#[cfg(not(feature = "url-strict"))]
 #[must_use]
 pub fn find_urls_in_text(text: &str) -> Vec<IdentifierMatch> {
     if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
@@ -54,7 +136,7 @@ pub fn find_urls_in_text(text: &str) -> Vec<IdentifierMatch> {
                 full_match.end(),
                 full_match.as_str().to_string(),
                 IdentifierType::Url,
-                DetectionConfidence::Medium, // URLs are context-dependent
+                DetectionConfidence::Medium,
             ));
         }
     }
@@ -157,7 +239,29 @@ mod tests {
         assert!(is_url("wss://example.com/socket"));
         // Invalid
         assert!(!is_url("not-a-url"));
-        assert!(!is_url("example.com")); // no protocol
+    }
+
+    /// Under `url-strict`, bare hostnames with a Public Suffix List TLD are
+    /// recognized as URLs (`example.com`, `www.example.com`), while prose
+    /// tokens that look like dotted names are not (`map.contains`,
+    /// `foo.notatld`).
+    #[cfg(feature = "url-strict")]
+    #[test]
+    fn test_is_url_bare_host_strict() {
+        assert!(is_url("example.com"));
+        assert!(is_url("www.example.com"));
+        assert!(is_url("github.io"));
+        // Prose tokens — must not validate.
+        assert!(!is_url("map.contains"));
+        assert!(!is_url("foo.notatld"));
+        assert!(!is_url("3.5.2"));
+    }
+
+    /// Under `not(url-strict)`, the legacy "scheme required" behavior holds.
+    #[cfg(not(feature = "url-strict"))]
+    #[test]
+    fn test_is_url_no_bare_host() {
+        assert!(!is_url("example.com"));
     }
 
     #[test]
@@ -165,6 +269,43 @@ mod tests {
         let text = "Visit https://example.com or http://test.org for more info";
         let matches = find_urls_in_text(text);
         assert_eq!(matches.len(), 2);
+    }
+
+    /// Bare-URL detection (issue #429): `linkify` extracts dotted hosts from
+    /// prose under `url-strict`, then the PSL post-filter keeps only the
+    /// real domains.
+    #[cfg(feature = "url-strict")]
+    #[test]
+    fn test_find_urls_bare_in_prose() {
+        let text = "visit example.com today";
+        let matches = find_urls_in_text(text);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches.first().expect("first").matched_text, "example.com");
+    }
+
+    /// Issue #429: URL extraction must not greedily eat trailing prose.
+    /// The legacy regex `https?://[^\s]+` happened to stop at whitespace
+    /// already, but apostrophes and trailing punctuation tested here can
+    /// confuse less careful extractors.
+    #[cfg(feature = "url-strict")]
+    #[test]
+    fn test_find_urls_does_not_over_match() {
+        let text = "Read https://example.com it's great";
+        let matches = find_urls_in_text(text);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches.first().expect("first").matched_text,
+            "https://example.com"
+        );
+
+        // Trailing punctuation is stripped by linkify.
+        let text = "Check https://example.com/foo.";
+        let matches = find_urls_in_text(text);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches.first().expect("first").matched_text,
+            "https://example.com/foo"
+        );
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/personal/detection/email.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/detection/email.rs
@@ -17,6 +17,46 @@ const CODE_FILE_EXTENSIONS: &[&str] = &[
 ];
 
 // ============================================================================
+// PSL Post-Filter
+// ============================================================================
+
+/// Reject emails whose TLD is not on the Mozilla Public Suffix List.
+///
+/// Closes the "any 2+ ASCII letters is a TLD" gap in the regex layer. Under
+/// `not(email-strict)` this is a no-op so the regex's behavior is preserved
+/// for callers who opt out of the ~250KB PSL data (embedded/wasm).
+///
+/// The domain part is lowercased before consulting the PSL because DNS
+/// domains are case-insensitive (RFC 5321 § 2.3.11) and `addr`'s suffix
+/// matcher is case-sensitive against the lowercase PSL.
+#[cfg(feature = "email-strict")]
+fn psl_validates_email(email: &str) -> bool {
+    // RFC 5321: only the domain is case-insensitive — the local part is in
+    // principle case-sensitive, so lowercase only after the `@`.
+    let normalized = email.rfind('@').map_or_else(
+        || email.to_string(),
+        |at| {
+            let (local, domain) = email.split_at(at);
+            format!("{local}{}", domain.to_ascii_lowercase())
+        },
+    );
+    match addr::parse_email_address(&normalized) {
+        Ok(parsed) => match parsed.host() {
+            addr::email::Host::Domain(d) => d.has_known_suffix(),
+            // IP-literal hosts (`user@[10.0.0.1]`) are RFC 5321 valid and have
+            // no TLD to validate — accept them.
+            addr::email::Host::IpAddr(_) => true,
+        },
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(feature = "email-strict"))]
+fn psl_validates_email(_email: &str) -> bool {
+    true
+}
+
+// ============================================================================
 // False Positive Filters
 // ============================================================================
 
@@ -66,10 +106,10 @@ pub fn is_email(value: &str) -> bool {
         return result;
     }
 
-    // Compute fresh
-    let result = patterns::email::EXACT.is_match(trimmed);
+    // Regex prefilter, then PSL post-filter (no-op under `not(email-strict)`).
+    let result = patterns::email::EXACT.is_match(trimmed) && psl_validates_email(trimmed);
 
-    // Cache the result
+    // Cache the final (post-PSL) result so the cached answer matches the API.
     EMAIL_CACHE.insert(trimmed.to_string(), result);
 
     result
@@ -165,6 +205,12 @@ pub fn detect_emails_in_text(text: &str) -> Vec<IdentifierMatch> {
 
             // Filter out code context false positives
             if is_code_context_false_positive(text, full_match.start(), matched_text) {
+                continue;
+            }
+
+            // Reject TLDs that aren't on the Public Suffix List (no-op under
+            // `not(email-strict)`).
+            if !psl_validates_email(matched_text) {
                 continue;
             }
 
@@ -366,5 +412,66 @@ mod tests {
         let stats2 = email_cache_stats();
 
         assert!(stats2.hits > stats1.hits);
+    }
+
+    // ── Public Suffix List validation (issue #429) ─────────────────────
+
+    #[cfg(feature = "email-strict")]
+    #[test]
+    #[serial]
+    fn test_psl_rejects_unknown_tld() {
+        clear_personal_caches();
+        // Made-up TLD — regex would accept it, PSL post-filter rejects it.
+        assert!(!is_email("user@example.notatld"));
+        assert!(!is_email("admin@foo.zz"));
+        // `.bar` is actually a registered ICANN TLD, so don't use it as a counter-example.
+    }
+
+    #[cfg(feature = "email-strict")]
+    #[test]
+    #[serial]
+    fn test_psl_accepts_psl_effective_tld() {
+        clear_personal_caches();
+        // `github.io` is a Public Suffix (private section) — should be accepted
+        // even though `.io` alone is also a TLD.
+        assert!(is_email("user@github.io"));
+        // Real TLDs still accepted.
+        assert!(is_email("user@example.com"));
+        assert!(is_email("user@example.museum"));
+    }
+
+    #[cfg(feature = "email-strict")]
+    #[test]
+    #[serial]
+    fn test_psl_detect_filters_made_up_tld_in_text() {
+        clear_personal_caches();
+        let text = "Contact user@example.com or fake@foo.notatld today";
+        let matches = detect_emails_in_text(text);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches.first().expect("first").matched_text,
+            "user@example.com"
+        );
+    }
+
+    #[cfg(feature = "email-strict")]
+    #[test]
+    #[serial]
+    fn test_psl_accepts_ip_literal_email() {
+        clear_personal_caches();
+        // IP-literal hosts have no TLD; RFC 5321 says they're valid emails.
+        assert!(is_email("user@[192.168.1.1]"));
+        assert!(is_email("admin@[10.0.0.1]"));
+    }
+
+    #[cfg(feature = "email-strict")]
+    #[test]
+    #[serial]
+    fn test_psl_handles_mixed_case_domain() {
+        // RFC 5321: email domains are case-insensitive. PSL is lowercase-only,
+        // so we must lowercase the domain before consulting it.
+        clear_personal_caches();
+        assert!(is_email("User@Example.COM"));
+        assert!(is_email("USER@GITHUB.IO"));
     }
 }

--- a/crates/octarine/src/primitives/identifiers/personal/validation/email.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/validation/email.rs
@@ -15,6 +15,11 @@ use super::super::detection;
 /// Uses simplified regex to avoid ReDoS attacks.
 /// Does not validate email deliverability, only format.
 ///
+/// Under the default `email-strict` feature, the TLD must appear on the
+/// Mozilla Public Suffix List — so `user@example.notatld` is rejected even
+/// though the regex matches it. Disable `email-strict` for embedded/wasm
+/// callers that cannot afford the ~250KB embedded PSL data.
+///
 /// # Examples
 ///
 /// ```ignore
@@ -30,6 +35,7 @@ use super::super::detection;
 /// - Email is shorter than 3 or longer than 254 characters
 /// - Local part is empty or longer than 64 characters
 /// - Email format doesn't match RFC pattern
+/// - Under `email-strict`, the TLD is not on the Public Suffix List
 /// - Email contains dangerous XSS patterns
 pub fn validate_email(email: &str) -> Result<(), Problem> {
     // Length limits to prevent DoS


### PR DESCRIPTION
## Summary

Closes the *\"any 2+ ASCII letters is a TLD\"* gap in email detection and the *\"scheme required\"* gap in URL detection — both produced unacceptable behavior for LLM-proxy redaction (filenames / version strings flagged as PII; bare URLs in user messages silently leaked).

Two new feature flags, both **on by default** (pre-1.0, no deprecation cycle needed):

- **`email-strict`** — `addr::parse_email_address` + `has_known_suffix()` post-filter on `is_email` and `detect_emails_in_text`. Domain is lowercased before consulting the PSL (RFC 5321 — domains are case-insensitive but `addr`'s matcher is case-sensitive against the lowercase PSL).
- **`url-strict`** — `find_urls_in_text` switches to `linkify::LinkFinder` (prose-aware boundaries, balances parens, trims trailing punctuation) + `url::Url::parse` for scheme-prefixed candidates or PSL bare-host check for hostnames. `is_url` adds a PSL bare-host fallback so `example.com` validates but `map.contains` does not.

Embedded / wasm callers can opt out with `--no-default-features` — the regex-only legacy paths are preserved verbatim under `not(*-strict)`.

## Test plan

From the issue, all verified:

- [x] `user@example.notatld` rejected (`test_psl_rejects_unknown_tld`)
- [x] `user@example.com` accepted (`test_is_email`)
- [x] `user@github.io` accepted via PSL effective TLD (`test_psl_accepts_psl_effective_tld`)
- [x] Bare URL \`\"visit example.com today\"\` detected (`test_find_urls_bare_in_prose`)
- [x] \`\"Read https://example.com it's great\"\` extracts just the URL — no trailing prose (`test_find_urls_does_not_over_match`)
- [x] `jdbc://foo` still detected via `is_url` regex path (`test_is_url`)
- [x] Opt-out (`--no-default-features --features console,full,derive`) preserves today's behavior (`test_is_url_no_bare_host`)

Plus regressions covered: case-insensitive domain (`User@Example.COM`), IP-literal email (`user@[10.0.0.1]`), prose tokens (`map.contains`, `3.5.2`, `foo.notatld`).

**Local verification:**

- ✅ 2700/2700 identifier tests pass (`just test-mod "identifiers::"`)
- ✅ 22/22 affected tests pass under `--no-default-features --features console,full,derive`
- ✅ Full 6943-test sweep under nextest `ci` profile — all green (1 unrelated flake `test_cache_cleanup` passed on retry)
- ✅ `just clippy`, `just fmt-check`, `just arch-check`, `just test-docs`

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)