### PR TITLE
feat(identifiers): Turkey pack — TCKN (NVI mod-10) + License Plate

### DIFF
--- a/crates/octarine/src/identifiers/builder/government/mod.rs
+++ b/crates/octarine/src/identifiers/builder/government/mod.rs
@@ -51,6 +51,7 @@ mod ssn;
 mod tax_id;
 mod test_patterns;
 mod thailand;
+mod turkey;
 mod uk;
 mod vehicle_id;
 

--- a/crates/octarine/src/identifiers/builder/government/turkey.rs
+++ b/crates/octarine/src/identifiers/builder/government/turkey.rs
@@ -1,0 +1,120 @@
+//! Turkey TCKN + license plate methods.
+
+use super::*;
+
+impl GovernmentBuilder {
+    /// Check if value matches Turkey TCKN format (bare or labeled)
+    #[must_use]
+    pub fn is_turkey_tckn(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_turkey_tckn(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Turkey TCKNs in text (label-anchored)
+    #[must_use]
+    pub fn find_turkey_tckns_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_turkey_tckns_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+                increment_by(metric_names::government_data_found(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate Turkey TCKN format (without checksum)
+    pub fn validate_turkey_tckn(&self, tckn: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_turkey_tckn(tckn);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "turkey_tckn_validation_failed",
+                    "Invalid Turkey TCKN format",
+                );
+            }
+        }
+        result
+    }
+
+    /// Validate Turkey TCKN with NVI mod-10 dual-check-digit verification
+    pub fn validate_turkey_tckn_with_checksum(&self, tckn: &str) -> Result<(), Problem> {
+        self.inner.validate_turkey_tckn_with_checksum(tckn)
+    }
+
+    /// Check if value matches Turkey license plate format
+    #[must_use]
+    pub fn is_turkey_license_plate(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_turkey_license_plate(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Turkey license plates in text
+    #[must_use]
+    pub fn find_turkey_license_plates_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_turkey_license_plates_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+                increment_by(metric_names::government_data_found(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate Turkey license plate format
+    pub fn validate_turkey_license_plate(&self, plate: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_turkey_license_plate(plate);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "turkey_license_plate_validation_failed",
+                    "Invalid Turkey license plate format",
+                );
+            }
+        }
+        result
+    }
+}

--- a/crates/octarine/src/identifiers/shortcuts/government.rs
+++ b/crates/octarine/src/identifiers/shortcuts/government.rs
@@ -428,6 +428,61 @@ pub fn validate_uk_driving_licence(licence: &str) -> Result<(), Problem> {
     GovernmentBuilder::new().validate_uk_driving_licence(licence)
 }
 
+// ============================================================================
+// Turkey
+// ============================================================================
+
+/// Check if value is a Turkey TCKN (T.C. Kimlik Numarası)
+#[must_use]
+pub fn is_turkey_tckn(value: &str) -> bool {
+    GovernmentBuilder::new().is_turkey_tckn(value)
+}
+
+/// Find all Turkey TCKNs in text (label-anchored only)
+#[must_use]
+pub fn find_turkey_tckns(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_turkey_tckns_in_text(text)
+}
+
+/// Validate a Turkey TCKN format
+///
+/// # Errors
+///
+/// Returns `Problem` if the format is invalid.
+pub fn validate_turkey_tckn(tckn: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_turkey_tckn(tckn)
+}
+
+/// Validate a Turkey TCKN with NVI mod-10 dual-check-digit verification
+///
+/// # Errors
+///
+/// Returns `Problem` if the format or either check digit is invalid.
+pub fn validate_turkey_tckn_with_checksum(tckn: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_turkey_tckn_with_checksum(tckn)
+}
+
+/// Check if value is a Turkey license plate
+#[must_use]
+pub fn is_turkey_license_plate(value: &str) -> bool {
+    GovernmentBuilder::new().is_turkey_license_plate(value)
+}
+
+/// Find all Turkey license plates in text
+#[must_use]
+pub fn find_turkey_license_plates(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_turkey_license_plates_in_text(text)
+}
+
+/// Validate a Turkey license plate format
+///
+/// # Errors
+///
+/// Returns `Problem` if the format is invalid.
+pub fn validate_turkey_license_plate(plate: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_turkey_license_plate(plate)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
@@ -551,5 +606,29 @@ mod tests {
         assert!(validate_uk_driving_licence("99999753116AB1XY").is_err());
         // Text scanning requires label
         assert!(!find_uk_driving_licences("DVLA MORGA753116SM9IJ").is_empty());
+    }
+
+    #[test]
+    fn test_turkey_tckn_shortcuts() {
+        // Bare 11-digit shape passes the format check
+        assert!(is_turkey_tckn("12345678901"));
+        // Leading zero rejected at pattern level
+        assert!(!is_turkey_tckn("01234567890"));
+        assert!(validate_turkey_tckn("12345678901").is_ok());
+        assert!(validate_turkey_tckn("").is_err());
+        // All-same rejected
+        assert!(validate_turkey_tckn("11111111111").is_err());
+        // Text scanning requires a label — bare digits collide with phones
+        assert!(!find_turkey_tckns("TCKN: 12345678901").is_empty());
+        assert!(find_turkey_tckns("12345678901").is_empty());
+    }
+
+    #[test]
+    fn test_turkey_license_plate_shortcuts() {
+        assert!(is_turkey_license_plate("34 ABC 123"));
+        assert!(!is_turkey_license_plate("82 ABC 123")); // province out of range
+        assert!(validate_turkey_license_plate("34 ABC 123").is_ok());
+        assert!(validate_turkey_license_plate("34 QBC 123").is_err()); // reserved letter
+        assert!(!find_turkey_license_plates("Plaka: 34 ABC 123").is_empty());
     }
 }

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -190,6 +190,8 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             | PiiType::NigeriaBvn
             | PiiType::NigeriaVehicleReg
             | PiiType::ThailandTnin
+            | PiiType::TurkeyTckn
+            | PiiType::TurkeyLicensePlate
             | PiiType::SingaporeNric
             | PiiType::SingaporeUen
             | PiiType::FinlandHetu

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -198,6 +198,14 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
             PiiType::ThailandTnin,
         ),
         (
+            GovernmentIdentifierBuilder::find_turkey_tckns_in_text,
+            PiiType::TurkeyTckn,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_turkey_license_plates_in_text,
+            PiiType::TurkeyLicensePlate,
+        ),
+        (
             GovernmentIdentifierBuilder::find_singapore_nrics_in_text,
             PiiType::SingaporeNric,
         ),

--- a/crates/octarine/src/observe/pii/types/classification.rs
+++ b/crates/octarine/src/observe/pii/types/classification.rs
@@ -25,6 +25,7 @@ impl PiiType {
             Self::AustraliaTfn | Self::AustraliaAbn | Self::IndiaAadhaar | Self::IndiaPan |
             Self::IndiaGstin | Self::IndiaVehicleReg | Self::IndiaVoterId | Self::IndiaPassport |
             Self::BrazilCpf | Self::BrazilCnpj | Self::MexicoCurp | Self::NigeriaNin | Self::NigeriaBvn | Self::NigeriaVehicleReg | Self::ThailandTnin |
+            Self::TurkeyTckn | Self::TurkeyLicensePlate |
             Self::SingaporeNric | Self::FinlandHetu | Self::PolandPesel | Self::ItalyFiscalCode |
             Self::ItalyVat | Self::ItalyPassport | Self::ItalyIdentityCard | Self::ItalyDriverLicense |
             Self::SpainNif | Self::SpainNie | Self::UkNi |

--- a/crates/octarine/src/observe/pii/types/core.rs
+++ b/crates/octarine/src/observe/pii/types/core.rs
@@ -53,6 +53,8 @@ impl PiiType {
             Self::NigeriaBvn => "nigeria_bvn",
             Self::NigeriaVehicleReg => "nigeria_vehicle_reg",
             Self::ThailandTnin => "thailand_tnin",
+            Self::TurkeyTckn => "turkey_tckn",
+            Self::TurkeyLicensePlate => "turkey_license_plate",
             Self::SingaporeNric => "singapore_nric",
             Self::SingaporeUen => "singapore_uen",
             Self::FinlandHetu => "finland_hetu",
@@ -205,6 +207,8 @@ impl PiiType {
             | Self::NigeriaBvn
             | Self::NigeriaVehicleReg
             | Self::ThailandTnin
+            | Self::TurkeyTckn
+            | Self::TurkeyLicensePlate
             | Self::SingaporeNric
             | Self::SingaporeUen
             | Self::FinlandHetu

--- a/crates/octarine/src/observe/pii/types/mapping.rs
+++ b/crates/octarine/src/observe/pii/types/mapping.rs
@@ -100,6 +100,8 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::NigeriaBvn => Self::NigeriaBvn,
             IdentifierType::NigeriaVehicleReg => Self::NigeriaVehicleReg,
             IdentifierType::ThailandTnin => Self::ThailandTnin,
+            IdentifierType::TurkeyTckn => Self::TurkeyTckn,
+            IdentifierType::TurkeyLicensePlate => Self::TurkeyLicensePlate,
             IdentifierType::SingaporeNric => Self::SingaporeNric,
             IdentifierType::SingaporeUen => Self::SingaporeUen,
             IdentifierType::FinlandHetu => Self::FinlandHetu,

--- a/crates/octarine/src/observe/pii/types/mod.rs
+++ b/crates/octarine/src/observe/pii/types/mod.rs
@@ -137,6 +137,10 @@ pub enum PiiType {
     NigeriaVehicleReg,
     /// Thai National Identification Number (TNIN, mod-11 check digit)
     ThailandTnin,
+    /// Turkey TCKN (T.C. Kimlik Numarası, 11 digits, NVI mod-10 dual check)
+    TurkeyTckn,
+    /// Turkey license plate (province 01-81 + 1-3 letters + 2-4 digits)
+    TurkeyLicensePlate,
     /// Singapore NRIC / FIN
     SingaporeNric,
     /// Singapore Unique Entity Number (UEN, 3 layout variants, opaque check letter)

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -44,8 +44,8 @@ pub(crate) use personal::{
     italy_identity_card, italy_passport, italy_vat, korea_brn, korea_driver_license, korea_frn,
     korea_passport, korea_rrn, mexico_curp, national_id, nigeria_bvn, nigeria_nin,
     nigeria_vehicle_reg, passport, personal_name, poland_pesel, singapore_nric, singapore_uen,
-    spain_nie, spain_nif, ssn, student_id, tax_id, thailand_tnin, uk_driving_licence, uk_nhs,
-    uk_ni, uk_passport,
+    spain_nie, spain_nif, ssn, student_id, tax_id, thailand_tnin, turkey_license_plate,
+    turkey_tckn, uk_driving_licence, uk_nhs, uk_ni, uk_passport,
 };
 
 // medical, biometric, location, and vehicle modules are already accessible via pub mod declarations

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
@@ -40,6 +40,7 @@ pub(crate) use regional_identifiers::{
     birthdate, brazil_cnpj, brazil_cpf, finland_hetu, italy_driver_license, italy_fiscal_code,
     italy_identity_card, italy_passport, italy_vat, mexico_curp, nigeria_bvn, nigeria_nin,
     nigeria_vehicle_reg, personal_name, poland_pesel, singapore_nric, singapore_uen, spain_nie,
-    spain_nif, thailand_tnin, uk_driving_licence, uk_nhs, uk_ni, uk_passport,
+    spain_nif, thailand_tnin, turkey_license_plate, turkey_tckn, uk_driving_licence, uk_nhs, uk_ni,
+    uk_passport,
 };
 pub(crate) use us_identifiers::{driver_license, employee_id, passport, ssn, student_id, tax_id};

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
@@ -1,10 +1,14 @@
 //! Regional personal identifier patterns (Latin America, Africa, Europe, etc.)
 //!
 //! Brazil (CPF, CNPJ), Mexico (CURP), Nigeria (NIN), Thailand (TNIN),
-//! Singapore (NRIC), Finland (HETU), UK NI, Spain (NIF, NIE),
-//! Italy (codice fiscale), Poland (PESEL), plus generic personal names and
-//! birthdate patterns.
+//! Turkey (TCKN, License Plate), Singapore (NRIC), Finland (HETU), UK NI,
+//! Spain (NIF, NIE), Italy (codice fiscale), Poland (PESEL), plus generic
+//! personal names and birthdate patterns.
 
+// arch-check: allow file-length — country-specific regex registry that grows
+// by ~30 LOC per identifier. A follow-up should split into regional submodules
+// (europe/americas/apac) but the per-country pattern blocks should stay
+// adjacent for ease of comparison.
 #![allow(clippy::expect_used)]
 // SAFETY: All regex patterns in this module are hardcoded and verified at compile time.
 // Regex::new() only fails on invalid syntax, which would be caught during development/testing.
@@ -206,6 +210,68 @@ pub(crate) mod thailand_tnin {
     /// formatted or labeled occurrences are scanned.
     pub fn all() -> Vec<&'static Regex> {
         vec![&*LABELED, &*FORMATTED]
+    }
+}
+
+/// Turkey TCKN (T.C. Kimlik Numarası, National ID) patterns
+///
+/// Format: 11 digits, first digit non-zero. Mod-10 dual-check-digit (NVI).
+/// Bare 11-digit form collides with phone numbers, so text scanning uses
+/// `labeled_only()`.
+pub(crate) mod turkey_tckn {
+    use super::*;
+
+    /// Bare 11-digit form with non-zero leading digit
+    pub static STANDARD: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\b[1-9]\d{10}\b").expect("BUG: Invalid regex pattern"));
+
+    /// TCKN with explicit label
+    ///
+    /// Accepts: `TCKN`, `TC Kimlik No`, `T.C. Kimlik`, `Türk Kimlik`,
+    /// `Nüfus Cüzdanı`. Case-insensitive.
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:TCKN|TC[\s\-]?Kimlik(?:[\s\-]?No)?|T\.?C\.?[\s\-]?Kimlik|T[üu]rk[\s\-]?Kimlik|N[üu]fus[\s\-]?C[üu]zdan[ıi])[\s:#\-]*([1-9]\d{10})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
+    }
+
+    /// Label-anchored only — used by text scanners; bare `\d{11}` collides
+    /// with phone numbers and other identifiers.
+    pub fn labeled_only() -> Vec<&'static Regex> {
+        vec![&*LABELED]
+    }
+}
+
+/// Turkey License Plate patterns
+///
+/// Format: province code (01-81) + 1-3 letters from `[A-PR-VY-Z]` (Q/W/X
+/// excluded) + 2-4 digits. Optional spaces or hyphens between groups.
+/// Example: `34 ABC 123` (Istanbul = province 34).
+pub(crate) mod turkey_license_plate {
+    use super::*;
+
+    /// Standard plate format. Province bounds and letter class are tight
+    /// enough to scan without a label.
+    pub static STANDARD: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b(?:0[1-9]|[1-7][0-9]|8[01])[\s\-]?[A-PR-VY-Z]{1,3}[\s\-]?\d{2,4}\b")
+            .expect("BUG: Invalid regex pattern")
+    });
+
+    /// Plate with explicit Turkish label (`plaka`)
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\bplaka[\s:#\-]*((?:0[1-9]|[1-7][0-9]|8[01])[\s\-]?[A-PR-VY-Z]{1,3}[\s\-]?\d{2,4})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
     }
 }
 

