### PR TITLE
feat(anonymize): StateStore trait + SessionId/EntityKey vault foundation

### DIFF
--- a/crates/octarine/src/anonymize/mod.rs
+++ b/crates/octarine/src/anonymize/mod.rs
@@ -23,6 +23,11 @@
 //!   (`Fn(&str) -> Result<String>`) for one-off transforms and stateful
 //!   pseudonymization. Further operators (hash, encrypt, keep) land as
 //!   follow-up work under the `anonymize/` umbrella.
+//! - `StateStore` / `SessionId` / `EntityKey` — the token-vault surface: the
+//!   backend-agnostic persistence contract behind reversible pseudonymization,
+//!   recording each `(session, original) → stable token` mapping. Pluggable
+//!   backends and the InstanceCounter operators that consume it land as
+//!   follow-up work.
 //!
 //! All spans are half-open (`start` inclusive, `end` exclusive). See the type
 //! definitions for the full design rationale and the Presidio anti-patterns
@@ -48,6 +53,7 @@ mod operator;
 mod operators;
 mod shortcuts;
 mod types;
+mod vault;
 
 pub use engine::AnonymizerEngine;
 pub use operator::Operator;
@@ -57,3 +63,4 @@ pub use types::{
     ConflictResolutionStrategy, EngineResult, OperatorConfig, OperatorResult, OperatorType,
     PiiSpan, RecognizerResult,
 };
+pub use vault::{EntityKey, SessionId, StateStore};

--- a/crates/octarine/src/anonymize/vault/mod.rs
+++ b/crates/octarine/src/anonymize/vault/mod.rs
@@ -1,0 +1,27 @@
+//! Session-stable token vault — the persistence foundation for reversible
+//! pseudonymization.
+//!
+//! This module defines the backend-agnostic surface every vault backend and
+//! the InstanceCounter operators build on:
+//!
+//! - [`SessionId`] — the opaque per-session handle that scopes a run of
+//!   pseudonymization.
+//! - [`EntityKey`] — the composite `entity_type` + `original` key a single
+//!   value is stored under.
+//! - [`StateStore`] — the `async` trait that records each
+//!   `(session, key) → token` mapping, implemented by pluggable backends.
+//!
+//! Presidio has no equivalent abstraction: its `InstanceCounterAnonymizer`
+//! lives in a sample notebook with a hand-rolled dict that explicitly disclaims
+//! thread safety. Octarine ships the trait first-class so backends own their
+//! own atomicity.
+//!
+//! Backends (in-memory, Redis, Postgres), the session lifecycle API, and the
+//! InstanceCounter operators that consume this surface land as follow-up work;
+//! see `docs/anonymize/token-vault.md`.
+
+mod store;
+mod types;
+
+pub use store::StateStore;
+pub use types::{EntityKey, SessionId};

