### PR TITLE
fix(identifiers): US ITIN — strict IRS middle-group rule + reject 9xx as SSN

### DIFF
--- a/crates/octarine/src/identifiers/builder/government/tax_id.rs
+++ b/crates/octarine/src/identifiers/builder/government/tax_id.rs
@@ -75,4 +75,29 @@ impl GovernmentBuilder {
     pub fn sanitize_ein(&self, ein: &str) -> Result<String, Problem> {
         self.inner.sanitize_ein(ein)
     }
+
+    /// Check if value is a valid ITIN (Individual Taxpayer Identification Number)
+    ///
+    /// Strict — requires `XXX-XX-XXXX` layout, area `9XX`, and a middle group
+    /// in `{50-65, 70-88, 90-92, 94-99}` per IRS Publication 1915.
+    #[must_use]
+    pub fn is_itin(&self, value: &str) -> bool {
+        self.inner.is_itin(value)
+    }
+
+    /// Find all valid ITINs in text
+    #[must_use]
+    pub fn find_itins_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        self.inner.find_itins_in_text(text)
+    }
+
+    /// Validate ITIN format
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the ITIN format, area, middle group, or serial
+    /// is invalid.
+    pub fn validate_itin(&self, itin: &str) -> Result<(), Problem> {
+        self.inner.validate_itin(itin)
+    }
 }

--- a/crates/octarine/src/identifiers/shortcuts/government.rs
+++ b/crates/octarine/src/identifiers/shortcuts/government.rs
@@ -63,6 +63,35 @@ pub fn validate_ein(ein: &str) -> Result<(), Problem> {
 }
 
 // =============================================================================
+// US ITIN (Individual Taxpayer Identification Number)
+// =============================================================================
+
+/// Check if value is a valid ITIN (Individual Taxpayer Identification Number)
+///
+/// Strict — area must be `9XX` and the middle group must lie in
+/// `{50-65, 70-88, 90-92, 94-99}` per IRS Publication 1915.
+#[must_use]
+pub fn is_itin(value: &str) -> bool {
+    GovernmentBuilder::new().is_itin(value)
+}
+
+/// Find all valid ITINs in text
+#[must_use]
+pub fn find_itins(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_itins_in_text(text)
+}
+
+/// Validate an ITIN format
+///
+/// # Errors
+///
+/// Returns `Problem` if the ITIN format, area, middle group, or serial is
+/// invalid.
+pub fn validate_itin(itin: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_itin(itin)
+}
+
+// =============================================================================
 // Singapore UEN
 // =============================================================================
 

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -166,6 +166,7 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             PiiType::Passport => redact_passports(&result, profile),
             PiiType::Vin
             | PiiType::Ein
+            | PiiType::Itin
             | PiiType::TaxId
             | PiiType::NationalId
             | PiiType::KoreaRrn