--- a/crates/octarine/src/primitives/identifiers/government/builder/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/mod.rs
@@ -69,6 +69,7 @@ mod ssn;
 mod tax_id;
 mod test_patterns;
 mod thailand;
+mod turkey;
 mod uk;
 mod vehicle_id;
 

--- a/crates/octarine/src/primitives/identifiers/government/builder/turkey.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/turkey.rs
@@ -1,0 +1,62 @@
+//! Turkey TCKN + license plate operations on `GovernmentIdentifierBuilder`.
+
+use super::*;
+
+impl GovernmentIdentifierBuilder {
+    /// Check if value matches Turkey TCKN format
+    #[must_use]
+    pub fn is_turkey_tckn(&self, value: &str) -> bool {
+        detection::is_turkey_tckn(value)
+    }
+
+    /// Find all Turkey TCKNs in text (label-anchored only)
+    #[must_use]
+    pub fn find_turkey_tckns_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_turkey_tckns_in_text(text)
+    }
+
+    /// Validate Turkey TCKN format (without checksum)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the TCKN format is invalid
+    pub fn validate_turkey_tckn(&self, tckn: &str) -> Result<(), Problem> {
+        validation::validate_turkey_tckn(tckn)
+    }
+
+    /// Validate Turkey TCKN with NVI mod-10 dual-check-digit verification
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the TCKN format or either check digit is invalid
+    pub fn validate_turkey_tckn_with_checksum(&self, tckn: &str) -> Result<(), Problem> {
+        validation::validate_turkey_tckn_with_checksum(tckn)
+    }
+
+    /// Check if a Turkey TCKN is a test/dummy pattern (all-same-digit)
+    #[must_use]
+    pub fn is_test_turkey_tckn(&self, tckn: &str) -> bool {
+        validation::is_test_turkey_tckn(tckn)
+    }
+
+    /// Check if value matches Turkey license plate format
+    #[must_use]
+    pub fn is_turkey_license_plate(&self, value: &str) -> bool {
+        detection::is_turkey_license_plate(value)
+    }
+
+    /// Find all Turkey license plates in text
+    #[must_use]
+    pub fn find_turkey_license_plates_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_turkey_license_plates_in_text(text)
+    }
+
+    /// Validate Turkey license plate format
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the plate format is invalid
+    pub fn validate_turkey_license_plate(&self, plate: &str) -> Result<(), Problem> {
+        validation::validate_turkey_license_plate(plate)
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
@@ -62,6 +62,7 @@ mod singapore;
 mod ssn;
 mod tax_id;
 mod thailand;
+mod turkey;
 mod vehicle_id;
 
 pub use australia::{
@@ -107,6 +108,10 @@ pub use singapore::{
 pub use ssn::{find_ssns_in_text, is_ssn};
 pub use tax_id::{find_eins_in_text, find_tax_ids_in_text, is_ein, is_tax_id};
 pub use thailand::{find_thailand_tnins_in_text, is_thailand_tnin};
+pub use turkey::{
+    find_turkey_license_plates_in_text, find_turkey_tckns_in_text, is_turkey_license_plate,
+    is_turkey_tckn,
+};
 pub use vehicle_id::{find_vehicle_ids_in_text, is_vehicle_id};
 
 /// Detect which type of government identifier a value is
@@ -172,6 +177,10 @@ pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
         Some(IdentifierType::MexicoCurp)
     } else if is_thailand_tnin(value) {
         Some(IdentifierType::ThailandTnin)
+    } else if is_turkey_tckn(value) {
+        Some(IdentifierType::TurkeyTckn)
+    } else if is_turkey_license_plate(value) {
+        Some(IdentifierType::TurkeyLicensePlate)
     } else if is_nigeria_vehicle_registration(value) {
         Some(IdentifierType::NigeriaVehicleReg)
     } else if is_nigeria_nin(value) {
@@ -261,6 +270,8 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
     all_matches.extend(find_nigeria_bvns_in_text(text));
     all_matches.extend(find_nigeria_vehicle_registrations_in_text(text));
     all_matches.extend(find_thailand_tnins_in_text(text));
+    all_matches.extend(find_turkey_tckns_in_text(text));
+    all_matches.extend(find_turkey_license_plates_in_text(text));
     all_matches.extend(find_singapore_nrics_in_text(text));
     all_matches.extend(find_singapore_uens_in_text(text));
     all_matches.extend(find_finland_hetus_in_text(text));

--- a/crates/octarine/src/primitives/identifiers/government/detection/turkey.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/turkey.rs
@@ -1,0 +1,167 @@
+//! Turkey identifier detection — TCKN (T.C. Kimlik Numarası) and license plate.
+//!
+//! Detection functions are pattern-based (shape-only). For checksum
+//! verification of TCKN, use
+//! [`super::super::validation::validate_turkey_tckn_with_checksum`].
+
+use super::super::super::common::patterns;
+use super::super::super::types::{IdentifierMatch, IdentifierType};
+use super::helpers::{
+    MAX_IDENTIFIER_LENGTH, MAX_INPUT_LENGTH, deduplicate_matches, exceeds_safe_length,
+    get_full_match,
+};
+
+/// Check if a value matches Turkey TCKN format (bare or labeled)
+///
+/// Format-only check (11 digits, leading non-zero). Use
+/// [`super::super::validation::validate_turkey_tckn_with_checksum`] for
+/// NVI mod-10 verification.
+#[must_use]
+pub fn is_turkey_tckn(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    patterns::turkey_tckn::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Turkey TCKN patterns in text
+///
+/// Label-anchored only — a bare 11-digit run collides with phone numbers
+/// (Turkish mobile/landline are also 11 digits with international code),
+/// so text scanning requires context.
+#[must_use]
+pub fn find_turkey_tckns_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::turkey_tckn::labeled_only() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::TurkeyTckn,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+/// Check if a value matches Turkey license plate format
+///
+/// Format: `<province 01-81>[\s\-]?<1-3 letters from A-PR-VY-Z>[\s\-]?<2-4 digits>`.
+#[must_use]
+pub fn is_turkey_license_plate(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    patterns::turkey_license_plate::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Turkey license plate patterns in text
+#[must_use]
+pub fn find_turkey_license_plates_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::turkey_license_plate::all() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::TurkeyLicensePlate,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_turkey_tckn_bare_eleven_digits_accepted() {
+        assert!(is_turkey_tckn("12345678901"));
+    }
+
+    #[test]
+    fn test_is_turkey_tckn_leading_zero_rejected_by_pattern() {
+        assert!(!is_turkey_tckn("01234567890"));
+    }
+
+    #[test]
+    fn test_is_turkey_tckn_wrong_length_rejected() {
+        assert!(!is_turkey_tckn("1234567890")); // 10
+        assert!(!is_turkey_tckn("123456789012")); // 12
+    }
+
+    #[test]
+    fn test_is_turkey_tckn_labeled_form() {
+        assert!(is_turkey_tckn("TCKN: 12345678901"));
+        assert!(is_turkey_tckn("TC Kimlik No 12345678901"));
+    }
+
+    #[test]
+    fn test_find_turkey_tckns_label_required() {
+        let bare = find_turkey_tckns_in_text("Some random text 12345678901 in the middle.");
+        assert!(
+            bare.is_empty(),
+            "bare 11-digit string must not match without a label"
+        );
+
+        let labeled = find_turkey_tckns_in_text("Customer TCKN: 12345678901.");
+        assert_eq!(labeled.len(), 1);
+    }
+
+    #[test]
+    fn test_find_turkey_tckns_multiple() {
+        let text = "Two records: TCKN 12345678901 and Türk Kimlik 98765432109.";
+        let found = find_turkey_tckns_in_text(text);
+        assert_eq!(found.len(), 2);
+    }
+
+    #[test]
+    fn test_is_turkey_license_plate_valid_forms() {
+        assert!(is_turkey_license_plate("34 ABC 123"));
+        assert!(is_turkey_license_plate("34ABC123"));
+        assert!(is_turkey_license_plate("06 A 12"));
+        assert!(is_turkey_license_plate("81 ZZ 99"));
+    }
+
+    #[test]
+    fn test_is_turkey_license_plate_rejects_invalid() {
+        // Province out of range
+        assert!(!is_turkey_license_plate("82 ABC 123"));
+        // Reserved letter Q
+        assert!(!is_turkey_license_plate("34 QBC 123"));
+    }
+
+    #[test]
+    fn test_find_turkey_license_plates_in_text() {
+        let labeled = find_turkey_license_plates_in_text("Plaka: 34 ABC 123 — Istanbul.");
+        assert!(!labeled.is_empty());
+
+        let bare = find_turkey_license_plates_in_text("Vehicle 34 ABC 123 stopped at the light.");
+        assert!(
+            !bare.is_empty(),
+            "STANDARD pattern matches province-bounded shape"
+        );
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
@@ -58,6 +58,7 @@ mod singapore;
 mod spain;
 mod ssn;
 mod thailand;
+mod turkey;
 mod uk;
 mod vin;
 
@@ -163,6 +164,12 @@ pub use nigeria::{
 // Re-export Thailand functions
 pub use thailand::{
     is_test_thailand_tnin, validate_thailand_tnin, validate_thailand_tnin_with_checksum,
+};
+
+// Re-export Turkey functions
+pub use turkey::{
+    is_test_turkey_tckn, validate_turkey_license_plate, validate_turkey_tckn,
+    validate_turkey_tckn_with_checksum,
 };
 
 // Re-export UK functions

--- a/crates/octarine/src/primitives/identifiers/government/validation/turkey.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/turkey.rs
@@ -1,0 +1,417 @@
+//! Turkey identifier validation — TCKN (T.C. Kimlik Numarası) and license plate.
+//!
+//! # TCKN — Turkish National ID
+//!
+//! Format: 11 digits. First digit must not be `0`.
+//!
+//! NVI mod-10 dual-check-digit algorithm:
+//! - Digit 10 = `(((d1+d3+d5+d7+d9) * 7) - (d2+d4+d6+d8)) mod 10`
+//! - Digit 11 = `(d1 + d2 + … + d10) mod 10`
+//!
+//! # License plate
+//!
+//! Format: `<province 01-81><1-3 letters from A-PR-VY-Z><2-4 digits>`, with
+//! optional spaces or hyphens between groups. Letters `Q`, `W`, `X` are
+//! reserved and not assigned. Example: `34 ABC 123` (Istanbul = 34).
+
+use crate::primitives::types::Problem;
+
+/// Validate Turkey TCKN format (without checksum)
+///
+/// Checks: 11 digits, leading digit non-zero, not all identical digits.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format is invalid.
+pub fn validate_turkey_tckn(value: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation("TCKN cannot be empty".to_string()));
+    }
+
+    for ch in trimmed.chars() {
+        if !ch.is_ascii_digit() && !matches!(ch, '-' | ' ' | '\t') {
+            return Err(Problem::Validation(format!(
+                "invalid character '{ch}' in TCKN"
+            )));
+        }
+    }
+
+    let digits: Vec<u8> = trimmed
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+
+    if digits.len() != 11 {
+        return Err(Problem::Validation(format!(
+            "TCKN must be 11 digits, got {}",
+            digits.len()
+        )));
+    }
+
+    if digits.first().copied() == Some(0) {
+        return Err(Problem::Validation(
+            "TCKN first digit cannot be 0".to_string(),
+        ));
+    }
+
+    if all_same_digit(&digits) {
+        return Err(Problem::Validation(
+            "TCKN cannot have all identical digits".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate Turkey TCKN with NVI mod-10 dual-check-digit verification
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format or either check digit fails.
+pub fn validate_turkey_tckn_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_turkey_tckn(value)?;
+
+    let digits: Vec<u8> = value
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+
+    let (computed_10, computed_11) = compute_tckn_check_digits(digits.get(..9).unwrap_or(&[]));
+    let actual_10 = digits.get(9).copied().unwrap_or(99);
+    let actual_11 = digits.get(10).copied().unwrap_or(99);
+
+    if computed_10 != actual_10 {
+        return Err(Problem::Validation(format!(
+            "TCKN 10th check digit mismatch: expected {computed_10}, got {actual_10}"
+        )));
+    }
+
+    if computed_11 != actual_11 {
+        return Err(Problem::Validation(format!(
+            "TCKN 11th check digit mismatch: expected {computed_11}, got {actual_11}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Check if a TCKN is a test/dummy pattern (all-same-digit). Used to skip
+/// generated placeholders in fixtures and audit logs.
+#[must_use]
+pub fn is_test_turkey_tckn(value: &str) -> bool {
+    let digits: Vec<u8> = value
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+    digits.len() == 11 && all_same_digit(&digits)
+}
+
+/// Validate Turkey license plate format
+///
+/// Format: `<province 01-81>[\s\-]?<1-3 letters from A-PR-VY-Z>[\s\-]?<2-4 digits>`.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format is invalid.
+pub fn validate_turkey_license_plate(value: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation(
+            "license plate cannot be empty".to_string(),
+        ));
+    }
+
+    let upper = trimmed.to_ascii_uppercase();
+    let compact: String = upper
+        .chars()
+        .filter(|c| !matches!(c, ' ' | '\t' | '-'))
+        .collect();
+
+    let bytes = compact.as_bytes();
+    if bytes.len() < 5 || bytes.len() > 10 {
+        return Err(Problem::Validation(format!(
+            "license plate must be 5-10 chars (excluding separators), got {}",
+            bytes.len()
+        )));
+    }
+
+    // First two chars: province digits.
+    let province_digits = compact.get(..2).unwrap_or("");
+    let province: u32 = province_digits
+        .parse()
+        .map_err(|_| Problem::Validation("license plate must start with 2 digits".to_string()))?;
+    if !(1..=81).contains(&province) {
+        return Err(Problem::Validation(format!(
+            "license plate province must be 01-81, got {province:02}"
+        )));
+    }
+
+    // Middle: 1-3 letters from valid class. Then 2-4 trailing digits.
+    let rest = compact.get(2..).unwrap_or("");
+    let letter_count = rest.chars().take_while(|c| c.is_ascii_alphabetic()).count();
+    if !(1..=3).contains(&letter_count) {
+        return Err(Problem::Validation(format!(
+            "license plate must have 1-3 letters after province, got {letter_count}"
+        )));
+    }
+
+    let letters = rest.get(..letter_count).unwrap_or("");
+    for ch in letters.chars() {
+        if matches!(ch, 'Q' | 'W' | 'X') {
+            return Err(Problem::Validation(format!(
+                "license plate letter '{ch}' is reserved (Q/W/X not assigned)"
+            )));
+        }
+        if !ch.is_ascii_uppercase() {
+            return Err(Problem::Validation(format!(
+                "license plate letter '{ch}' must be A-Z"
+            )));
+        }
+    }
+
+    let trailing = rest.get(letter_count..).unwrap_or("");
+    if !(2..=4).contains(&trailing.len()) {
+        return Err(Problem::Validation(format!(
+            "license plate must end with 2-4 digits, got {}",
+            trailing.len()
+        )));
+    }
+    if !trailing.chars().all(|c| c.is_ascii_digit()) {
+        return Err(Problem::Validation(
+            "license plate trailing group must be digits".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn all_same_digit(digits: &[u8]) -> bool {
+    digits
+        .first()
+        .is_some_and(|&first| digits.iter().all(|&d| d == first))
+}
+
+/// Compute the TCKN 10th and 11th check digits from the first 9 digits.
+///
+/// Algorithm (NVI):
+/// - `d10 = (((d1+d3+d5+d7+d9) * 7) - (d2+d4+d6+d8)) mod 10`
+/// - `d11 = (d1 + d2 + … + d10) mod 10`
+fn compute_tckn_check_digits(first_9: &[u8]) -> (u8, u8) {
+    if first_9.len() != 9 {
+        return (99, 99);
+    }
+
+    let mut odd_sum: u32 = 0; // d1, d3, d5, d7, d9 (1-indexed odd)
+    let mut even_sum: u32 = 0; // d2, d4, d6, d8 (1-indexed even)
+    for (i, &d) in first_9.iter().enumerate() {
+        // 0-indexed: i=0 is d1 (odd), i=1 is d2 (even)
+        if i.checked_rem(2).unwrap_or(0) == 0 {
+            odd_sum = odd_sum.saturating_add(u32::from(d));
+        } else {
+            even_sum = even_sum.saturating_add(u32::from(d));
+        }
+    }
+
+    let weighted = odd_sum.saturating_mul(7);
+    // Use modular arithmetic to avoid underflow: (weighted - even_sum) mod 10.
+    // Add 10 * even_sum to keep the dividend non-negative (10 is the modulus).
+    let dividend = weighted.saturating_add(even_sum.saturating_mul(9));
+    let d10 = u8::try_from(dividend.checked_rem(10).unwrap_or(0)).unwrap_or(0);
+
+    // d11 = (d1 + d2 + … + d10) mod 10
+    let first_9_sum: u32 = first_9.iter().map(|&d| u32::from(d)).sum();
+    let total = first_9_sum.saturating_add(u32::from(d10));
+    let d11 = u8::try_from(total.checked_rem(10).unwrap_or(0)).unwrap_or(0);
+
+    (d10, d11)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn make_valid_tckn(first_9: &str) -> String {
+        let digits: Vec<u8> = first_9
+            .chars()
+            .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+            .collect();
+        assert_eq!(digits.len(), 9, "make_valid_tckn needs 9 digits");
+        assert!(digits.first().copied() != Some(0), "first digit non-zero");
+        let (d10, d11) = compute_tckn_check_digits(&digits);
+        let mut all = digits.clone();
+        all.push(d10);
+        all.push(d11);
+        all.iter()
+            .map(|d| char::from_digit(u32::from(*d), 10).unwrap_or('0'))
+            .collect()
+    }
+
+    // ===== TCKN format tests =====
+
+    #[test]
+    fn test_validate_tckn_valid_unformatted() {
+        let tckn = make_valid_tckn("123456789");
+        assert!(validate_turkey_tckn(&tckn).is_ok());
+    }
+
+    #[test]
+    fn test_validate_tckn_rejects_wrong_length() {
+        assert!(validate_turkey_tckn("1234567890").is_err()); // 10
+        assert!(validate_turkey_tckn("123456789012").is_err()); // 12
+    }
+
+    #[test]
+    fn test_validate_tckn_rejects_empty() {
+        assert!(validate_turkey_tckn("").is_err());
+    }
+
+    #[test]
+    fn test_validate_tckn_rejects_letters() {
+        assert!(validate_turkey_tckn("1234567890a").is_err());
+    }
+
+    #[test]
+    fn test_validate_tckn_rejects_leading_zero() {
+        // 11 digits starting with 0 — must reject regardless of checksum
+        assert!(validate_turkey_tckn("01234567890").is_err());
+    }
+
+    #[test]
+    fn test_validate_tckn_rejects_all_same() {
+        assert!(validate_turkey_tckn("11111111111").is_err());
+    }
+
+    // ===== TCKN checksum tests =====
+
+    #[test]
+    fn test_validate_tckn_with_checksum_generated() {
+        let tckn = make_valid_tckn("123456789");
+        assert!(
+            validate_turkey_tckn_with_checksum(&tckn).is_ok(),
+            "Generated TCKN {tckn} should validate"
+        );
+    }
+
+    #[test]
+    fn test_validate_tckn_with_checksum_tampered_last() {
+        let tckn = make_valid_tckn("123456789");
+        let mut chars: Vec<char> = tckn.chars().collect();
+        if let Some(c) = chars.last_mut() {
+            *c = if *c == '0' { '1' } else { '0' };
+        }
+        let tampered: String = chars.into_iter().collect();
+        assert!(validate_turkey_tckn_with_checksum(&tampered).is_err());
+    }
+
+    #[test]
+    fn test_validate_tckn_with_checksum_tampered_tenth() {
+        let tckn = make_valid_tckn("123456789");
+        let mut chars: Vec<char> = tckn.chars().collect();
+        if let Some(c) = chars.get_mut(9) {
+            *c = if *c == '0' { '1' } else { '0' };
+        }
+        let tampered: String = chars.into_iter().collect();
+        assert!(validate_turkey_tckn_with_checksum(&tampered).is_err());
+    }
+
+    #[test]
+    fn test_validate_tckn_with_checksum_multiple_seeds() {
+        for seed in &["123456789", "987654321", "111222333"] {
+            let tckn = make_valid_tckn(seed);
+            assert!(
+                validate_turkey_tckn_with_checksum(&tckn).is_ok(),
+                "Generated TCKN {tckn} from seed {seed} should validate"
+            );
+        }
+    }
+
+    // ===== Test-pattern tests =====
+
+    #[test]
+    fn test_is_test_turkey_tckn_all_same() {
+        assert!(is_test_turkey_tckn("11111111111"));
+        assert!(is_test_turkey_tckn("00000000000"));
+    }
+
+    #[test]
+    fn test_is_test_turkey_tckn_rejects_real() {
+        let tckn = make_valid_tckn("123456789");
+        assert!(!is_test_turkey_tckn(&tckn));
+    }
+
+    #[test]
+    fn test_is_test_turkey_tckn_rejects_wrong_length() {
+        assert!(!is_test_turkey_tckn("111"));
+    }
+
+    // ===== License plate tests =====
+
+    #[test]
+    fn test_validate_plate_valid_spaced() {
+        assert!(validate_turkey_license_plate("34 ABC 123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_plate_valid_compact() {
+        assert!(validate_turkey_license_plate("34ABC123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_plate_valid_short_letters() {
+        assert!(validate_turkey_license_plate("06 A 12").is_ok());
+        assert!(validate_turkey_license_plate("81 ZZ 99").is_ok());
+    }
+
+    #[test]
+    fn test_validate_plate_valid_long_digits() {
+        assert!(validate_turkey_license_plate("34 ABC 1234").is_ok());
+    }
+
+    #[test]
+    fn test_validate_plate_rejects_province_zero() {
+        assert!(validate_turkey_license_plate("00 ABC 123").is_err());
+    }
+
+    #[test]
+    fn test_validate_plate_rejects_province_too_high() {
+        assert!(validate_turkey_license_plate("82 ABC 123").is_err());
+        assert!(validate_turkey_license_plate("99 ABC 123").is_err());
+    }
+
+    #[test]
+    fn test_validate_plate_rejects_reserved_letters() {
+        assert!(validate_turkey_license_plate("34 QBC 123").is_err());
+        assert!(validate_turkey_license_plate("34 WBC 123").is_err());
+        assert!(validate_turkey_license_plate("34 XBC 123").is_err());
+    }
+
+    #[test]
+    fn test_validate_plate_rejects_too_few_digits() {
+        assert!(validate_turkey_license_plate("34 ABC 1").is_err());
+    }
+
+    #[test]
+    fn test_validate_plate_rejects_too_many_digits() {
+        assert!(validate_turkey_license_plate("34 ABC 12345").is_err());
+    }
+
+    #[test]
+    fn test_validate_plate_rejects_too_many_letters() {
+        assert!(validate_turkey_license_plate("34 ABCD 123").is_err());
+    }
+
+    #[test]
+    fn test_validate_plate_rejects_empty() {
+        assert!(validate_turkey_license_plate("").is_err());
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -90,6 +90,8 @@ pub enum IdentifierType {
     NigeriaBvn,         // Nigerian Bank Verification Number (11 digits, no public checksum)
     NigeriaVehicleReg,  // Nigerian vehicle registration (XXX-NNN-XX current, AA999-AAA legacy)
     ThailandTnin,       // Thai National Identification Number (13 digits, mod-11 check)
+    TurkeyTckn,         // Turkey TCKN (T.C. Kimlik Numarası, 11 digits, NVI mod-10 dual check)
+    TurkeyLicensePlate, // Turkey license plate (province 01-81 + 1-3 letters + 2-4 digits)
     SingaporeNric,      // Singapore NRIC/FIN
     SingaporeUen,       // Singapore Unique Entity Number (3 layout variants, opaque check letter)
     FinlandHetu,        // Finnish personal identity code

--- a/docs/presidio-gap-analysis.md
+++ b/docs/presidio-gap-analysis.md
@@ -132,6 +132,14 @@ Each gap includes the source domain report reference. Severity rule: blocks a Pr
 
 ### CRIT-13. Turkey missing entirely — TR_NATIONAL_ID + TR_LICENSE_PLATE
 
+- **Status**: ✅ Closed in #434. `TurkeyTckn` (NVI mod-10 dual check) and
+  `TurkeyLicensePlate` (province 01-81 + `[A-PR-VY-Z]` letter class)
+  implemented in `primitives/identifiers/government/{detection,validation,
+  builder}/turkey.rs`, wired through the Layer 3 `GovernmentBuilder`,
+  shortcut module, PII bridge (`PiiType::TurkeyTckn`,
+  `PiiType::TurkeyLicensePlate`), and `scan_government()`. Classification:
+  `is_high_risk = true`; not `is_gdpr_protected` (Turkey is governed by
+  KVKK, not GDPR).
 - **Presidio**: `TrNationalIdRecognizer` (11-digit NVI mod-10: `10th digit = (odd_sum * 7 - even_sum) % 10`, `11th = sum of first 10 mod 10`). `TR_LICENSE_PLATE` (province codes 01-81, letters `[A-PR-VY-Z]` excluding Q/W/X). Turkish context: `tc kimlik, kimlik no, tckn, nüfus cüzdanı, türk kimlik, plaka`.
 - **Octarine**: No `TurkeyTckn` identifier, no `validation/turkey.rs`, no patterns.
 - **Impact**: Turkey's KVKK (Kişisel Verilerin Korunması Kanunu, Law 6698) is the local GDPR. TCKN is the most-cited personal identifier in KVKK enforcement actions. Cannot serve Turkish customers.


### PR DESCRIPTION
## Summary

Closes Presidio gap-analysis CRIT-13: adds the two Turkish identifiers that have been missing entirely.

- **TurkeyTckn** — T.C. Kimlik Numarası, 11 digits with NVI mod-10 dual-check-digit
  - Digit 10 = `(((d1+d3+d5+d7+d9) * 7) - (d2+d4+d6+d8)) mod 10`
  - Digit 11 = `(d1 + d2 + … + d10) mod 10`
- **TurkeyLicensePlate** — province (01-81) + 1-3 letters from `[A-PR-VY-Z]` (Q/W/X reserved) + 2-4 digits

Mirrors the existing `ThailandTnin` template across primitives detection/validation/builder, Layer 3 builder with observe metrics, public shortcuts, and the full PII bridge (`PiiType`, `From` mapping, classification, redactor, scanner). Classified as `is_high_risk = true` only — Turkey is governed by KVKK (Law 6698), not GDPR.

### Notable choices

- **TCKN text scanning is label-anchored** (`TCKN`, `TC Kimlik`, `Türk Kimlik`, `Nüfus Cüzdanı`) because a bare 11-digit string collides with Turkish phone numbers. `is_turkey_tckn` still accepts the bare form for direct queries (matches the UK NHS labeled-only split).
- **Plate STANDARD regex is province-bounded** (`(?:0[1-9]|[1-7][0-9]|8[01])`), tight enough to scan without a label.
- **Checksum math uses saturating arithmetic** (`saturating_add`/`mul`, `checked_rem`) per the workspace's `arithmetic_side_effects = deny` lint.
- `regional_identifiers.rs` crossed 800 LOC after the additions — added an `arch-check: allow file-length` justification (matches the precedent in `gazetteer.rs`); the file is a country-by-country regex registry that grows ~30 LOC per identifier and should be split into regional submodules in a follow-up.

## Test plan

- [x] 16 new unit tests in `validation/turkey.rs` (TCKN format + checksum + tampering, plate province bounds, letter class, digit count)
- [x] 9 new unit tests in `detection/turkey.rs` (bare/labeled forms, label requirement for text scanning, multi-match)
- [x] 2 new shortcut tests in `identifiers/shortcuts/government.rs`
- [x] `just check`, `just clippy`, `just arch-check` all green
- [x] Full PII+identifiers test suite (3120 tests) passes

## Pre-review findings

- 2x `missing-test-file` (HIGH): `primitives/identifiers/government/builder/turkey.rs`, `identifiers/builder/government/turkey.rs` — these are pure delegation shims (no business logic); the wrapped behavior is exercised by `validation/turkey.rs` and `detection/turkey.rs` tests, and the Layer 3 metric-emission path is covered indirectly by the shortcut tests that call `GovernmentBuilder::new()`. Matches the convention used by the existing UK / Italy / Korea Layer 3 builder files.

Closes #434