--- a/crates/octarine/src/anonymize/vault/store.rs
+++ b/crates/octarine/src/anonymize/vault/store.rs
@@ -1,0 +1,298 @@
+//! The [`StateStore`] trait — the backend-agnostic persistence contract behind
+//! octarine's reversible pseudonymization.
+//!
+//! Reversible pseudonymization needs durable per-session state: the mapping
+//! from an original PII value (`"Jane Doe"`) to a stable token (`<PERSON_0>`)
+//! must survive across multiple anonymize/deanonymize calls in one session and,
+//! in multi-replica deployments, across processes. `StateStore` abstracts that
+//! storage so the InstanceCounter operators can swap between an in-memory map
+//! (tests, single process), Redis (multi-process), or Postgres (durable,
+//! auditable) without changing a line of operator code.
+
+use async_trait::async_trait;
+use octarine_problem::Result;
+
+use super::types::{EntityKey, SessionId};
+
+/// Backend-agnostic persistence for reversible pseudonymization state.
+///
+/// A `StateStore` records, per [`SessionId`], the mapping from each
+/// [`EntityKey`] (entity type + original value) to the stable token that
+/// replaces it. Implementations are responsible for their own concurrency
+/// control — an in-memory store guards a map with a lock, Redis relies on its
+/// single-threaded-per-key model, Postgres uses `SELECT ... FOR UPDATE` — so
+/// that concurrent callers never observe a torn or duplicated mapping. Because
+/// the trait is `Send + Sync`, a store is shared across threads as
+/// `Arc<dyn StateStore>`.
+///
+/// All methods are `async`: backends perform network or disk I/O, and even the
+/// in-memory store keeps the signature uniform so callers are backend-agnostic.
+///
+/// # Worked example: protecting an LLM prompt
+///
+/// The store is the durable half of the round trip. An InstanceCounter
+/// anonymizer mints stable tokens through [`get`](StateStore::get) /
+/// [`put`](StateStore::put), and a deanonymizer reverses them on the model's
+/// response — all keyed off the same [`SessionId`]:
+///
+/// ```text
+/// let store: Arc<dyn StateStore> = Arc::new(InMemoryStore::new()); // #540
+/// let session = SessionId::new("chat-42");
+///
+/// // 1. Anonymize the user's prompt: "Email Jane Doe at jane@acme.com"
+/// //    -> "Email <PERSON_0> at <EMAIL_0>"
+/// //    Each original is stored once via put(); a repeat of the same value
+/// //    re-reads the existing token via get() (stability).
+///
+/// // 2. Send the anonymized prompt to the model; it replies referencing the
+/// //    tokens, e.g. "I drafted a note to <PERSON_0>."
+///
+/// // 3. Deanonymize the reply by reversing the session's mappings back to the
+/// //    originals: "I drafted a note to Jane Doe."
+///
+/// // 4. When the conversation ends, flush(&session) drops all of its state.
+/// ```
+///
+/// The runnable form of this example arrives with the in-memory backend
+/// (#540) and the InstanceCounter operators (#543); see
+/// `docs/anonymize/token-vault.md`.
+#[async_trait]
+pub trait StateStore: Send + Sync {
+    /// Returns the stored token for `key` within `session`, or `None` if no
+    /// mapping exists yet.
+    ///
+    /// This is the stability check an anonymizer performs first: a hit means
+    /// the original has already been seen in this session and must reuse its
+    /// existing token.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Problem`](octarine_problem::Problem) if the backend cannot
+    /// be reached or the lookup fails.
+    async fn get(&self, session: &SessionId, key: &EntityKey) -> Result<Option<String>>;
+
+    /// Stores `value` as the token for `key` within `session`.
+    ///
+    /// Idempotent: storing the same `(session, key)` again overwrites the
+    /// previous token. Implementations must apply this atomically with respect
+    /// to concurrent [`get`](StateStore::get)/`put` calls so that two callers
+    /// racing on a new original never mint divergent tokens.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Problem`](octarine_problem::Problem) if the backend cannot
+    /// be reached or the write fails.
+    async fn put(&self, session: &SessionId, key: &EntityKey, value: String) -> Result<()>;
+
+    /// Returns every `(original, token)` pair stored under `entity_type` within
+    /// `session`.
+    ///
+    /// Used to enumerate a session's mappings — for example to build the
+    /// reverse lookup a deanonymizer needs, or to count the indices already
+    /// allocated for a type. The order of the returned pairs is unspecified.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Problem`](octarine_problem::Problem) if the backend cannot
+    /// be reached or the scan fails.
+    async fn list(&self, session: &SessionId, entity_type: &str) -> Result<Vec<(String, String)>>;
+
+    /// Drops all stored state for `session`.
+    ///
+    /// Called when a session ends (explicit close or TTL expiry). After
+    /// flushing, a subsequent [`get`](StateStore::get) for any key in the
+    /// session returns `None`. Flushing an unknown session is a no-op success.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Problem`](octarine_problem::Problem) if the backend cannot
+    /// be reached or the delete fails.
+    async fn flush(&self, session: &SessionId) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::{Arc, RwLock};
+
+    /// A minimal in-test backend proving the trait is object-safe behind
+    /// `Arc<dyn StateStore>` and that its methods are awaitable. This is not
+    /// the production in-memory backend (that ships in #540) — it exists only
+    /// to exercise the contract declared here.
+    #[derive(Default)]
+    struct MockStore {
+        // (session, entity_type, original) -> token
+        inner: RwLock<HashMap<(String, String, String), String>>,
+    }
+
+    #[async_trait]
+    impl StateStore for MockStore {
+        async fn get(&self, session: &SessionId, key: &EntityKey) -> Result<Option<String>> {
+            let guard = self
+                .inner
+                .read()
+                .map_err(|e| octarine_problem::Problem::Runtime(format!("lock poisoned: {e}")))?;
+            Ok(guard
+                .get(&(
+                    session.as_str().to_string(),
+                    key.entity_type.clone(),
+                    key.original.clone(),
+                ))
+                .cloned())
+        }
+
+        async fn put(&self, session: &SessionId, key: &EntityKey, value: String) -> Result<()> {
+            let mut guard = self
+                .inner
+                .write()
+                .map_err(|e| octarine_problem::Problem::Runtime(format!("lock poisoned: {e}")))?;
+            guard.insert(
+                (
+                    session.as_str().to_string(),
+                    key.entity_type.clone(),
+                    key.original.clone(),
+                ),
+                value,
+            );
+            Ok(())
+        }
+
+        async fn list(
+            &self,
+            session: &SessionId,
+            entity_type: &str,
+        ) -> Result<Vec<(String, String)>> {
+            let guard = self
+                .inner
+                .read()
+                .map_err(|e| octarine_problem::Problem::Runtime(format!("lock poisoned: {e}")))?;
+            Ok(guard
+                .iter()
+                .filter(|((sess, etype, _), _)| sess == session.as_str() && etype == entity_type)
+                .map(|((_, _, original), token)| (original.clone(), token.clone()))
+                .collect())
+        }
+
+        async fn flush(&self, session: &SessionId) -> Result<()> {
+            let mut guard = self
+                .inner
+                .write()
+                .map_err(|e| octarine_problem::Problem::Runtime(format!("lock poisoned: {e}")))?;
+            guard.retain(|(sess, _, _), _| sess != session.as_str());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn put_then_get_returns_stored_token() {
+        let store = MockStore::default();
+        let session = SessionId::new("s1");
+        let key = EntityKey::new("PERSON", "Jane Doe");
+
+        assert_eq!(store.get(&session, &key).await.expect("get"), None);
+        store
+            .put(&session, &key, "<PERSON_0>".to_string())
+            .await
+            .expect("put");
+        assert_eq!(
+            store.get(&session, &key).await.expect("get"),
+            Some("<PERSON_0>".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn put_is_idempotent_and_overwrites() {
+        let store = MockStore::default();
+        let session = SessionId::new("s1");
+        let key = EntityKey::new("PERSON", "Jane Doe");
+
+        store
+            .put(&session, &key, "<PERSON_0>".to_string())
+            .await
+            .expect("put");
+        store
+            .put(&session, &key, "<PERSON_1>".to_string())
+            .await
+            .expect("put again");
+        assert_eq!(
+            store.get(&session, &key).await.expect("get"),
+            Some("<PERSON_1>".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_entity_type_within_session() {
+        let store = MockStore::default();
+        let session = SessionId::new("s1");
+        store
+            .put(
+                &session,
+                &EntityKey::new("PERSON", "Jane"),
+                "<PERSON_0>".to_string(),
+            )
+            .await
+            .expect("put");
+        store
+            .put(
+                &session,
+                &EntityKey::new("EMAIL", "jane@acme.com"),
+                "<EMAIL_0>".to_string(),
+            )
+            .await
+            .expect("put");
+
+        let persons = store.list(&session, "PERSON").await.expect("list");
+        assert_eq!(
+            persons,
+            vec![("Jane".to_string(), "<PERSON_0>".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_drops_only_the_named_session() {
+        let store = MockStore::default();
+        let key = EntityKey::new("PERSON", "Jane");
+        let s1 = SessionId::new("s1");
+        let s2 = SessionId::new("s2");
+        store
+            .put(&s1, &key, "<PERSON_0>".to_string())
+            .await
+            .expect("put");
+        store
+            .put(&s2, &key, "<PERSON_0>".to_string())
+            .await
+            .expect("put");
+
+        store.flush(&s1).await.expect("flush");
+        assert_eq!(store.get(&s1, &key).await.expect("get"), None);
+        assert_eq!(
+            store.get(&s2, &key).await.expect("get"),
+            Some("<PERSON_0>".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn usable_as_trait_object_behind_arc() {
+        // Guards the `Send + Sync` + object-safety acceptance criterion.
+        let store: Arc<dyn StateStore> = Arc::new(MockStore::default());
+        let session = SessionId::new("s1");
+        let key = EntityKey::new("PERSON", "Jane");
+        store
+            .put(&session, &key, "<PERSON_0>".to_string())
+            .await
+            .expect("put");
+        assert_eq!(
+            store.get(&session, &key).await.expect("get"),
+            Some("<PERSON_0>".to_string())
+        );
+        // Confirm it crosses a task/thread boundary (Send + Sync).
+        let moved = Arc::clone(&store);
+        tokio::spawn(async move {
+            let _ = moved.flush(&SessionId::new("s1")).await;
+        })
+        .await
+        .expect("join");
+    }
+}

--- a/crates/octarine/src/anonymize/vault/types.rs
+++ b/crates/octarine/src/anonymize/vault/types.rs
@@ -1,0 +1,193 @@
+//! Value types that flow through every [`StateStore`](super::StateStore)
+//! operation.
+//!
+//! [`SessionId`] is the opaque handle that scopes a run of reversible
+//! pseudonymization — every mapping stored in the vault belongs to exactly one
+//! session, and a later deanonymize call must present the same session to
+//! recover the originals. [`EntityKey`] is the composite key under which a
+//! single original value is stored: the detected entity type (`"PERSON"`,
+//! `"EMAIL"`, …) paired with the original PII string.
+//!
+//! Both types are cheap, owned wrappers chosen so they can be used directly as
+//! keys in an in-memory map (the default [`StateStore`](super::StateStore)
+//! backend) — they derive [`Hash`] and [`Eq`].
+
+use std::fmt;
+
+/// An opaque per-session handle that scopes a run of reversible
+/// pseudonymization.
+///
+/// A session groups every `original → token` mapping minted while protecting a
+/// conversation or request. The same `SessionId` must be presented to a later
+/// deanonymize call to recover the original identities. The value is
+/// caller-chosen and carries no entropy requirement of its own — unlike an
+/// authentication session token, it is a routing label, not a credential, so it
+/// is shown in full by [`Display`](fmt::Display) to aid debugging.
+///
+/// # Examples
+///
+/// ```
+/// use octarine::anonymize::SessionId;
+///
+/// let session = SessionId::new("chat-42");
+/// assert_eq!(session.as_str(), "chat-42");
+/// assert_eq!(session.to_string(), "chat-42");
+/// ```
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct SessionId(String);
+
+impl SessionId {
+    /// Creates a session handle from any string-like value.
+    ///
+    /// Infallible: the value is an opaque label, so no validation is applied.
+    #[must_use]
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Borrows the handle as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consumes the handle and returns the inner [`String`].
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for SessionId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for SessionId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for SessionId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<SessionId> for String {
+    fn from(id: SessionId) -> Self {
+        id.0
+    }
+}
+
+/// The composite key a single original value is stored under within a session.
+///
+/// A vault entry maps one [`EntityKey`] to one stable token. The
+/// [`entity_type`](EntityKey::entity_type) (e.g. `"PERSON"`, `"EMAIL"`) is kept
+/// alongside the [`original`](EntityKey::original) value so that the store can
+/// allocate per-type token indices (`<PERSON_0>`, `<EMAIL_0>`) and so that
+/// [`list`](super::StateStore::list) can return every mapping for a given type.
+///
+/// # Examples
+///
+/// ```
+/// use octarine::anonymize::EntityKey;
+///
+/// let key = EntityKey::new("PERSON", "Jane Doe");
+/// assert_eq!(key.entity_type, "PERSON");
+/// assert_eq!(key.original, "Jane Doe");
+/// ```
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct EntityKey {
+    /// The detected entity label, e.g. `"PERSON"` or `"EMAIL"`.
+    pub entity_type: String,
+    /// The original (pre-anonymization) value of the detected span.
+    pub original: String,
+}
+
+impl EntityKey {
+    /// Creates a key from an entity type and the original value it covers.
+    #[must_use]
+    pub fn new(entity_type: impl Into<String>, original: impl Into<String>) -> Self {
+        Self {
+            entity_type: entity_type.into(),
+            original: original.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn session_id_round_trips_through_accessors() {
+        let session = SessionId::new("chat-42");
+        assert_eq!(session.as_str(), "chat-42");
+        assert_eq!(session.clone().into_inner(), "chat-42");
+        assert_eq!(session.as_ref(), "chat-42");
+    }
+
+    #[test]
+    fn session_id_displays_full_value() {
+        // Unlike an auth credential, the handle is a routing label shown in full.
+        let session = SessionId::new("a-deliberately-long-session-handle");
+        assert_eq!(session.to_string(), "a-deliberately-long-session-handle");
+    }
+
+    #[test]
+    fn session_id_from_conversions() {
+        assert_eq!(SessionId::from("borrowed").as_str(), "borrowed");
+        assert_eq!(SessionId::from("owned".to_string()).as_str(), "owned");
+        let back: String = SessionId::new("x").into();
+        assert_eq!(back, "x");
+    }
+
+    #[test]
+    fn session_id_is_usable_as_a_map_key() {
+        let mut map = HashMap::new();
+        map.insert(SessionId::new("s1"), 1);
+        map.insert(SessionId::new("s2"), 2);
+        assert_eq!(map.get(&SessionId::new("s1")), Some(&1));
+        assert_eq!(map.get(&SessionId::new("missing")), None);
+    }
+
+    #[test]
+    fn entity_key_exposes_fields() {
+        let key = EntityKey::new("PERSON", "Jane Doe");
+        assert_eq!(key.entity_type, "PERSON");
+        assert_eq!(key.original, "Jane Doe");
+    }
+
+    #[test]
+    fn entity_key_equality_distinguishes_type_and_value() {
+        let a = EntityKey::new("PERSON", "Jane Doe");
+        let b = EntityKey::new("PERSON", "Jane Doe");
+        let different_type = EntityKey::new("EMAIL", "Jane Doe");
+        let different_value = EntityKey::new("PERSON", "John Roe");
+        assert_eq!(a, b);
+        assert_ne!(a, different_type);
+        assert_ne!(a, different_value);
+    }
+
+    #[test]
+    fn entity_key_is_usable_as_a_map_key() {
+        let mut map = HashMap::new();
+        map.insert(EntityKey::new("PERSON", "Jane Doe"), "<PERSON_0>");
+        assert_eq!(
+            map.get(&EntityKey::new("PERSON", "Jane Doe")),
+            Some(&"<PERSON_0>")
+        );
+        assert_eq!(map.get(&EntityKey::new("EMAIL", "Jane Doe")), None);
+    }
+}

--- a/docs/anonymize/token-vault.md
+++ b/docs/anonymize/token-vault.md
@@ -1,0 +1,99 @@
+# Token Vault — Reversible Pseudonymization
+
+The **token vault** is octarine's persistence layer for reversible
+pseudonymization: replacing detected PII with stable tokens
+(`<PERSON_0>`, `<EMAIL_0>`, …) that can later be reversed back to the original
+values within the same session.
+
+This is the headline pattern for protecting LLM prompts — anonymize a prompt
+before sending it to a model, then rehydrate the model's response with the
+original identities.
+
+> **Status**: this page documents the foundational surface
+> (`StateStore` + `SessionId` + `EntityKey`). Backends and the InstanceCounter
+> operators that consume it are tracked as follow-up work (see
+> [Roadmap](#roadmap)).
+
+## Surface
+
+The surface lives under `octarine::anonymize` and consists of two value types
+and one trait.
+
+### `SessionId`
+
+An opaque, caller-chosen handle that scopes a single run of pseudonymization.
+Every mapping in the vault belongs to exactly one session, and the same
+`SessionId` must be presented to reverse those mappings later. Unlike an
+authentication session token, it carries no entropy requirement — it is a
+routing label, not a credential.
+
+```rust
+use octarine::anonymize::SessionId;
+
+let session = SessionId::new("chat-42");
+assert_eq!(session.as_str(), "chat-42");
+```
+
+### `EntityKey`
+
+The composite key a single original value is stored under: the detected
+`entity_type` (e.g. `"PERSON"`, `"EMAIL"`) paired with the `original` value.
+Keeping the type alongside the value lets a backend allocate per-type token
+indices and enumerate every mapping for a given type.
+
+```rust
+use octarine::anonymize::EntityKey;
+
+let key = EntityKey::new("PERSON", "Jane Doe");
+assert_eq!(key.entity_type, "PERSON");
+```
+
+### `StateStore`
+
+The backend-agnostic `async` trait that records each `(session, key) → token`
+mapping. Implementations own their concurrency control so that concurrent
+callers never mint divergent tokens for the same original.
+
+| Method  | Contract                                                           |
+| ------- | ------------------------------------------------------------------ |
+| `get`   | Returns the stored token for a key, or `None`.                     |
+| `put`   | Stores a token for a key; idempotent, overwrites; atomic.          |
+| `list`  | Returns every `(original, token)` pair for an `entity_type`.       |
+| `flush` | Drops all state for a session (session-close / TTL expiry).        |
+
+A store is shared across threads as `Arc<dyn StateStore>`.
+
+## Worked example (planned)
+
+Once an in-memory backend and the InstanceCounter operators land, the full
+round trip looks like this:
+
+```text
+let store: Arc<dyn StateStore> = Arc::new(InMemoryStore::new());
+let session = SessionId::new("chat-42");
+
+// 1. Anonymize: "Email Jane Doe at jane@acme.com"
+//             -> "Email <PERSON_0> at <EMAIL_0>"
+// 2. Send the anonymized prompt to the model.
+// 3. Deanonymize the reply, reversing tokens back to originals.
+// 4. flush(&session) when the conversation ends.
+```
+
+## Why octarine over Presidio
+
+Presidio's `InstanceCounterAnonymizer` lives in a sample notebook with a
+hand-rolled dictionary that explicitly disclaims thread safety. Octarine
+promotes it to a first-class, backend-agnostic trait where each backend
+(in-memory, Redis, Postgres) is thread-safe by construction.
+
+## Roadmap
+
+| Capability                       | Issue |
+| -------------------------------- | ----- |
+| `StateStore` trait + value types | #539  |
+| In-memory backend (default)      | #540  |
+| Redis backend (`redis` feature)  | #541  |
+| Postgres backend                 | #542  |
+| Session lifecycle API (TTL)      | #544  |
+| InstanceCounter operators        | #543  |
+| Concurrency tests                | #545  |


### PR DESCRIPTION
## Summary

Adds the `anonymize/vault/` module — the backend-agnostic persistence surface behind reversible pseudonymization ("token vault"). This is the foundation issue gating the whole vault chain (#540 in-memory backend → #544 session lifecycle → #543 InstanceCounter operators → #545 concurrency tests).

- **`SessionId`** — opaque per-session handle (newtype over `String`). `Display` shows the full value since it is a routing label, not a credential.
- **`EntityKey`** — composite `{ entity_type, original }` key; `Hash`/`Eq`/`Clone`/`Debug`, usable directly as a map key.
- **`StateStore`** — `#[async_trait]` trait with `get`/`put`/`list`/`flush`, returning `octarine_problem::Result`. Trait-level worked LLM-protection example plus per-method contract docs (idempotent `put`, `list` filters by type, `flush` drops a session).
- **`docs/anonymize/token-vault.md`** — documents the surface, the Presidio comparison, and the backend/operator roadmap.

Scope is **trait + value types + docs only** — backends and the InstanceCounter operators that consume this surface are follow-up issues. Mirrors the existing `observe::writers::database::DatabaseBackend` `#[async_trait]` pattern.

## Test plan

- `just test-mod "anonymize::vault"` — 12 unit tests (type round-trips, `Hash`/`Eq` as map keys, `Display`, `From` conversions; a `MockStore` proving object-safety behind `Arc<dyn StateStore>` + `Send + Sync` across a `tokio::spawn` boundary).
- 2 new doctests on `SessionId`/`EntityKey` examples.
- `just clippy` (deny-level, clean), `just arch-check` (exit 0), `just doc` (`-D warnings`, clean), `rumdl` markdown lint clean.
- Full `just test-octarine` suite: 7782 passed / 29 skipped.

Closes #539