@@ -310,7 +311,7 @@ mod tests {
 
     #[test]
     fn test_redact_ssn_strict() {
-        let text = "SSN: 900-00-0001";
+        let text = "SSN: 517-29-8346";
         let result = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
         // ProductionStrict uses Complete::Token strategy → [SSN]
         assert_eq!(result, "SSN: [SSN]");
@@ -381,7 +382,7 @@ mod tests {
 
     #[test]
     fn test_redact_multiple_pii() {
-        let text = "Contact: user@example.com, SSN: 900-00-0001, Card: 4242424242424242";
+        let text = "Contact: user@example.com, SSN: 517-29-8346, Card: 4242424242424242";
         let result = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
         // ProductionStrict uses Complete::Token strategy
         assert!(result.contains("[EMAIL]"));
@@ -398,14 +399,14 @@ mod tests {
 
     #[test]
     fn test_redact_testing_profile() {
-        let text = "SSN: 900-00-0001, Email: user@example.com";
+        let text = "SSN: 517-29-8346, Email: user@example.com";
         let result = redact_pii_with_profile(text, RedactionProfile::Testing);
         assert_eq!(result, text); // No redaction in testing mode
     }
 
     #[test]
     fn test_scan_and_redact() {
-        let text = "Email: user@example.com, SSN: 900-00-0001";
+        let text = "Email: user@example.com, SSN: 517-29-8346";
         let result = scan_and_redact(text, RedactionProfile::ProductionStrict);
 
         assert!(result.contains_pii);
@@ -446,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_multiple_ssns_in_line() {
-        let text = "SSN1: 900-00-0001, SSN2: 900-00-0002, SSN3: 900-00-0003";
+        let text = "SSN1: 517-29-8346, SSN2: 517-29-8347, SSN3: 517-29-8348";
         let result = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
         // All SSNs should be redacted
         let ssn_count = result.matches("[SSN]").count();
@@ -534,7 +535,7 @@ mod tests {
     #[test]
     fn test_partial_redaction_lenient() {
         // Test that ProductionLenient shows partial data
-        let text = "SSN: 900-00-0001";
+        let text = "SSN: 517-29-8346";
         let result = redact_pii_with_profile(text, RedactionProfile::ProductionLenient);
         // Should show last digits in lenient mode
         assert!(result.contains("0001") || result.contains("***"));

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -98,6 +98,10 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
         ),
         (GovernmentIdentifierBuilder::find_eins_in_text, PiiType::Ein),
         (
+            GovernmentIdentifierBuilder::find_itins_in_text,
+            PiiType::Itin,
+        ),
+        (
             GovernmentIdentifierBuilder::find_tax_ids_in_text,
             PiiType::TaxId,
         ),

--- a/crates/octarine/src/observe/pii/scanner/mod.rs
+++ b/crates/octarine/src/observe/pii/scanner/mod.rs
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn test_scan_for_pii_ssn() {
-        let text = "SSN: 900-00-0001"; // 900 series is test data
+        let text = "SSN: 517-29-8346";
         let types = scan_for_pii(text);
         assert!(types.contains(&PiiType::Ssn));
     }
@@ -351,7 +351,7 @@ mod tests {
 
     #[test]
     fn test_scan_for_pii_multiple() {
-        let text = "Email: user@example.com, SSN: 900-00-0001, Card: 4242424242424242";
+        let text = "Email: user@example.com, SSN: 517-29-8346, Card: 4242424242424242";
         let types = scan_for_pii(text);
         assert!(
             types.len() >= 3,
@@ -375,7 +375,7 @@ mod tests {
 
     #[test]
     fn test_is_pii_present_true() {
-        assert!(is_pii_present("SSN: 900-00-0001"));
+        assert!(is_pii_present("SSN: 517-29-8346"));
         assert!(is_pii_present("user@example.com"));
         assert!(is_pii_present("4242424242424242"));
     }

--- a/crates/octarine/src/observe/pii/types/classification.rs
+++ b/crates/octarine/src/observe/pii/types/classification.rs
@@ -20,7 +20,7 @@ impl PiiType {
             Self::CreditCard | Self::BankAccount | Self::RoutingNumber | Self::PaymentToken |
             Self::Iban | Self::CryptoAddress |
             // Government (identity theft risk)
-            Self::Ssn | Self::DriverLicense | Self::Passport | Self::Ein | Self::TaxId | Self::NationalId | Self::Vin |
+            Self::Ssn | Self::DriverLicense | Self::Passport | Self::Ein | Self::Itin | Self::TaxId | Self::NationalId | Self::Vin |
             Self::KoreaRrn | Self::KoreaFrn | Self::KoreaDriverLicense | Self::KoreaPassport | Self::KoreaBrn |
             Self::AustraliaTfn | Self::AustraliaAbn | Self::IndiaAadhaar | Self::IndiaPan |
             Self::IndiaGstin | Self::IndiaVehicleReg | Self::IndiaVoterId | Self::IndiaPassport |
@@ -113,6 +113,7 @@ impl PiiType {
                 | Self::PrescriptionNumber
                 | Self::DeaNumber
                 | Self::Ssn // SSN is also PHI in medical context
+                | Self::Itin // ITIN is also PHI in medical context (IRS-issued tax ID for patients)
                 | Self::Name // Names in medical context
                 | Self::Birthdate // DOB in medical context
                 | Self::Age // Age in medical context — HIPAA Safe Harbor requires aggregating > 89

--- a/crates/octarine/src/observe/pii/types/core.rs
+++ b/crates/octarine/src/observe/pii/types/core.rs
@@ -29,6 +29,7 @@ impl PiiType {
             Self::Passport => "passport",
             Self::Vin => "vin",
             Self::Ein => "ein",
+            Self::Itin => "itin",
             Self::TaxId => "tax_id",
             Self::NationalId => "national_id",
             Self::KoreaRrn => "korea_rrn",
@@ -183,6 +184,7 @@ impl PiiType {
             | Self::Passport
             | Self::Vin
             | Self::Ein
+            | Self::Itin
             | Self::TaxId
             | Self::NationalId
             | Self::KoreaRrn

--- a/crates/octarine/src/observe/pii/types/mapping.rs
+++ b/crates/octarine/src/observe/pii/types/mapping.rs
@@ -76,6 +76,7 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::DriverLicense => Self::DriverLicense,
             IdentifierType::Passport => Self::Passport,
             IdentifierType::Ein => Self::Ein,
+            IdentifierType::Itin => Self::Itin,
             IdentifierType::TaxId => Self::TaxId,
             IdentifierType::NationalId => Self::NationalId,
             IdentifierType::KoreaRrn => Self::KoreaRrn,

--- a/crates/octarine/src/observe/pii/types/mod.rs
+++ b/crates/octarine/src/observe/pii/types/mod.rs
@@ -89,6 +89,8 @@ pub enum PiiType {
     Vin,
     /// Employer Identification Number
     Ein,
+    /// US Individual Taxpayer Identification Number (area 9XX, IRS middle group 50-65/70-88/90-92/94-99)
+    Itin,
     /// Tax ID (generic)
     TaxId,
     /// National ID number (non-US government identifiers)

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/us_identifiers.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/us_identifiers.rs
@@ -62,10 +62,37 @@ pub(crate) mod tax_id {
     pub static EIN_FORMAT: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"\b\d{2}-\d{7}\b").expect("BUG: Invalid regex pattern"));
 
-    /// ITIN (starts with 9)
-    /// Example: "912-34-5678"
+    /// ITIN — loose 9XX-XX-XXXX shape (kept for SSN-vs-tax-ID bucketing in
+    /// `tax_id` detection). Does NOT enforce the IRS middle-group rule and so
+    /// will match non-ITIN 9XX strings. Use [`ITIN_FORMAT_STRICT`] for
+    /// identification as `IdentifierType::Itin`.
+    /// Example: "912-34-5678" (matches even though group 34 is not a valid IRS middle group)
     pub static ITIN_FORMAT: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"\b9\d{2}-?\d{2}-?\d{4}\b").expect("BUG: Invalid regex pattern"));
+
+    /// ITIN — strict IRS layout. Area `9XX`, middle group in `{50-65, 70-88,
+    /// 90-92, 94-99}`. Per IRS Publication 1915 and 26 CFR §301.6109-1.
+    /// Example: "900-70-0001" (valid), "912-34-5678" (group 34 — does NOT match)
+    pub static ITIN_FORMAT_STRICT: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b9\d{2}-?(?:5[0-9]|6[0-5]|7[0-9]|8[0-8]|9[02]|9[4-9])-?\d{4}\b")
+            .expect("BUG: Invalid regex pattern")
+    });
+
+    /// ITIN — strict exact-match (no surrounding text). For validators.
+    pub static ITIN_FORMAT_STRICT_EXACT: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"^9\d{2}-?(?:5[0-9]|6[0-5]|7[0-9]|8[0-8]|9[02]|9[4-9])-?\d{4}$")
+            .expect("BUG: Invalid regex pattern")
+    });
+
+    /// ITIN with explicit label (highest confidence)
+    /// Captures: prefix (label) + number
+    /// Example: "ITIN: 900-70-0001" → groups: ("ITIN: ", "900-70-0001")
+    pub static ITIN_LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(\b(?:ITIN|Individual[\s-]?Taxpayer[\s-]?Identification[\s-]?Number)[\s#:-]+)(9\d{2}-?(?:5[0-9]|6[0-5]|7[0-9]|8[0-8]|9[02]|9[4-9])-?\d{4})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
 
     /// Generic TIN with prefix
     pub static GENERIC_TIN: Lazy<Regex> = Lazy::new(|| {

--- a/crates/octarine/src/primitives/identifiers/government/builder/aggregate.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/aggregate.rs
@@ -39,14 +39,14 @@ impl GovernmentIdentifierBuilder {
     ///
     /// // Complete - use type tokens like [SSN], [VEHICLE_ID]
     /// let result = builder.redact_all_in_text_with_policy(
-    ///     "SSN: 900-00-0001",
+    ///     "SSN: 517-29-8346",
     ///     TextRedactionPolicy::Complete,
     /// );
     /// assert!(result.contains("[SSN]"));
     ///
     /// // Partial - shows last 4 digits for SSN
     /// let result = builder.redact_all_in_text_with_policy(
-    ///     "SSN: 900-00-0001",
+    ///     "SSN: 517-29-8346",
     ///     TextRedactionPolicy::Partial,
     /// );
     /// assert!(result.contains("***-**-0001"));
@@ -75,11 +75,11 @@ mod tests {
         let gov = builder();
 
         // Detection
-        assert!(gov.is_government_identifier("900-00-0001"));
-        assert!(gov.is_government_present("SSN: 900-00-0001"));
+        assert!(gov.is_government_identifier("517-29-8346"));
+        assert!(gov.is_government_present("SSN: 517-29-8346"));
 
         // Redaction with policy
-        let text = "SSN: 900-00-0001, VIN: 1HGBH41JXMN109186";
+        let text = "SSN: 517-29-8346, VIN: 1HGBH41JXMN109186";
         let redacted = gov.redact_all_in_text_with_policy(text, TextRedactionPolicy::Complete);
         assert!(redacted.contains("[SSN]"));
         assert!(redacted.contains("[VEHICLE_ID]"));

--- a/crates/octarine/src/primitives/identifiers/government/builder/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/mod.rs
@@ -25,14 +25,14 @@
 //! let gov = builder.government();
 //!
 //! // Detection
-//! let is_ssn = gov.is_ssn("900-00-0001");
-//! let matches = gov.find_ssns_in_text("SSN: 900-00-0001");
+//! let is_ssn = gov.is_ssn("517-29-8346");
+//! let matches = gov.find_ssns_in_text("SSN: 517-29-8346");
 //!
 //! // Validation
-//! let valid = gov.validate_ssn("234-56-7890");
+//! let valid = gov.validate_ssn("517-29-8346");
 //!
 //! // Sanitization (with explicit strategy)
-//! let redacted = gov.redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::Token);
+//! let redacted = gov.redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::Token);
 //!
 //! // Conversion
 //! let normalized = gov.normalize_ssn("900 00 0001");

--- a/crates/octarine/src/primitives/identifiers/government/builder/ssn.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/ssn.rs
@@ -40,7 +40,7 @@ impl GovernmentIdentifierBuilder {
     /// };
     ///
     /// let builder = GovernmentIdentifierBuilder::new();
-    /// let result = builder.redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::Token);
+    /// let result = builder.redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::Token);
     /// assert_eq!(result, "[SSN]");
     /// ```
     #[must_use]
@@ -59,7 +59,7 @@ impl GovernmentIdentifierBuilder {
     ///
     /// let builder = GovernmentIdentifierBuilder::new();
     /// let result = builder.redact_ssns_in_text_with_strategy(
-    ///     "SSN: 900-00-0001",
+    ///     "SSN: 517-29-8346",
     ///     SsnRedactionStrategy::LastFour,
     /// );
     /// assert!(result.contains("***-**-0001"));

--- a/crates/octarine/src/primitives/identifiers/government/builder/tax_id.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/tax_id.rs
@@ -89,6 +89,36 @@ impl GovernmentIdentifierBuilder {
     pub fn sanitize_ein(&self, ein: &str) -> Result<String, Problem> {
         sanitization::sanitize_ein_strict(ein)
     }
+
+    /// Check if value is a valid ITIN (Individual Taxpayer Identification Number)
+    ///
+    /// Strict — requires `XXX-XX-XXXX` layout, area `9XX`, and a middle group
+    /// in `{50-65, 70-88, 90-92, 94-99}` per IRS Publication 1915. Use
+    /// [`is_tax_id`](Self::is_tax_id) for the broader superset check.
+    #[must_use]
+    pub fn is_itin(&self, value: &str) -> bool {
+        detection::is_itin(value)
+    }
+
+    /// Find all valid ITINs in text
+    ///
+    /// Returns `Itin`-tagged matches that pass the full IRS rule. Values with
+    /// the right shape but an invalid middle group are not returned here —
+    /// `find_tax_ids_in_text` will still surface them as `TaxId`.
+    #[must_use]
+    pub fn find_itins_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_itins_in_text(text)
+    }
+
+    /// Validate ITIN format
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the ITIN format, area, middle group, or serial
+    /// is invalid.
+    pub fn validate_itin(&self, itin: &str) -> Result<(), Problem> {
+        validation::validate_itin(itin)
+    }
 }
 
 #[cfg(test)]

--- a/crates/octarine/src/primitives/identifiers/government/detection/itin.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/itin.rs
@@ -1,0 +1,172 @@
+//! US Individual Taxpayer Identification Number (ITIN) detection.
+//!
+//! - `is_itin` is strict — requires `XXX-XX-XXXX` shape **and** valid IRS
+//!   middle group (delegates to `validation::validate_itin`).
+//! - `find_itins_in_text` scans for strict-shaped candidates and tags
+//!   matches as `IdentifierType::Itin`. The same value may also appear in
+//!   `find_tax_ids_in_text` results — ITINs are a subset of tax IDs.
+
+use super::super::super::common::patterns;
+use super::super::super::types::{DetectionConfidence, IdentifierMatch, IdentifierType};
+use super::helpers::{MAX_INPUT_LENGTH, deduplicate_matches, exceeds_safe_length, get_full_match};
+
+/// Check if a value is a valid ITIN (Individual Taxpayer Identification Number)
+///
+/// Strict: requires `XXX-XX-XXXX` or `XXXXXXXXX` layout, area `9XX`, and a
+/// middle group in `{50-65, 70-88, 90-92, 94-99}` per IRS Publication 1915.
+#[must_use]
+pub fn is_itin(value: &str) -> bool {
+    super::super::validation::validate_itin(value).is_ok()
+}
+
+/// Find all valid ITIN patterns in text
+///
+/// Scans for the strict ITIN regex (`ITIN_FORMAT_STRICT` and `ITIN_LABELED`)
+/// and then runs each candidate through `is_itin` to enforce the full IRS
+/// rule. Matches are tagged `IdentifierType::Itin`.
+///
+/// Labeled matches get `High` confidence; bare strict-shape matches get
+/// `Medium` because raw `9XX-XX-XXXX` strings overlap with arbitrary
+/// numeric identifiers.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::detection;
+///
+/// let text = "ITIN: 900-70-0001";
+/// let matches = detection::find_itins_in_text(text);
+/// assert_eq!(matches.len(), 1);
+/// ```
+#[must_use]
+pub fn find_itins_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    // Labeled first (High confidence)
+    for capture in patterns::tax_id::ITIN_LABELED.captures_iter(text) {
+        let full_match = get_full_match(&capture);
+        let matched_text = full_match.as_str();
+        // The capture's group 2 is the ITIN body without the label
+        let number = capture.get(2).map_or("", |m| m.as_str());
+        if !is_itin(number) {
+            continue;
+        }
+        matches.push(IdentifierMatch::high_confidence(
+            full_match.start(),
+            full_match.end(),
+            matched_text.to_string(),
+            IdentifierType::Itin,
+        ));
+    }
+
+    // Bare strict-shape candidates (Medium confidence)
+    for capture in patterns::tax_id::ITIN_FORMAT_STRICT.captures_iter(text) {
+        let full_match = get_full_match(&capture);
+        let matched_text = full_match.as_str();
+        if !is_itin(matched_text) {
+            continue;
+        }
+        matches.push(IdentifierMatch::new(
+            full_match.start(),
+            full_match.end(),
+            matched_text.to_string(),
+            IdentifierType::Itin,
+            DetectionConfidence::Medium,
+        ));
+    }
+
+    deduplicate_matches(matches)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_is_itin_accepts_valid() {
+        assert!(is_itin("900-70-0001"));
+        assert!(is_itin("999-88-1234"));
+        assert!(is_itin("900-50-0001"));
+        // Bare digits accepted
+        assert!(is_itin("900700001"));
+    }
+
+    #[test]
+    fn test_is_itin_rejects_gap_groups() {
+        assert!(!is_itin("912-34-5678")); // group 34 invalid
+        assert!(!is_itin("987-12-3456")); // group 12 invalid
+        assert!(!is_itin("900-01-0001")); // group 01 invalid
+        assert!(!is_itin("900-66-0001")); // gap between 65/70
+        assert!(!is_itin("900-89-0001")); // gap between 88/90
+        assert!(!is_itin("900-93-0001")); // gap between 92/94
+    }
+
+    #[test]
+    fn test_is_itin_rejects_non_itin_area() {
+        assert!(!is_itin("123-70-0001")); // SSN area
+        assert!(!is_itin("517-70-0001")); // SSN area
+        assert!(!is_itin("899-70-0001")); // just below ITIN
+    }
+
+    #[test]
+    fn test_find_itins_in_text_labeled() {
+        let text = "ITIN: 900-70-0001 on the form";
+        let matches = find_itins_in_text(text);
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("Should detect labeled ITIN");
+        assert_eq!(first.identifier_type, IdentifierType::Itin);
+        assert_eq!(first.confidence, DetectionConfidence::High);
+    }
+
+    #[test]
+    fn test_find_itins_in_text_bare() {
+        let text = "Tax record 900-70-0001 attached";
+        let matches = find_itins_in_text(text);
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("Should detect bare ITIN");
+        assert_eq!(first.identifier_type, IdentifierType::Itin);
+        assert_eq!(first.confidence, DetectionConfidence::Medium);
+    }
+
+    #[test]
+    fn test_find_itins_in_text_skips_invalid_middle_group() {
+        // 912-34-5678 matches the loose ITIN_FORMAT but not ITIN_FORMAT_STRICT
+        let text = "Possibly an ITIN: 912-34-5678 in this text";
+        let matches = find_itins_in_text(text);
+        assert!(
+            matches.is_empty(),
+            "Invalid IRS middle group must not produce ITIN matches"
+        );
+    }
+
+    #[test]
+    fn test_find_itins_in_text_skips_ssn_area() {
+        // SSN-area values must never appear as ITIN matches even if the
+        // middle group happens to be in the ITIN range.
+        let text = "SSN: 123-70-0001 on file";
+        let matches = find_itins_in_text(text);
+        assert!(matches.is_empty(), "SSN-area values must not be ITIN");
+    }
+
+    #[test]
+    fn test_find_itins_in_text_multiple() {
+        let text = "Taxpayer 900-70-0001 also files as 999-88-1234";
+        let matches = find_itins_in_text(text);
+        assert_eq!(matches.len(), 2);
+        assert!(
+            matches
+                .iter()
+                .all(|m| m.identifier_type == IdentifierType::Itin)
+        );
+    }
+
+    #[test]
+    fn test_find_itins_in_text_empty() {
+        assert!(find_itins_in_text("").is_empty());
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
@@ -49,6 +49,7 @@ mod driver_license;
 mod europe;
 mod helpers;
 mod india;
+mod itin;
 mod korea_brn;
 mod korea_driver_license;
 mod korea_frn;
@@ -89,6 +90,7 @@ pub use india::{
     find_india_voter_ids_in_text, is_india_aadhaar, is_india_gstin, is_india_pan,
     is_india_passport, is_india_vehicle_registration, is_india_voter_id,
 };
+pub use itin::{find_itins_in_text, is_itin};
 pub use korea_brn::{find_korea_brns_in_text, is_korea_brn};
 pub use korea_driver_license::{find_korea_driver_licenses_in_text, is_korea_driver_license};
 pub use korea_frn::{find_korea_frns_in_text, is_korea_frn};
@@ -151,6 +153,8 @@ pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
         Some(IdentifierType::Ssn)
     } else if is_ein(value) {
         Some(IdentifierType::Ein)
+    } else if is_itin(value) {
+        Some(IdentifierType::Itin)
     } else if is_tax_id(value) {
         Some(IdentifierType::TaxId)
     } else if is_driver_license(value) {
@@ -245,6 +249,7 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
 
     all_matches.extend(find_ssns_in_text(text));
     all_matches.extend(find_eins_in_text(text));
+    all_matches.extend(find_itins_in_text(text));
     all_matches.extend(find_tax_ids_in_text(text));
     all_matches.extend(find_driver_licenses_in_text(text));
     all_matches.extend(find_passports_in_text(text));
@@ -393,7 +398,12 @@ mod tests {
             detect_government_identifier("00-0000001"),
             Some(IdentifierType::TaxId)
         );
-        // ITINs continue to be TaxId
+        // Valid ITINs route to Itin
+        assert_eq!(
+            detect_government_identifier("900-70-0001"),
+            Some(IdentifierType::Itin)
+        );
+        // 9XX-area values that fail the IRS middle-group rule fall through to TaxId
         assert_eq!(
             detect_government_identifier("912-34-5678"),
             Some(IdentifierType::TaxId)

--- a/crates/octarine/src/primitives/identifiers/government/detection/ssn.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/ssn.rs
@@ -9,6 +9,7 @@
 use super::super::super::common::patterns;
 use super::super::super::types::{DetectionConfidence, IdentifierMatch, IdentifierType};
 use super::super::common::{is_itin_area, is_test_ssn};
+use super::super::validation::validate_itin;
 use super::helpers::{MAX_INPUT_LENGTH, deduplicate_matches, exceeds_safe_length, get_full_match};
 
 /// Extract only ASCII digits from a string
@@ -134,13 +135,24 @@ pub fn find_ssns_in_text(text: &str) -> Vec<IdentifierMatch> {
             let full_match = get_full_match(&capture);
             let matched_text = full_match.as_str();
 
-            // Reclassify ITINs (area 900-999) as TaxId
+            // Reclassify ITINs (area 900-999). Values that satisfy the full
+            // IRS rule become `Itin`; values that only share the 9XX area but
+            // fail the middle-group constraint stay `TaxId` so they remain
+            // visible as PII without claiming to be an ITIN. We validate
+            // against the extracted digit string so labeled matches
+            // (e.g. "SSN: 900-70-1234") still route correctly.
             if is_itin_area(matched_text) {
+                let digits = extract_digits(matched_text);
+                let identifier_type = if validate_itin(&digits).is_ok() {
+                    IdentifierType::Itin
+                } else {
+                    IdentifierType::TaxId
+                };
                 matches.push(IdentifierMatch::high_confidence(
                     full_match.start(),
                     full_match.end(),
                     matched_text.to_string(),
-                    IdentifierType::TaxId,
+                    identifier_type,
                 ));
                 continue;
             }
@@ -259,18 +271,30 @@ mod tests {
 
     #[test]
     fn test_find_ssns_reclassifies_itin() {
+        // 900-70-1234 has valid ITIN middle group 70 → reclassified as `Itin`.
+        // 912-34-5678 has invalid middle group 34 → reclassified as `TaxId`
+        // (it shares the area but fails the IRS middle-group rule).
         let text = "ITIN holder SSN: 900-70-1234 and 912-34-5678";
         let matches = find_ssns_in_text(text);
-        // Both should be reclassified as TaxId
         assert!(
             matches
                 .iter()
-                .all(|m| m.identifier_type == IdentifierType::TaxId),
-            "900-999 area codes should be classified as TaxId, not Ssn"
+                .any(|m| m.identifier_type == IdentifierType::Itin
+                    && m.matched_text.contains("900-70-1234")),
+            "900-70-1234 should classify as Itin, got: {matches:?}"
         );
         assert!(
-            !matches.is_empty(),
-            "ITINs should still be detected as TaxId"
+            matches
+                .iter()
+                .any(|m| m.identifier_type == IdentifierType::TaxId
+                    && m.matched_text.contains("912-34-5678")),
+            "912-34-5678 should classify as TaxId (invalid ITIN middle group), got: {matches:?}"
+        );
+        assert!(
+            !matches
+                .iter()
+                .any(|m| m.identifier_type == IdentifierType::Ssn),
+            "9XX-area values must never be Ssn"
         );
     }
 }

--- a/crates/octarine/src/primitives/identifiers/government/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/mod.rs
@@ -37,14 +37,14 @@
 //! let gov = builder.government();
 //!
 //! // Detection
-//! let is_ssn = gov.is_ssn("900-00-0001");
-//! let ssns = gov.find_ssns_in_text("SSN: 900-00-0001");
+//! let is_ssn = gov.is_ssn("517-29-8346");
+//! let ssns = gov.find_ssns_in_text("SSN: 517-29-8346");
 //!
 //! // Validation
-//! let valid = gov.validate_ssn("234-56-7890");
+//! let valid = gov.validate_ssn("517-29-8346");
 //!
 //! // Sanitization
-//! let redacted = gov.redact_ssn("900-00-0001");
+//! let redacted = gov.redact_ssn("517-29-8346");
 //!
 //! // Conversion
 //! let normalized = gov.normalize_ssn("900 00 0001");

--- a/crates/octarine/src/primitives/identifiers/government/redaction.rs
+++ b/crates/octarine/src/primitives/identifiers/government/redaction.rs
@@ -50,7 +50,7 @@
 //!
 //! // Text scanning with generic policy
 //! let redacted = redact_all_government_ids_in_text_with_policy(
-//!     "SSN: 900-00-0001, VIN: 1HGBH41JXMN109186",
+//!     "SSN: 517-29-8346, VIN: 1HGBH41JXMN109186",
 //!     Some(TextRedactionPolicy::Complete)
 //! );
 //! // Result: "SSN: [SSN], VIN: [VEHICLE_ID]"

--- a/crates/octarine/src/primitives/identifiers/government/sanitization/ssn.rs
+++ b/crates/octarine/src/primitives/identifiers/government/sanitization/ssn.rs
@@ -19,7 +19,7 @@ use super::strategy::SsnRedactionStrategy;
 /// - `Anonymous` → `[Redacted]`
 /// - `LastFour` → `***-**-0001`
 /// - `FirstFive` → `900-00-****` (RISKY - leaks geographic area)
-/// - `Skip` → `900-00-0001` (no redaction)
+/// - `Skip` → `517-29-8346` (no redaction)
 ///
 /// # Security Considerations
 ///
@@ -35,15 +35,15 @@ use super::strategy::SsnRedactionStrategy;
 /// };
 ///
 /// // Complete token redaction
-/// let token = redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::Token);
+/// let token = redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::Token);
 /// assert_eq!(token, "[SSN]");
 ///
 /// // Partial redaction (last 4 - safer)
-/// let partial = redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::LastFour);
+/// let partial = redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::LastFour);
 /// assert_eq!(partial, "***-**-0001");
 ///
 /// // Complete masking
-/// let masked = redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::Mask);
+/// let masked = redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::Mask);
 /// assert_eq!(masked, "***-**-****");
 /// ```
 #[must_use]
@@ -112,13 +112,13 @@ mod tests {
     fn test_redact_ssn_with_strategies() {
         // Token
         assert_eq!(
-            redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::Token),
+            redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::Token),
             "[SSN]"
         );
 
         // Mask
         assert_eq!(
-            redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::Mask),
+            redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::Mask),
             "***-**-****"
         );
         assert_eq!(
@@ -132,14 +132,14 @@ mod tests {
 
         // Anonymous
         assert_eq!(
-            redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::Anonymous),
+            redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::Anonymous),
             "[Redacted]"
         );
 
         // LastFour
         assert_eq!(
-            redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::LastFour),
-            "***-**-0001"
+            redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::LastFour),
+            "***-**-8346"
         );
         assert_eq!(
             redact_ssn_with_strategy("900 00 0002", SsnRedactionStrategy::LastFour),
@@ -148,8 +148,8 @@ mod tests {
 
         // FirstFive (RISKY)
         assert_eq!(
-            redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::FirstFive),
-            "900-00-****"
+            redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::FirstFive),
+            "517-29-****"
         );
         assert_eq!(
             redact_ssn_with_strategy("900 00 0002", SsnRedactionStrategy::FirstFive),
@@ -164,8 +164,8 @@ mod tests {
 
         // Skip
         assert_eq!(
-            redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::Skip),
-            "900-00-0001"
+            redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::Skip),
+            "517-29-8346"
         );
     }
 
@@ -173,7 +173,7 @@ mod tests {
     fn test_multiple_formats() {
         // Dashed format
         assert_eq!(
-            redact_ssn_with_strategy("900-00-0001", SsnRedactionStrategy::Token),
+            redact_ssn_with_strategy("517-29-8346", SsnRedactionStrategy::Token),
             "[SSN]"
         );
 

--- a/crates/octarine/src/primitives/identifiers/government/sanitization/strict.rs
+++ b/crates/octarine/src/primitives/identifiers/government/sanitization/strict.rs
@@ -24,12 +24,12 @@ use super::super::{conversion, validation};
 /// use crate::primitives::identifiers::government::sanitization;
 ///
 /// // Valid SSN with spaces
-/// let sanitized = sanitization::sanitize_ssn_strict("900 00 0001")?;
-/// assert_eq!(sanitized, "900-00-0001");
+/// let sanitized = sanitization::sanitize_ssn_strict("234 56 7890")?;
+/// assert_eq!(sanitized, "517-29-8346");
 ///
 /// // Valid SSN already formatted
-/// let sanitized = sanitization::sanitize_ssn_strict("900-00-0001")?;
-/// assert_eq!(sanitized, "900-00-0001");
+/// let sanitized = sanitization::sanitize_ssn_strict("517-29-8346")?;
+/// assert_eq!(sanitized, "517-29-8346");
 ///
 /// // Invalid SSN (bad format)
 /// assert!(sanitization::sanitize_ssn_strict("123456789").is_err());

--- a/crates/octarine/src/primitives/identifiers/government/sanitization/text.rs
+++ b/crates/octarine/src/primitives/identifiers/government/sanitization/text.rs
@@ -29,7 +29,7 @@ use super::strategy::{
 ///     redact_ssns_in_text_with_strategy, SsnRedactionStrategy
 /// };
 ///
-/// let text = "Employee SSN: 900-00-0001";
+/// let text = "Employee SSN: 517-29-8346";
 ///
 /// // Complete token
 /// let safe = redact_ssns_in_text_with_strategy(text, SsnRedactionStrategy::Token);
@@ -37,7 +37,7 @@ use super::strategy::{
 ///
 /// // Partial last 4
 /// let partial = redact_ssns_in_text_with_strategy(text, SsnRedactionStrategy::LastFour);
-/// assert_eq!(partial, "Employee SSN: ***-**-0001");
+/// assert_eq!(partial, "Employee SSN: ***-**-8346");
 /// ```
 #[must_use]
 pub fn redact_ssns_in_text_with_strategy(
@@ -62,7 +62,7 @@ pub fn redact_ssns_in_text_with_strategy(
                     let redacted = redact_ssn_with_strategy(ssn, strategy);
 
                     if i == 0 {
-                        // Preserve label: "SSN: 900-00-0001" → "SSN: [SSN]"
+                        // Preserve label: "SSN: 517-29-8346" → "SSN: [SSN]"
                         let label = caps.get(1).map_or("", |m| m.as_str());
                         format!("{}{}", label, redacted)
                     } else {
@@ -472,7 +472,7 @@ pub fn redact_vehicle_ids_in_text_with_strategy(
 /// use crate::primitives::identifiers::government::sanitization;
 /// use crate::primitives::identifiers::government::redaction::TextRedactionPolicy;
 ///
-/// let text = "SSN: 900-00-0001, VIN: 1HGBH41JXMN109186";
+/// let text = "SSN: 517-29-8346, VIN: 1HGBH41JXMN109186";
 ///
 /// // Default (Complete)
 /// let safe = sanitization::redact_all_government_ids_in_text_with_policy(text, None);
@@ -483,7 +483,7 @@ pub fn redact_vehicle_ids_in_text_with_strategy(
 ///     text,
 ///     Some(TextRedactionPolicy::Partial)
 /// );
-/// assert!(partial.contains("***-**-0001")); // Last 4 visible
+/// assert!(partial.contains("***-**-8346")); // Last 4 visible
 /// ```
 #[must_use]
 pub fn redact_all_government_ids_in_text_with_policy(
@@ -532,23 +532,23 @@ mod tests {
 
     #[test]
     fn test_redact_ssns_in_text() {
-        let text = "Employee SSN: 900-00-0001";
+        let text = "Employee SSN: 517-29-8346";
         let result = redact_ssns_in_text_with_strategy(text, SsnRedactionStrategy::Token);
         assert_eq!(result, "Employee SSN: [SSN]");
     }
 
     #[test]
     fn test_redact_ssns_in_text_multiple() {
-        let text = "SSN: 900-00-0001 and SSN: 900-00-0002";
+        let text = "SSN: 517-29-8346 and SSN: 517-29-8347";
         let result = redact_ssns_in_text_with_strategy(text, SsnRedactionStrategy::Token);
         assert_eq!(result, "SSN: [SSN] and SSN: [SSN]");
     }
 
     #[test]
     fn test_redact_ssns_in_text_last_four() {
-        let text = "Employee SSN: 900-00-0001";
+        let text = "Employee SSN: 517-29-8346";
         let result = redact_ssns_in_text_with_strategy(text, SsnRedactionStrategy::LastFour);
-        assert_eq!(result, "Employee SSN: ***-**-0001");
+        assert_eq!(result, "Employee SSN: ***-**-8346");
     }
 
     // ========================================================================
@@ -619,7 +619,7 @@ mod tests {
     fn test_redact_all_government_ids() {
         use crate::primitives::identifiers::GovernmentTextPolicy;
 
-        let text = "SSN: 900-00-0001, VIN: 1HGBH41JXMN109186, EIN: 00-0000001";
+        let text = "SSN: 517-29-8346, VIN: 1HGBH41JXMN109186, EIN: 00-0000001";
         let result = redact_all_government_ids_in_text_with_policy(
             text,
             Some(GovernmentTextPolicy::Complete),
@@ -633,14 +633,14 @@ mod tests {
     fn test_redact_all_government_ids_with_policy() {
         use crate::primitives::identifiers::GovernmentTextPolicy;
 
-        let text = "SSN: 900-00-0001";
+        let text = "SSN: 517-29-8346";
 
         // Partial policy shows last 4
         let partial = redact_all_government_ids_in_text_with_policy(
             text,
             Some(GovernmentTextPolicy::Partial),
         );
-        assert!(partial.contains("***-**-0001"));
+        assert!(partial.contains("***-**-8346"));
 
         // Skip policy returns original
         let none =
@@ -668,7 +668,7 @@ mod tests {
         assert!(matches!(result, Cow::Borrowed(_)));
 
         // Dirty text should return owned
-        let text = "SSN: 900-00-0001";
+        let text = "SSN: 517-29-8346";
         let result = redact_ssns_in_text_with_strategy(text, SsnRedactionStrategy::Token);
         assert!(matches!(result, Cow::Owned(_)));
     }

--- a/crates/octarine/src/primitives/identifiers/government/validation/itin.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/itin.rs
@@ -1,0 +1,238 @@
+//! US Individual Taxpayer Identification Number (ITIN) validation
+//!
+//! Pure validation functions for IRS-issued ITINs (26 CFR §301.6109-1).
+//!
+//! # ITIN Format
+//!
+//! ITINs share the SSN visual layout `XXX-XX-XXXX` but are distinguished by:
+//!
+//! - **Area**: always `9XX` (`900-999`)
+//! - **Middle group**: must be in `{50-65, 70-88, 90-92, 94-99}`
+//! - **Serial**: `0001-9999` (`0000` is reserved)
+//!
+//! The middle-group rule is the load-bearing constraint that separates a real
+//! ITIN from "any 9-digit number that starts with 9". Without it, arbitrary
+//! identifiers (sequence numbers, hashes) get misclassified.
+//!
+//! # Authoritative References
+//!
+//! - IRS Publication 1915 (Understanding Your IRS Individual Taxpayer
+//!   Identification Number)
+//! - 26 CFR §301.6109-1
+//! - Presidio `us_itin_recognizer.py` (cross-reference for the same rule)
+
+use crate::primitives::Problem;
+
+/// Check if an ITIN middle group is in the IRS-assigned range.
+///
+/// The IRS reserves three blocks within `00-99` for ITIN middle groups:
+/// `50-65`, `70-88`, `90-92`, `94-99`. Anything else is a non-ITIN value
+/// even if the area is `9XX`.
+#[must_use]
+pub fn is_valid_itin_group(group: u8) -> bool {
+    matches!(
+        group,
+        50..=65 | 70..=88 | 90..=92 | 94..=99
+    )
+}
+
+/// Validate an ITIN.
+///
+/// Enforces format, area, middle-group, and serial constraints. Returns
+/// `Ok(())` only for values the IRS could have assigned as an ITIN.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` for any of:
+///
+/// - Wrong digit count or non-`XXX-XX-XXXX`/`XXXXXXXXX` layout
+/// - Area outside `900-999`
+/// - Middle group outside `{50-65, 70-88, 90-92, 94-99}`
+/// - Serial `0000`
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::validation;
+///
+/// assert!(validation::validate_itin("900-70-0001").is_ok());
+/// assert!(validation::validate_itin("999-88-1234").is_ok());
+/// assert!(validation::validate_itin("912-34-5678").is_err()); // group 34 not in IRS range
+/// assert!(validation::validate_itin("899-70-0001").is_err()); // area not 9XX
+/// ```
+pub fn validate_itin(itin: &str) -> Result<(), Problem> {
+    let cleaned: String = itin.chars().filter(|c| c.is_ascii_digit()).collect();
+
+    if cleaned.len() != 9 {
+        return Err(Problem::Validation("ITIN must be 9 digits".into()));
+    }
+
+    // Reject layouts that aren't either bare 9 digits or XXX-XX-XXXX. Allowing
+    // arbitrary dash positions (e.g., 1-23-456789) would silently accept
+    // SSN/EIN shapes.
+    let bare_digits = itin.chars().all(|c| c.is_ascii_digit());
+    let dashed = {
+        let parts: Vec<&str> = itin.split('-').collect();
+        parts.len() == 3
+            && parts.first().is_some_and(|p| p.len() == 3)
+            && parts.get(1).is_some_and(|p| p.len() == 2)
+            && parts.get(2).is_some_and(|p| p.len() == 4)
+            && parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit()))
+    };
+    if !bare_digits && !dashed {
+        return Err(Problem::Validation(
+            "ITIN format must be XXX-XX-XXXX".into(),
+        ));
+    }
+
+    let area: u16 = cleaned[0..3]
+        .parse()
+        .map_err(|_| Problem::Validation("Invalid ITIN area".into()))?;
+    let group: u8 = cleaned[3..5]
+        .parse()
+        .map_err(|_| Problem::Validation("Invalid ITIN middle group".into()))?;
+    let serial = &cleaned[5..9];
+
+    if !(900..=999).contains(&area) {
+        return Err(Problem::Validation(format!(
+            "ITIN area must be 900-999, got {area}"
+        )));
+    }
+
+    if !is_valid_itin_group(group) {
+        return Err(Problem::Validation(format!(
+            "Invalid ITIN middle group: {group:02} (must be 50-65, 70-88, 90-92, or 94-99)"
+        )));
+    }
+
+    if serial == "0000" {
+        return Err(Problem::Validation("ITIN serial 0000 is reserved".into()));
+    }
+
+    Ok(())
+}
+
+/// Check if an ITIN is a known test/sample pattern.
+///
+/// IRS Publication 1915 does not publish ITIN test ranges (unlike Brookhaven's
+/// EIN examples), so this list is conservative: only repeated-digit and
+/// obviously synthetic strings are flagged.
+#[must_use]
+pub fn is_test_itin(itin: &str) -> bool {
+    let cleaned: String = itin.chars().filter(|c| c.is_ascii_digit()).collect();
+
+    if cleaned.len() != 9 || !cleaned.chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+
+    // All same digit (e.g., 999-99-9999) — flagged even though 9 in the middle
+    // group is valid, because real ITINs don't repeat.
+    if let Some(first) = cleaned.chars().next()
+        && cleaned.chars().all(|c| c == first)
+    {
+        return true;
+    }
+
+    // Documentation placeholders observed in Presidio test fixtures.
+    let test_itins = ["999991234"];
+    test_itins.contains(&cleaned.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_validate_itin_accepts_valid_middle_groups() {
+        // One sample from each IRS block
+        assert!(validate_itin("900-50-0001").is_ok()); // start of 50-65
+        assert!(validate_itin("900-65-0001").is_ok()); // end of 50-65
+        assert!(validate_itin("900-70-0001").is_ok()); // start of 70-88
+        assert!(validate_itin("900-88-0001").is_ok()); // end of 70-88
+        assert!(validate_itin("900-90-0001").is_ok()); // start of 90-92
+        assert!(validate_itin("900-92-0001").is_ok()); // end of 90-92
+        assert!(validate_itin("900-94-0001").is_ok()); // start of 94-99
+        assert!(validate_itin("900-99-0001").is_ok()); // end of 94-99
+    }
+
+    #[test]
+    fn test_validate_itin_rejects_gap_middle_groups() {
+        // Gaps between IRS-assigned ranges
+        assert!(validate_itin("900-01-0001").is_err()); // before 50
+        assert!(validate_itin("900-49-0001").is_err()); // just before 50
+        assert!(validate_itin("900-66-0001").is_err()); // gap between 65 and 70
+        assert!(validate_itin("900-69-0001").is_err()); // gap between 65 and 70
+        assert!(validate_itin("900-89-0001").is_err()); // gap between 88 and 90
+        assert!(validate_itin("900-93-0001").is_err()); // gap between 92 and 94
+    }
+
+    #[test]
+    fn test_validate_itin_rejects_non_itin_area() {
+        // Area must be 900-999
+        assert!(validate_itin("123-70-0001").is_err()); // SSN range
+        assert!(validate_itin("517-70-0001").is_err()); // SSN range
+        assert!(validate_itin("899-70-0001").is_err()); // just below ITIN
+    }
+
+    #[test]
+    fn test_validate_itin_rejects_serial_zero() {
+        assert!(validate_itin("900-70-0000").is_err());
+    }
+
+    #[test]
+    fn test_validate_itin_format_errors() {
+        // 9-digit bare format is accepted
+        assert!(validate_itin("900700001").is_ok());
+        // Wrong layout
+        assert!(validate_itin("12-345-6789").is_err());
+        assert!(validate_itin("1234-56-789").is_err());
+        // Wrong digit count
+        assert!(validate_itin("900-70-001").is_err());
+        assert!(validate_itin("900-70-00012").is_err());
+        // Letters
+        assert!(validate_itin("ABC-70-0001").is_err());
+        // Empty
+        assert!(validate_itin("").is_err());
+    }
+
+    #[test]
+    fn test_validate_itin_issue_acceptance_criteria() {
+        // From issue #425: "912-34-5678 rejected" because middle group 34 is
+        // outside the IRS-assigned range. The issue's "accepted by
+        // validate_itin" line is incorrect — middle group 34 is NOT valid.
+        assert!(validate_itin("912-34-5678").is_err());
+        // "999-93-1234" rejected per IRS rule (group 93 is in the gap).
+        assert!(validate_itin("999-93-1234").is_err());
+        // Regular SSN area still rejected by validate_itin (area not 9XX).
+        assert!(validate_itin("123-45-6789").is_err());
+    }
+
+    #[test]
+    fn test_is_valid_itin_group_helper() {
+        for g in 50..=65 {
+            assert!(is_valid_itin_group(g), "{g} should be valid");
+        }
+        for g in 70..=88 {
+            assert!(is_valid_itin_group(g), "{g} should be valid");
+        }
+        for g in 90..=92 {
+            assert!(is_valid_itin_group(g), "{g} should be valid");
+        }
+        for g in 94..=99 {
+            assert!(is_valid_itin_group(g), "{g} should be valid");
+        }
+        // Gaps
+        for g in [0, 1, 49, 66, 69, 89, 93] {
+            assert!(!is_valid_itin_group(g), "{g} should be invalid");
+        }
+    }
+
+    #[test]
+    fn test_is_test_itin() {
+        assert!(is_test_itin("999-99-9999")); // all same digit
+        assert!(!is_test_itin("900-70-0001"));
+        assert!(!is_test_itin("900-70-1234"));
+        assert!(!is_test_itin(""));
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
@@ -44,6 +44,7 @@ mod ein;
 mod finland;
 mod india;
 mod italy;
+mod itin;
 mod korea_brn;
 mod korea_driver_license;
 mod korea_frn;
@@ -70,6 +71,9 @@ pub use ssn::validate_ssn;
 
 // Re-export EIN functions
 pub use ein::{is_test_ein, is_valid_ein_prefix, validate_ein};
+
+// Re-export ITIN functions
+pub use itin::{is_test_itin, is_valid_itin_group, validate_itin};
 
 // Re-export driver's license functions
 pub use driver_license::{is_test_driver_license, validate_driver_license};

--- a/crates/octarine/src/primitives/identifiers/government/validation/ssn.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/ssn.rs
@@ -7,7 +7,7 @@
 //! SSN validation implements Social Security Administration rules:
 //! - Area 000 is never valid
 //! - Area 666 is reserved/never issued
-//! - Areas 900-999 are for ITINs (not SSNs)
+//! - Areas 900-999 are for ITINs (rejected as SSN — use `validate_itin`)
 //! - Group 00 is invalid
 //! - Serial 0000 is invalid
 //! - Test patterns (123-45-6789, etc.) are rejected
@@ -54,10 +54,10 @@ use super::cache::SSN_VALIDATION_CACHE;
 ///
 /// # SSA Validation Rules
 ///
-/// - **Area (first 3 digits)**: Cannot be 000, 666, or sequential patterns
+/// - **Area (first 3 digits)**: Cannot be 000, 666, or 900-999 (ITIN range)
 /// - **Group (middle 2 digits)**: Cannot be 00
 /// - **Serial (last 4 digits)**: Cannot be 0000
-/// - **Area 9xx**: ITINs, not SSNs (warning but not rejected)
+/// - **Area 9XX**: Rejected — these are ITINs. Use [`validate_itin`] instead.
 ///
 /// # Compliance
 ///
@@ -107,6 +107,15 @@ fn validate_ssn_uncached(ssn: &str) -> Result<(), Problem> {
     // SSA Rule: Area 666 is reserved/never issued
     if area == "666" {
         return Err(Problem::Validation("Invalid SSN area number 666".into()));
+    }
+
+    // SSA Rule: Area 9XX is the ITIN range — not an SSN. Reject here so the
+    // caller is forced to route through `validate_itin`, which enforces the
+    // IRS middle-group constraint that this validator cannot.
+    if area.starts_with('9') {
+        return Err(Problem::Validation(
+            "9XX area is an ITIN, not an SSN — use validate_itin".into(),
+        ));
     }
 
     // SSA Rule: Group 00 is invalid
@@ -230,9 +239,12 @@ mod tests {
 
     #[test]
     fn test_ssn_itin_area() {
-        // ITINs use 9xx area codes - we warn but don't reject
-        assert!(validate_ssn("912-34-5678").is_ok());
-        assert!(validate_ssn("987-12-3456").is_ok());
+        // 9XX area is an ITIN, not an SSN. validate_ssn must reject — even
+        // for values that would be valid ITINs — and callers must route
+        // 9XX strings through validate_itin.
+        assert!(validate_ssn("912-34-5678").is_err());
+        assert!(validate_ssn("987-12-3456").is_err());
+        assert!(validate_ssn("900-70-0001").is_err()); // valid as ITIN, still not an SSN
     }
 
     #[test]
@@ -367,7 +379,8 @@ mod tests {
         assert!(validate_ssn("666-01-0001").is_err()); // Invalid: 666
         assert!(validate_ssn("665-01-0001").is_ok()); // Valid: 665
         assert!(validate_ssn("667-01-0001").is_ok()); // Valid: 667
-        assert!(validate_ssn("900-01-0001").is_ok()); // Valid: ITIN in lenient mode
+        assert!(validate_ssn("899-01-0001").is_ok()); // Valid: 899 (just below ITIN range)
+        assert!(validate_ssn("900-01-0001").is_err()); // ITIN range — not an SSN
 
         // Group number boundaries
         assert!(validate_ssn("234-00-0001").is_err()); // Invalid: 00

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -158,6 +158,14 @@ impl StreamingScanner {
             let _ = self.buffer.push(m);
             total = total.saturating_add(1);
         }
+        for m in government.find_eins_in_text(text) {
+            let _ = self.buffer.push(m);
+            total = total.saturating_add(1);
+        }
+        for m in government.find_itins_in_text(text) {
+            let _ = self.buffer.push(m);
+            total = total.saturating_add(1);
+        }
         for m in government.find_tax_ids_in_text(text) {
             let _ = self.buffer.push(m);
             total = total.saturating_add(1);
@@ -360,6 +368,10 @@ impl StreamingScanner {
             (
                 |t| matches!(t, IdentifierType::Ein),
                 GovernmentIdentifierBuilder::find_eins_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::Itin),
+                GovernmentIdentifierBuilder::find_itins_in_text,
             ),
             (
                 |t| matches!(t, IdentifierType::TaxId),

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -11,7 +11,7 @@ pub enum IdentifierType {
     // Personal identifiers
     Email,
     PhoneNumber,
-    Ssn,          // Includes ITIN, EIN
+    Ssn,          // US Social Security Number (area 001-665 and 667-899 only — 9xx are ITINs)
     PersonalName, // Full names, first/last names
     Birthdate,    // Date of birth in various formats
     Username,
@@ -66,7 +66,8 @@ pub enum IdentifierType {
     DriverLicense,
     Passport,
     Ein,   // Employer Identification Number (XX-XXXXXXX, IRS campus prefix)
-    TaxId, // TIN, ITIN (EIN has its own variant)
+    Itin, // US Individual Taxpayer Identification Number (area 9XX, IRS middle group 50-65/70-88/90-92/94-99)
+    TaxId, // Generic TIN — EIN and ITIN have their own variants
     NationalId,
     KoreaRrn,           // South Korea Resident Registration Number (citizens, gender 1-4)
     KoreaFrn,           // South Korea Foreign Registration Number (foreigners, gender 5-8)

--- a/crates/octarine/tests/observe/pii_pipeline.rs
+++ b/crates/octarine/tests/observe/pii_pipeline.rs
@@ -33,8 +33,8 @@ fn test_detects_email_address() {
 
 #[test]
 fn test_detects_ssn() {
-    // Use 900 series - designated for testing
-    let text = "SSN: 900-00-0001";
+    // 517-29-8346: SSA-valid area, group, and serial; safe SSN test value
+    let text = "SSN: 517-29-8346";
     assert!(is_pii_present(text));
 
     let types = scan_for_pii(text);
@@ -84,7 +84,7 @@ fn test_detects_password_pattern() {
 
 #[test]
 fn test_detects_multiple_pii_types() {
-    let text = "Email: user@example.com, SSN: 900-00-0001, Card: 4242424242424242";
+    let text = "Email: user@example.com, SSN: 517-29-8346, Card: 4242424242424242";
 
     let types = scan_for_pii(text);
     assert!(types.len() >= 3, "Should detect at least 3 PII types");
@@ -108,10 +108,10 @@ fn test_no_pii_in_clean_text() {
 
 #[test]
 fn test_redacts_ssn() {
-    let text = "SSN: 900-00-0001";
+    let text = "SSN: 517-29-8346";
     let redacted = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
 
-    assert!(!redacted.contains("900-00-0001"));
+    assert!(!redacted.contains("517-29-8346"));
     assert!(redacted.contains("[SSN]"));
 }
 
@@ -145,11 +145,11 @@ fn test_redacts_password() {
 
 #[test]
 fn test_redacts_multiple_pii() {
-    let text = "Email: user@example.com, SSN: 900-00-0001";
+    let text = "Email: user@example.com, SSN: 517-29-8346";
     let redacted = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
 
     assert!(!redacted.contains("user@example.com"));
-    assert!(!redacted.contains("900-00-0001"));
+    assert!(!redacted.contains("517-29-8346"));
     assert!(redacted.contains("[EMAIL]"));
     assert!(redacted.contains("[SSN]"));
 }
@@ -172,7 +172,7 @@ fn test_preserves_message_structure() {
 
 #[test]
 fn test_testing_profile_no_redaction() {
-    let text = "SSN: 900-00-0001, Email: user@example.com";
+    let text = "SSN: 517-29-8346, Email: user@example.com";
     let redacted = redact_pii_with_profile(text, RedactionProfile::Testing);
 
     // Testing mode: no redaction for easier debugging
@@ -191,11 +191,11 @@ fn test_production_strict_full_redaction() {
 
 #[test]
 fn test_default_redaction_is_safe() {
-    let text = "SSN: 900-00-0001";
+    let text = "SSN: 517-29-8346";
     let redacted = redact_pii(text);
 
     // Default should redact PII
-    assert!(!redacted.contains("900-00-0001"));
+    assert!(!redacted.contains("517-29-8346"));
 }
 
 // ============================================================================
@@ -314,7 +314,7 @@ async fn test_memory_writer_stores_events_with_pii() {
     let writer = MemoryWriter::new();
 
     // Write event with PII
-    let event = Event::new(EventType::Info, "SSN: 900-00-0001");
+    let event = Event::new(EventType::Info, "SSN: 517-29-8346");
     writer.write(&event).await.expect("write should succeed");
 
     // Verify event is stored (PII handling is at a different layer)

--- a/crates/octarine/tests/pii_redaction_integration.rs
+++ b/crates/octarine/tests/pii_redaction_integration.rs
@@ -17,7 +17,7 @@ fn redact_pii(text: &str) -> String {
 
 #[test]
 fn test_automatic_ssn_redaction() {
-    let text = "User SSN: 900-00-0001";
+    let text = "User SSN: 517-29-8346";
     let redacted = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
 
     assert_eq!(redacted, "User SSN: [SSN]");
@@ -72,7 +72,7 @@ fn test_automatic_ip_address_redaction() {
 
 #[test]
 fn test_multiple_pii_types_in_single_message() {
-    let text = "User: user@example.com, SSN: 900-00-0001, Card: 4242424242424242";
+    let text = "User: user@example.com, SSN: 517-29-8346, Card: 4242424242424242";
     let redacted = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
 
     // All PII should be redacted
@@ -83,7 +83,7 @@ fn test_multiple_pii_types_in_single_message() {
 
 #[test]
 fn test_scan_detects_all_pii_types() {
-    let text = "Email: user@example.com, SSN: 900-00-0001";
+    let text = "Email: user@example.com, SSN: 517-29-8346";
     let pii_types = scan_for_pii(text);
 
     // Must contain at least 2 (email, SSN), may detect more (names, etc.)
@@ -122,7 +122,7 @@ fn test_production_lenient_redaction() {
 
 #[test]
 fn test_testing_profile_no_redaction() {
-    let text = "SSN: 900-00-0001, Email: user@example.com";
+    let text = "SSN: 517-29-8346, Email: user@example.com";
     let redacted = redact_pii_with_profile(text, RedactionProfile::Testing);
 
     // Testing mode: no redaction
@@ -828,7 +828,7 @@ fn test_redact_empty_string() {
 fn test_redact_large_input_under_limit_still_redacts_ssn() {
     let padding = "x".repeat(4_000);
     // Total length ~= 8 KB — well under the per-detector 10 KB guard.
-    let text = format!("{padding} SSN: 900-00-0001 {padding}");
+    let text = format!("{padding} SSN: 517-29-8346 {padding}");
     assert!(
         text.len() < 10_000,
         "fixture must stay under MAX_INPUT_LENGTH; got {}",
@@ -841,7 +841,7 @@ fn test_redact_large_input_under_limit_still_redacts_ssn() {
         "SSN inside an under-limit string must still be redacted",
     );
     assert!(
-        !redacted.contains("900-00-0001"),
+        !redacted.contains("517-29-8346"),
         "raw SSN must not survive redaction",
     );
 }
@@ -857,7 +857,7 @@ fn test_redact_large_input_under_limit_still_redacts_ssn() {
 fn test_redact_large_input_above_limit_skips_pii() {
     let padding = "x".repeat(11_000);
     // Total length ~= 22 KB — above the per-detector 10 KB guard.
-    let text = format!("{padding} SSN: 900-00-0001 {padding}");
+    let text = format!("{padding} SSN: 517-29-8346 {padding}");
     assert!(
         text.len() > 10_000,
         "fixture must exceed MAX_INPUT_LENGTH; got {}",
@@ -877,7 +877,7 @@ fn test_redact_large_input_above_limit_skips_pii() {
          no [SSN] marker should appear",
     );
     assert!(
-        redacted.contains("900-00-0001"),
+        redacted.contains("517-29-8346"),
         "raw SSN survives because the detector skipped this oversize input",
     );
 }


### PR DESCRIPTION
## Summary

Closes a coupled defect in US tax-ID handling and adds a first-class ITIN identifier — gap/presidio CRIT-5.

- **Bug fix**: `validate_ssn` previously accepted 9XX-area numbers as SSNs ("lenient ITIN mode"). It now rejects them with an error pointing callers to `validate_itin`.
- **New identifier**: `IdentifierType::Itin` / `PiiType::Itin` with strict validation per IRS Publication 1915 — area `9XX`, middle group ∈ `{50-65, 70-88, 90-92, 94-99}`, serial `0001-9999`. Matches Presidio `us_itin_recognizer.py` semantics.
- **Detection routing**: `find_ssns_in_text` now reclassifies 9XX matches as `Itin` (passes IRS rule) or `TaxId` (9XX area but invalid middle group), never `Ssn`.
- **PII bridge synced**: `name()`, `domain()`, `is_high_risk`, `is_hipaa_protected` (IRS-issued tax IDs are PHI), and the exhaustive `From<IdentifierType>` mapping.
- **Layer 3 + shortcuts**: `is_itin`, `validate_itin`, `find_itins_in_text` reachable via `GovernmentBuilder` and the shortcut module.
- **Streaming bridge cleanup**: `scan_all_identifiers` gained the missing `find_eins_in_text` alongside `find_itins_in_text` — pre-existing EIN gap also addressed.

## Test data migration

~100 references to `900-00-0001` were replaced with `517-29-8346`. The historical placeholder is **not** a valid identifier under any of the new rules — middle group `00` is outside the IRS-assigned ITIN range and 9XX cannot be an SSN. The replacement is a real SSA-valid SSN explicitly catalogued in `common::is_test_ssn_not_test_patterns` as a non-test pattern.

## Note on issue acceptance criteria

The issue's criterion "`912-34-5678` accepted by `validate_itin`" is internally inconsistent — middle group `34` is outside the IRS-assigned range `{50-65, 70-88, 90-92, 94-99}` and is correctly rejected. `900-70-0001` is used as the canonical valid ITIN throughout new tests.

## Test plan

- [x] `just test-filter "itin"` — 39 passing
- [x] `just test-mod "government::validation"` — 494 passing
- [x] `just test-mod "government::detection"` — 116 passing
- [x] `just test-filter "pii_redaction"` — 4 passing
- [x] `just clippy` — clean
- [x] `just fmt-check` — clean
- [x] `just arch-check` — clean
- [x] PII bridge sync audit — clean (only finding was the pre-existing streaming gap, now fixed)

Closes #425