### PR TITLE
feat(anonymize): Mask operator with multi-char units + strict validation

### DIFF
--- a/crates/octarine/src/anonymize/engine.rs
+++ b/crates/octarine/src/anonymize/engine.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 
 use octarine_problem::{Problem, Result};
 
-use super::operators::{Redact, Replace};
+use super::operators::{Mask, Redact, Replace};
 use super::{
     ConflictResolutionStrategy, EngineResult, Operator, OperatorConfig, OperatorResult, PiiSpan,
     RecognizerResult,
@@ -88,8 +88,9 @@ impl Default for AnonymizerEngine {
 }
 
 impl AnonymizerEngine {
-    /// Creates an engine with the built-in operators (`replace`, `redact`) and
-    /// the default [`ConflictResolutionStrategy::MergeSimilarOrContained`].
+    /// Creates an engine with the built-in operators (`replace`, `redact`,
+    /// `mask`) and the default
+    /// [`ConflictResolutionStrategy::MergeSimilarOrContained`].
     #[must_use]
     pub fn new() -> Self {
         let mut engine = Self {
@@ -99,6 +100,7 @@ impl AnonymizerEngine {
         };
         engine.register(Box::new(Replace));
         engine.register(Box::new(Redact));
+        engine.register(Box::new(Mask));
         engine
     }
 
@@ -111,8 +113,8 @@ impl AnonymizerEngine {
 
     /// Registers a custom operator, returning `self` for chaining.
     ///
-    /// An operator whose name matches a built-in (`replace`, `redact`) replaces
-    /// it.
+    /// An operator whose name matches a built-in (`replace`, `redact`, `mask`)
+    /// replaces it.
     #[must_use]
     pub fn with_operator(mut self, operator: Box<dyn Operator>) -> Self {
         self.register(operator);
@@ -632,6 +634,48 @@ mod tests {
     #[test]
     fn longest_free_subrange_none_when_fully_covered() {
         assert_eq!(longest_free_subrange(2, 5, &[(0, 10)]), None);
+    }
+
+    #[test]
+    fn mask_operator_tail_masks_through_engine() {
+        // The built-in `mask` operator is reachable by name and tail-masks a
+        // PAN span, preserving the surrounding text and the leading digits.
+        let engine = AnonymizerEngine::new();
+        let mut params = HashMap::new();
+        params.insert("masking_char".to_string(), json!("*"));
+        params.insert("chars_to_mask".to_string(), json!(12));
+        params.insert("from_end".to_string(), json!(true));
+        let mut ops = HashMap::new();
+        ops.insert(
+            "CREDIT_CARD".to_string(),
+            OperatorConfig::with_params("mask", params).expect("cfg"),
+        );
+
+        // "card 4111-1111-1111-1234." — PAN spans bytes 5..24.
+        let text = "card 4111-1111-1111-1234.";
+        let out = engine
+            .anonymize(text, vec![rr("CREDIT_CARD", 5, 24, 0.99)], &ops)
+            .expect("anonymize");
+        assert_eq!(out.text.as_deref(), Some("card 4111-11************."));
+        let item = out.items.first().expect("one item");
+        assert_eq!(item.operator.as_deref(), Some("mask"));
+    }
+
+    #[test]
+    fn mask_operator_invalid_config_fails_engine_up_front() {
+        // A negative chars_to_mask must fail validation before any output is
+        // built (not silently no-op, the Presidio anti-pattern).
+        let engine = AnonymizerEngine::new();
+        let mut params = HashMap::new();
+        params.insert("masking_char".to_string(), json!("*"));
+        params.insert("chars_to_mask".to_string(), json!(-1));
+        let mut ops = HashMap::new();
+        ops.insert(
+            "US_SSN".to_string(),
+            OperatorConfig::with_params("mask", params).expect("cfg"),
+        );
+        let err = engine.anonymize("123-45-6789", vec![rr("US_SSN", 0, 11, 0.9)], &ops);
+        assert!(err.is_err());
     }
 
     #[test]

--- a/crates/octarine/src/anonymize/mod.rs
+++ b/crates/octarine/src/anonymize/mod.rs
@@ -16,10 +16,13 @@
 //! - `Operator` — the transformation trait every operator implements.
 //! - `AnonymizerEngine` — applies operators to detected spans with conflict
 //!   resolution and offset tracking.
-//! - `Replace` / `Redact` — the stateless built-in operators. `Custom` wraps a
-//!   caller-supplied closure (`Fn(&str) -> Result<String>`) for one-off
-//!   transforms and stateful pseudonymization. Further operators (mask, hash,
-//!   encrypt, keep) land as follow-up work under the `anonymize/` umbrella.
+//! - `Replace` / `Redact` / `Mask` — the stateless built-in operators.
+//!   `Replace` substitutes a fixed value (or `<ENTITY_TYPE>`), `Redact` deletes
+//!   the span, and `Mask` positionally masks characters (multi-char units and
+//!   tail-masking via `from_end`). `Custom` wraps a caller-supplied closure
+//!   (`Fn(&str) -> Result<String>`) for one-off transforms and stateful
+//!   pseudonymization. Further operators (hash, encrypt, keep) land as
+//!   follow-up work under the `anonymize/` umbrella.
 //!
 //! All spans are half-open (`start` inclusive, `end` exclusive). See the type
 //! definitions for the full design rationale and the Presidio anti-patterns
@@ -48,7 +51,7 @@ mod types;
 
 pub use engine::AnonymizerEngine;
 pub use operator::Operator;
-pub use operators::{Custom, Redact, Replace};
+pub use operators::{Custom, Mask, Redact, Replace};
 pub use shortcuts::{anonymize, redact_all};
 pub use types::{
     ConflictResolutionStrategy, EngineResult, OperatorConfig, OperatorResult, OperatorType,

--- a/crates/octarine/src/anonymize/operators/mask.rs
+++ b/crates/octarine/src/anonymize/operators/mask.rs
@@ -1,0 +1,355 @@
+//! Mask operator — positionally masks characters of a span.
+//!
+//! `Mask` replaces a fixed number of characters at the start (or, with
+//! `from_end`, the tail) of a detected span with a mask **unit**. It is the
+//! canonical PAN/phone tail-mask transform: mask the leading digits of a card
+//! and show the last four, or vice versa.
+//!
+//! # Octarine vs Presidio
+//!
+//! Two deliberate improvements over Presidio's `Mask`:
+//!
+//! - **Multi-character mask units.** Presidio validates `masking_char` to a
+//!   single character; octarine accepts any non-empty string, so `"**"` or
+//!   `"XX"` are valid units (each masked position expands to the whole unit).
+//!   There is no security reason for the single-char limit.
+//! - **Explicit rejection of invalid parameters.** Presidio silently no-ops on
+//!   a negative `chars_to_mask`; octarine fails fast with a
+//!   [`Problem`](octarine_problem::Problem) so a misconfigured pipeline is
+//!   caught at [`validate`](Operator::validate) time, before any output is
+//!   built.
+//!
+//! # The transformation is single-sourced
+//!
+//! The actual masking is performed by the shared primitive
+//! `primitives::identifiers::mask_chars`, the same positional masker the PII
+//! redactor and identifier sanitizers build on. This operator only parses and
+//! validates parameters, then delegates — so "mask N characters" has exactly
+//! one implementation.
+
+use octarine_problem::{Problem, Result};
+use serde_json::Value;
+
+use super::super::operator::Operator;
+use super::super::{OperatorConfig, OperatorType};
+use crate::primitives::identifiers::mask_chars;
+
+/// Parameter key holding the mask unit (one or more characters).
+const PARAM_MASKING_CHAR: &str = "masking_char";
+/// Parameter key holding the number of characters to mask.
+const PARAM_CHARS_TO_MASK: &str = "chars_to_mask";
+/// Parameter key selecting tail-masking.
+const PARAM_FROM_END: &str = "from_end";
+
+/// Masks a fixed number of characters at one end of the matched span.
+///
+/// Parameters (read from the [`OperatorConfig`]):
+///
+/// - `masking_char` (**required**): the mask unit, any non-empty string. Each
+///   masked character position is replaced by the entire unit, so `"*"` keeps
+///   the length and `"XX"` doubles each masked position.
+/// - `chars_to_mask` (**required**): a non-negative integer. Values larger than
+///   the span's character length are clamped to that length. A negative or
+///   non-integer value is rejected.
+/// - `from_end` (optional, default `false`): mask the trailing characters
+///   instead of the leading ones.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// use octarine::anonymize::{Mask, Operator, OperatorConfig};
+/// use serde_json::json;
+///
+/// // Tail-mask the last 12 characters of a PAN with '*'.
+/// let mut params = HashMap::new();
+/// params.insert("masking_char".to_string(), json!("*"));
+/// params.insert("chars_to_mask".to_string(), json!(12));
+/// params.insert("from_end".to_string(), json!(true));
+/// let config = OperatorConfig::with_params("mask", params)?;
+///
+/// // The leading "4111-11" is kept; the trailing 12 characters become '*'.
+/// assert_eq!(
+///     Mask.operate("4111-1111-1111-1234", "CREDIT_CARD", &config)?,
+///     "4111-11************",
+/// );
+///
+/// // Multi-character mask units are allowed (Presidio rejects these).
+/// let mut params = HashMap::new();
+/// params.insert("masking_char".to_string(), json!("XX"));
+/// params.insert("chars_to_mask".to_string(), json!(3));
+/// let config = OperatorConfig::with_params("mask", params)?;
+/// assert_eq!(Mask.operate("secret", "PASSWORD", &config)?, "XXXXXXret");
+/// # Ok::<(), octarine_problem::Problem>(())
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Mask;
+
+/// The validated `mask` parameter triple: `(unit, chars_to_mask, from_end)`.
+type MaskParams = (String, usize, bool);
+
+impl Mask {
+    /// Parses and validates the operator parameters once, so
+    /// [`validate`](Operator::validate) and [`operate`](Operator::operate)
+    /// share a single source of truth.
+    fn parse_params(config: &OperatorConfig) -> Result<MaskParams> {
+        // masking_char: required, non-empty string.
+        let unit = match config.param_str(PARAM_MASKING_CHAR) {
+            Some(s) if !s.is_empty() => s.to_string(),
+            Some(_) => {
+                return Err(Problem::Validation(
+                    "mask operator: 'masking_char' must be a non-empty string".to_string(),
+                ));
+            }
+            None => {
+                return Err(Problem::Validation(
+                    "mask operator: 'masking_char' is required".to_string(),
+                ));
+            }
+        };
+
+        // chars_to_mask: required, non-negative integer. `as_u64` returns None
+        // for negative, fractional, or non-numeric values — so the silent
+        // no-op on a negative count (the Presidio bug) becomes an explicit
+        // failure here.
+        let chars_to_mask = match config.params.get(PARAM_CHARS_TO_MASK) {
+            Some(value) => value.as_u64().ok_or_else(|| {
+                Problem::Validation(format!(
+                    "mask operator: 'chars_to_mask' must be a non-negative integer, got {value}"
+                ))
+            })?,
+            None => {
+                return Err(Problem::Validation(
+                    "mask operator: 'chars_to_mask' is required".to_string(),
+                ));
+            }
+        };
+        // usize is 64-bit on supported targets, but guard the cast explicitly so
+        // a 32-bit target rejects an out-of-range count rather than truncating.
+        let chars_to_mask = usize::try_from(chars_to_mask).map_err(|_| {
+            Problem::Validation(format!(
+                "mask operator: 'chars_to_mask' ({chars_to_mask}) exceeds the addressable range"
+            ))
+        })?;
+
+        // from_end: optional bool, default false; reject a present-but-non-bool.
+        let from_end = match config.params.get(PARAM_FROM_END) {
+            Some(Value::Bool(b)) => *b,
+            Some(other) => {
+                return Err(Problem::Validation(format!(
+                    "mask operator: 'from_end' must be a boolean, got {other}"
+                )));
+            }
+            None => false,
+        };
+
+        Ok((unit, chars_to_mask, from_end))
+    }
+}
+
+impl Operator for Mask {
+    fn operate(&self, text: &str, _entity_type: &str, config: &OperatorConfig) -> Result<String> {
+        let (unit, chars_to_mask, from_end) = Self::parse_params(config)?;
+        Ok(mask_chars(text, &unit, chars_to_mask, from_end))
+    }
+
+    /// Validates the `masking_char`, `chars_to_mask`, and `from_end` parameters
+    /// up front so a misconfigured operator fails before any output is built.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Problem::Validation`] if `masking_char` is missing or empty,
+    /// if `chars_to_mask` is missing or not a non-negative integer, or if
+    /// `from_end` is present but not a boolean.
+    fn validate(&self, config: &OperatorConfig) -> Result<()> {
+        Self::parse_params(config).map(|_| ())
+    }
+
+    fn operator_name(&self) -> &'static str {
+        "mask"
+    }
+
+    fn operator_type(&self) -> OperatorType {
+        OperatorType::Anonymize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use std::collections::HashMap;
+
+    use proptest::prelude::*;
+    use serde_json::json;
+
+    use super::*;
+
+    /// Builds a `mask` config from raw JSON params.
+    fn mask_config(params: HashMap<String, Value>) -> OperatorConfig {
+        OperatorConfig::with_params("mask", params).expect("valid config")
+    }
+
+    /// Convenience for the common `(masking_char, chars_to_mask, from_end)` case.
+    fn mask_config_of(unit: Value, count: Value, from_end: Option<bool>) -> OperatorConfig {
+        let mut params = HashMap::new();
+        params.insert(PARAM_MASKING_CHAR.to_string(), unit);
+        params.insert(PARAM_CHARS_TO_MASK.to_string(), count);
+        if let Some(b) = from_end {
+            params.insert(PARAM_FROM_END.to_string(), json!(b));
+        }
+        mask_config(params)
+    }
+
+    #[test]
+    fn masks_from_start_by_default() {
+        let config = mask_config_of(json!("*"), json!(4), None);
+        let out = Mask.operate("1234567890", "X", &config).expect("operate");
+        assert_eq!(out, "****567890");
+    }
+
+    #[test]
+    fn masks_from_end_when_requested() {
+        let config = mask_config_of(json!("*"), json!(4), Some(true));
+        let out = Mask.operate("1234567890", "X", &config).expect("operate");
+        assert_eq!(out, "123456****");
+    }
+
+    #[test]
+    fn accepts_multi_char_mask_unit() {
+        // Octarine beats Presidio: multi-char units are allowed.
+        let config = mask_config_of(json!("XX"), json!(2), None);
+        let out = Mask.operate("abcd", "X", &config).expect("operate");
+        assert_eq!(out, "XXXXcd");
+
+        let config = mask_config_of(json!("**"), json!(2), Some(true));
+        let out = Mask.operate("abcd", "X", &config).expect("operate");
+        assert_eq!(out, "ab****");
+    }
+
+    #[test]
+    fn clamps_count_to_char_length() {
+        let config = mask_config_of(json!("*"), json!(99), None);
+        let out = Mask.operate("abc", "X", &config).expect("operate");
+        assert_eq!(out, "***");
+    }
+
+    #[test]
+    fn rejects_negative_chars_to_mask_not_silent_noop() {
+        // The headline anti-pattern: Presidio silently no-ops; octarine rejects.
+        let config = mask_config_of(json!("*"), json!(-1), None);
+        assert!(Mask.validate(&config).is_err());
+        assert!(Mask.operate("abc", "X", &config).is_err());
+    }
+
+    #[test]
+    fn rejects_fractional_chars_to_mask() {
+        let config = mask_config_of(json!("*"), json!(2.5), None);
+        assert!(Mask.validate(&config).is_err());
+    }
+
+    #[test]
+    fn rejects_non_numeric_chars_to_mask() {
+        let config = mask_config_of(json!("*"), json!("4"), None);
+        assert!(Mask.validate(&config).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_chars_to_mask() {
+        let mut params = HashMap::new();
+        params.insert(PARAM_MASKING_CHAR.to_string(), json!("*"));
+        let config = mask_config(params);
+        assert!(Mask.validate(&config).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_masking_char() {
+        let config = mask_config_of(json!(""), json!(4), None);
+        assert!(Mask.validate(&config).is_err());
+    }
+
+    #[test]
+    fn rejects_non_string_masking_char() {
+        let config = mask_config_of(json!(42), json!(4), None);
+        assert!(Mask.validate(&config).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_masking_char() {
+        let mut params = HashMap::new();
+        params.insert(PARAM_CHARS_TO_MASK.to_string(), json!(4));
+        let config = mask_config(params);
+        assert!(Mask.validate(&config).is_err());
+    }
+
+    #[test]
+    fn rejects_non_bool_from_end() {
+        let mut params = HashMap::new();
+        params.insert(PARAM_MASKING_CHAR.to_string(), json!("*"));
+        params.insert(PARAM_CHARS_TO_MASK.to_string(), json!(4));
+        params.insert(PARAM_FROM_END.to_string(), json!("yes"));
+        let config = mask_config(params);
+        assert!(Mask.validate(&config).is_err());
+    }
+
+    #[test]
+    fn validate_accepts_good_config() {
+        let config = mask_config_of(json!("*"), json!(0), Some(false));
+        assert!(Mask.validate(&config).is_ok());
+    }
+
+    #[test]
+    fn masks_by_char_not_byte() {
+        // UTF-8 safety: count characters, not bytes.
+        let config = mask_config_of(json!("*"), json!(2), Some(true));
+        let out = Mask.operate("café", "X", &config).expect("operate");
+        assert_eq!(out, "ca**");
+
+        let config = mask_config_of(json!("*"), json!(2), None);
+        let out = Mask.operate("😀😀😀😀", "X", &config).expect("operate");
+        assert_eq!(out, "**😀😀");
+    }
+
+    #[test]
+    fn name_and_type() {
+        assert_eq!(Mask.operator_name(), "mask");
+        assert_eq!(Mask.operator_type(), OperatorType::Anonymize);
+    }
+
+    proptest! {
+        /// PAN tail-mask: masking the last 12 of a 16-digit-with-separators PAN
+        /// always preserves the leading characters verbatim and replaces every
+        /// trailing masked position with the mask char.
+        #[test]
+        fn pan_tail_mask_preserves_prefix_and_masks_tail(
+            d in proptest::collection::vec(0u8..10, 16)
+        ) {
+            // Build "dddd-dddd-dddd-dddd" (19 chars: 16 digits + 3 hyphens).
+            const DIGITS: [char; 10] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+            let mut pan = String::new();
+            for (i, digit) in d.iter().enumerate() {
+                if i > 0 && i % 4 == 0 {
+                    pan.push('-');
+                }
+                pan.push(*DIGITS.get(usize::from(*digit)).unwrap_or(&'0'));
+            }
+
+            let config = mask_config_of(json!("*"), json!(12), Some(true));
+            let out = Mask.operate(&pan, "CREDIT_CARD", &config).expect("operate");
+
+            let pan_chars: Vec<char> = pan.chars().collect();
+            let out_chars: Vec<char> = out.chars().collect();
+            // Same total length (single-char unit preserves length).
+            prop_assert_eq!(out_chars.len(), pan_chars.len());
+            let keep = pan_chars.len().saturating_sub(12);
+            // Leading `keep` characters are untouched.
+            prop_assert_eq!(out_chars.get(..keep), pan_chars.get(..keep));
+            // Every remaining position is the mask char.
+            prop_assert!(
+                out_chars
+                    .get(keep..)
+                    .is_some_and(|tail| tail.iter().all(|&c| c == '*'))
+            );
+        }
+    }
+}

--- a/crates/octarine/src/anonymize/operators/mod.rs
+++ b/crates/octarine/src/anonymize/operators/mod.rs
@@ -3,15 +3,18 @@
 //! Each operator is a pure implementation of the
 //! [`Operator`](crate::anonymize::Operator) trait. The
 //! [`AnonymizerEngine`](crate::anonymize::AnonymizerEngine) seeds its default
-//! registry with the stateless built-ins here ([`Replace`], [`Redact`]);
-//! [`Custom`] carries a caller-supplied closure and is registered explicitly
-//! via [`with_operator`](crate::anonymize::AnonymizerEngine::with_operator).
+//! registry with the stateless built-ins here ([`Replace`], [`Redact`],
+//! [`Mask`]); [`Custom`] carries a caller-supplied closure and is registered
+//! explicitly via
+//! [`with_operator`](crate::anonymize::AnonymizerEngine::with_operator).
 //! Additional operators land as follow-up work under the `anonymize/` umbrella.
 
 mod custom;
+mod mask;
 mod redact;
 mod replace;
 
 pub use custom::Custom;
+pub use mask::Mask;
 pub use redact::Redact;
 pub use replace::Replace;

--- a/crates/octarine/src/primitives/identifiers/common/masking.rs
+++ b/crates/octarine/src/primitives/identifiers/common/masking.rs
@@ -274,6 +274,69 @@ pub fn create_mask(length: usize, mask_char: char) -> String {
     mask_char.to_string().repeat(length)
 }
 
+/// Mask a fixed number of characters from one end of a string
+///
+/// Positional masking with a configurable mask **unit** (one or more
+/// characters). `count` characters are masked from the start, or from the tail
+/// when `from_end` is `true`. Each masked character position is replaced by the
+/// entire `unit` string, so multi-character units like `"**"` or `"XX"` are
+/// supported (the output for a single masked position is the full unit).
+///
+/// `count` is clamped to the character length of `value`, so a `count` larger
+/// than the string simply masks the whole string. UTF-8 safe: counting and
+/// slicing are by `char`, never by byte.
+///
+/// This is the shared transformation behind the anonymize `mask` operator and
+/// any other caller needing positional masking — kept here so the logic has a
+/// single home.
+///
+/// # Arguments
+///
+/// * `value` - The input string
+/// * `unit` - The mask unit (one or more characters, e.g. `"*"` or `"XX"`)
+/// * `count` - Number of characters to mask (clamped to the char length)
+/// * `from_end` - Mask from the tail instead of the start
+///
+/// # Returns
+///
+/// The masked string. With a single-character `unit` the length in characters
+/// is preserved; multi-character units expand each masked position.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Mask the first 4 characters.
+/// assert_eq!(mask_chars("1234567890", "*", 4, false), "****567890");
+///
+/// // Tail-mask the last 4 (PAN/phone pattern).
+/// assert_eq!(mask_chars("1234567890", "*", 4, true), "123456****");
+///
+/// // Multi-character unit.
+/// assert_eq!(mask_chars("abcd", "XX", 2, false), "XXXXcd");
+///
+/// // count larger than the string clamps to its length.
+/// assert_eq!(mask_chars("abc", "*", 99, false), "***");
+/// ```
+pub fn mask_chars(value: &str, unit: &str, count: usize, from_end: bool) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    let char_count = chars.len();
+    let to_mask = count.min(char_count);
+    let keep = char_count.saturating_sub(to_mask);
+    let mask = unit.repeat(to_mask);
+
+    if from_end {
+        let visible: String = chars
+            .get(..keep)
+            .map_or_else(String::new, |s| s.iter().collect());
+        format!("{visible}{mask}")
+    } else {
+        let visible: String = chars
+            .get(to_mask..)
+            .map_or_else(String::new, |s| s.iter().collect());
+        format!("{mask}{visible}")
+    }
+}
+
 /// Mask digits while preserving separators
 ///
 /// Useful for SSN, phone numbers, credit cards with formatting.
@@ -437,6 +500,49 @@ mod tests {
         assert_eq!(create_mask(5, '*'), "*****");
         assert_eq!(create_mask(10, '#'), "##########");
         assert_eq!(create_mask(0, '*'), "");
+    }
+
+    // ===== mask_chars Tests =====
+
+    #[test]
+    fn test_mask_chars_from_start() {
+        assert_eq!(mask_chars("1234567890", "*", 4, false), "****567890");
+        assert_eq!(mask_chars("ABCDEFGH", "*", 3, false), "***DEFGH");
+    }
+
+    #[test]
+    fn test_mask_chars_from_end() {
+        assert_eq!(mask_chars("1234567890", "*", 4, true), "123456****");
+        assert_eq!(mask_chars("ABCDEFGH", "*", 3, true), "ABCDE***");
+    }
+
+    #[test]
+    fn test_mask_chars_multi_char_unit() {
+        // Each masked position expands to the full unit.
+        assert_eq!(mask_chars("abcd", "XX", 2, false), "XXXXcd");
+        assert_eq!(mask_chars("abcd", "**", 2, true), "ab****");
+    }
+
+    #[test]
+    fn test_mask_chars_clamps_to_length() {
+        assert_eq!(mask_chars("abc", "*", 99, false), "***");
+        assert_eq!(mask_chars("abc", "*", 99, true), "***");
+        assert_eq!(mask_chars("", "*", 5, false), "");
+    }
+
+    #[test]
+    fn test_mask_chars_zero_count_is_identity() {
+        assert_eq!(mask_chars("abc", "*", 0, false), "abc");
+        assert_eq!(mask_chars("abc", "*", 0, true), "abc");
+    }
+
+    #[test]
+    fn test_mask_chars_unicode() {
+        // Char-count semantics, not byte-count.
+        assert_eq!(mask_chars("café", "*", 2, true), "ca**");
+        assert_eq!(mask_chars("café", "*", 2, false), "**fé");
+        assert_eq!(mask_chars("😀😀😀😀", "*", 2, false), "**😀😀");
+        assert_eq!(mask_chars("A😀B😀C", "*", 2, true), "A😀B**");
     }
 
     // ===== mask_digits_preserve_format Tests =====

--- a/crates/octarine/src/primitives/identifiers/common/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/mod.rs
@@ -23,7 +23,7 @@ pub use luhn::{
     is_valid as is_luhn_valid, is_valid_with_min_length as is_luhn_valid_with_min_length,
 };
 pub use masking::{
-    alphanumeric_only, create_mask, digits_only, mask_all, mask_digits_preserve_format,
+    alphanumeric_only, create_mask, digits_only, mask_all, mask_chars, mask_digits_preserve_format,
     mask_middle, show_first_and_last, show_first_n, show_last_n,
 };
 pub use utils::{

--- a/crates/octarine/src/primitives/identifiers/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/mod.rs
@@ -43,6 +43,10 @@
 // Private to identifiers/ - sibling modules (like paths/) cannot access
 mod common;
 
+// Re-export the generic positional masker for crate-internal use (the
+// anonymize `mask` operator delegates to it — single-source transformation).
+pub(crate) use common::mask_chars;
+
 // Accessible within crate - observe/pii and security can use these
 pub(crate) mod builder;
 pub(crate) mod streaming;


### PR DESCRIPTION
## Summary

Adds the `Mask` anonymize operator — positional character masking from the start or, with `from_end=true`, the tail (the PAN/phone use case). The transformation is **single-sourced** per epic #604: a new generic `mask_chars` primitive in `identifiers/common/masking.rs` (the same module the PII redactor and identifier sanitizers build on) does the masking; the operator only parses/validates parameters, then delegates.

### Octarine beats Presidio
- **Multi-char mask units** (`"**"`, `"XX"`) — Presidio validates `masking_char` to length 1; octarine accepts any non-empty string (audit §A.3).
- **Explicit rejection of invalid params** — negative / fractional / non-numeric / missing `chars_to_mask` fail fast via `Problem::Validation`; Presidio silently no-ops on a negative count (audit §F.3 / W.6).

### Behavior
- `chars_to_mask` clamps to the span's char length (Presidio parity).
- All masking is UTF-8 safe (char-count, not byte-count).
- Registered as a stateless built-in alongside `replace`/`redact`; reachable by name `"mask"`.

> Note: the issue referenced `Problem::invalid_param`, which doesn't exist in the crate — used `Problem::Validation`, consistent with `Replace`/`Custom`/the types layer.

## Files
- `primitives/identifiers/common/masking.rs` — new `mask_chars` + tests
- `primitives/identifiers/common/mod.rs`, `identifiers/mod.rs` — targeted `pub(crate)` re-export (kept `common` private)
- `anonymize/operators/mask.rs` — **new** `Mask` operator
- `anonymize/operators/mod.rs`, `anonymize/mod.rs`, `anonymize/engine.rs` — wire-up, registration, docs, engine tests

## Test plan
- `just test-octarine` → 7770 passed
- Operator tests: multi-char units, negative/fractional/missing `chars_to_mask` rejection, empty/non-string `masking_char` rejection, clamp, `from_end` tail-mask, UTF-8, PAN tail-mask `proptest`
- Engine integration tests: `mask` by name (PAN tail-mask) + fail-fast on bad config
- `just clippy`, `just arch-check`, `just doc`, `just test-docs`, `just fmt-check` → all clean

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)