### PR TITLE
refactor(anonymize): async session-aware engine path (sans-IO core)

### DIFF
--- a/crates/octarine/src/anonymize/engine.rs
+++ b/crates/octarine/src/anonymize/engine.rs
@@ -15,13 +15,14 @@
 //! original all stay correctly aligned with no delta arithmetic.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use octarine_problem::{Problem, Result};
 
 use super::operators::{Mask, Redact, Replace};
 use super::{
-    ConflictResolutionStrategy, EngineResult, Operator, OperatorConfig, OperatorResult, PiiSpan,
-    RecognizerResult,
+    AsyncOperator, ConflictResolutionStrategy, EngineResult, Operator, OperatorConfig,
+    OperatorResult, PiiSpan, RecognizerResult, SessionId, StateStore,
 };
 use crate::observe;
 use crate::observe::metrics::{increment_by, record};
@@ -35,6 +36,15 @@ crate::define_metrics! {
 /// The operator config key the engine falls back to for entities with no
 /// explicit operator and no `DEFAULT` entry.
 const DEFAULT_OPERATOR_KEY: &str = "DEFAULT";
+
+/// A resolved replacement for one applied span: the transformed text plus the
+/// name of the operator that produced it. Threaded from a shell's resolution
+/// step into the sans-IO [`splice`](AnonymizerEngine::splice) core so that core
+/// performs no operator dispatch.
+struct Replacement {
+    text: String,
+    operator: String,
+}
 
 /// Applies configurable per-entity operators to detected PII spans.
 ///
@@ -65,6 +75,8 @@ const DEFAULT_OPERATOR_KEY: &str = "DEFAULT";
 /// ```
 pub struct AnonymizerEngine {
     registry: HashMap<String, Box<dyn Operator>>,
+    async_registry: HashMap<String, Box<dyn AsyncOperator>>,
+    store: Option<Arc<dyn StateStore>>,
     conflict: ConflictResolutionStrategy,
     emit_events: bool,
 }
@@ -73,8 +85,12 @@ impl std::fmt::Debug for AnonymizerEngine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut names: Vec<&str> = self.registry.keys().map(String::as_str).collect();
         names.sort_unstable();
+        let mut async_names: Vec<&str> = self.async_registry.keys().map(String::as_str).collect();
+        async_names.sort_unstable();
         f.debug_struct("AnonymizerEngine")
             .field("operators", &names)
+            .field("async_operators", &async_names)
+            .field("has_store", &self.store.is_some())
             .field("conflict", &self.conflict)
             .field("emit_events", &self.emit_events)
             .finish()
@@ -95,6 +111,8 @@ impl AnonymizerEngine {
     pub fn new() -> Self {
         let mut engine = Self {
             registry: HashMap::new(),
+            async_registry: HashMap::new(),
+            store: None,
             conflict: ConflictResolutionStrategy::default(),
             emit_events: true,
         };
@@ -118,6 +136,36 @@ impl AnonymizerEngine {
     #[must_use]
     pub fn with_operator(mut self, operator: Box<dyn Operator>) -> Self {
         self.register(operator);
+        self
+    }
+
+    /// Registers a session-aware [`AsyncOperator`], returning `self` for
+    /// chaining.
+    ///
+    /// Async operators are reached only by
+    /// [`anonymize_async`](AnonymizerEngine::anonymize_async) and
+    /// [`deanonymize_async`](AnonymizerEngine::deanonymize_async); the
+    /// synchronous [`anonymize`](AnonymizerEngine::anonymize) path never invokes
+    /// them. On the async path an async operator shadows a sync operator of the
+    /// same name. Most store-backed operators also need a store injected with
+    /// [`with_store`](AnonymizerEngine::with_store).
+    #[must_use]
+    pub fn with_async_operator(mut self, operator: Box<dyn AsyncOperator>) -> Self {
+        self.async_registry
+            .insert(operator.operator_name().to_string(), operator);
+        self
+    }
+
+    /// Injects the token-vault [`StateStore`] the async path resolves reversible
+    /// tokens through, returning `self` for chaining.
+    ///
+    /// The store is shared as `Arc<dyn StateStore>` and handed to each
+    /// [`AsyncOperator`] per span. The synchronous path ignores it entirely —
+    /// vault access is async-only by design (see the operator module's
+    /// sync/async boundary invariant).
+    #[must_use]
+    pub fn with_store(mut self, store: Arc<dyn StateStore>) -> Self {
+        self.store = Some(store);
         self
     }
 
@@ -185,7 +233,159 @@ impl AnonymizerEngine {
         outcome
     }
 
+    /// Anonymizes `text` on the **async, session-aware** path, resolving
+    /// reversible tokens through the injected [`StateStore`] within `session`.
+    ///
+    /// This is the asynchronous shell over the same sans-IO splice core as
+    /// [`anonymize`](Self::anonymize). For each
+    /// applied span it prefers a registered [`AsyncOperator`] (handed the store
+    /// and session so it can mint a stable token), falling back to a synchronous
+    /// [`Operator`] — a fixed transform — when no async operator is configured
+    /// for that entity's operator name. Register async operators with
+    /// [`with_async_operator`](Self::with_async_operator) and the store with
+    /// [`with_store`](Self::with_store).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Problem`] if an operator config names an unregistered
+    /// operator, if a config is rejected by `validate`, if a span lies outside
+    /// `text` or on a non-char boundary, if an async operator needs a store but
+    /// none was injected, or if an operator's transform or store I/O fails.
+    pub async fn anonymize_async(
+        &self,
+        text: &str,
+        results: Vec<RecognizerResult>,
+        operators: &HashMap<String, OperatorConfig>,
+        session: &SessionId,
+    ) -> Result<EngineResult> {
+        self.run_async(text, results, operators, session).await
+    }
+
+    /// Reverses a previously anonymized `text` on the async, session-aware path,
+    /// restoring originals from the tokens recorded in the [`StateStore`] for
+    /// `session`.
+    ///
+    /// Mechanically identical to [`anonymize_async`](Self::anonymize_async): the
+    /// direction is determined by which operators the caller configured —
+    /// register deanonymizing [`AsyncOperator`]s (and matching
+    /// [`OperatorConfig`] names) that read tokens back out of the store, mirror
+    /// of the sync [`Custom`](crate::anonymize::Custom) /
+    /// [`Custom::deanonymizer`](crate::anonymize::Custom::deanonymizer) pairing.
+    /// It exists as a named entry point so reversing reads as `deanonymize`, not
+    /// `anonymize`.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`anonymize_async`](Self::anonymize_async).
+    pub async fn deanonymize_async(
+        &self,
+        text: &str,
+        results: Vec<RecognizerResult>,
+        operators: &HashMap<String, OperatorConfig>,
+        session: &SessionId,
+    ) -> Result<EngineResult> {
+        self.run_async(text, results, operators, session).await
+    }
+
+    /// The instrumented async shell shared by
+    /// [`anonymize_async`](Self::anonymize_async) and
+    /// [`deanonymize_async`](Self::deanonymize_async).
+    async fn run_async(
+        &self,
+        text: &str,
+        results: Vec<RecognizerResult>,
+        operators: &HashMap<String, OperatorConfig>,
+        session: &SessionId,
+    ) -> Result<EngineResult> {
+        let start = std::time::Instant::now();
+        let outcome = self
+            .anonymize_async_inner(text, results, operators, session)
+            .await;
+
+        if self.emit_events {
+            record(
+                metric_names::anonymize_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            match &outcome {
+                Ok(result) => {
+                    increment_by(metric_names::spans_operated(), result.items.len() as u64);
+                    observe::debug(
+                        "anonymize",
+                        format!("anonymized {} span(s) (async)", result.items.len()),
+                    );
+                }
+                Err(_) => {
+                    increment_by(metric_names::errors(), 1);
+                }
+            }
+        }
+
+        outcome
+    }
+
+    /// The un-instrumented core of the async path: validate, resolve overlaps,
+    /// select applied spans, resolve each replacement through the async (then
+    /// sync) registry, then hand the parallel replacements to the sans-IO
+    /// [`splice`](Self::splice) core.
+    async fn anonymize_async_inner(
+        &self,
+        text: &str,
+        results: Vec<RecognizerResult>,
+        operators: &HashMap<String, OperatorConfig>,
+        session: &SessionId,
+    ) -> Result<EngineResult> {
+        self.validate_operators(&results, operators)?;
+
+        let resolved = self.resolve_conflicts(results);
+        let applied = dedupe_overlaps(&resolved);
+
+        let mut replacements: Vec<Replacement> = Vec::with_capacity(applied.len());
+        for span in &applied {
+            let original = text
+                .get(span.start..span.end)
+                .ok_or_else(|| span_error(text, span.start, span.end))?;
+            let config = self.config_for(&span.entity_type, operators);
+
+            let replacement = if let Some(operator) = self.async_registry.get(&config.operator_name)
+            {
+                // Async operators may read or write the vault, so a store must
+                // have been injected.
+                let store = self.store.as_deref().ok_or_else(|| {
+                    Problem::Validation(format!(
+                        "async operator '{}' requires a StateStore; call with_store(..)",
+                        config.operator_name
+                    ))
+                })?;
+                let text = operator
+                    .operate_async(original, &span.entity_type, &config, store, session)
+                    .await?;
+                Replacement {
+                    text,
+                    operator: operator.operator_name().to_string(),
+                }
+            } else {
+                // Fall back to a synchronous fixed transform.
+                let operator = self.lookup(&config.operator_name)?;
+                let text = operator.operate(original, &span.entity_type, &config)?;
+                Replacement {
+                    text,
+                    operator: operator.operator_name().to_string(),
+                }
+            };
+
+            replacements.push(replacement);
+        }
+
+        self.splice(text, &applied, &replacements)
+    }
+
     /// The un-instrumented core of [`anonymize`](AnonymizerEngine::anonymize).
+    ///
+    /// This is the synchronous shell over the sans-IO [`splice`](Self::splice)
+    /// core: it validates configs, resolves overlaps, selects the spans that
+    /// will actually be applied, resolves each one's replacement through the
+    /// **sync** operator registry (a fixed transform, no I/O), then splices.
     fn anonymize_inner(
         &self,
         text: &str,
@@ -197,43 +397,65 @@ impl AnonymizerEngine {
         self.validate_operators(&results, operators)?;
 
         let resolved = self.resolve_conflicts(results);
+        let applied = dedupe_overlaps(&resolved);
 
+        // Resolve each applied span's replacement via the sync registry. This is
+        // the only step that differs between the sync and async shells; both
+        // then hand the parallel replacements to the same `splice` core.
+        let mut replacements: Vec<Replacement> = Vec::with_capacity(applied.len());
+        for span in &applied {
+            let original = text
+                .get(span.start..span.end)
+                .ok_or_else(|| span_error(text, span.start, span.end))?;
+            let config = self.config_for(&span.entity_type, operators);
+            let operator = self.lookup(&config.operator_name)?;
+            let text = operator.operate(original, &span.entity_type, &config)?;
+            replacements.push(Replacement {
+                text,
+                operator: operator.operator_name().to_string(),
+            });
+        }
+
+        self.splice(text, &applied, &replacements)
+    }
+
+    /// Splices `replacements` into `text` at the `applied` spans — the shared
+    /// sans-IO core of both the sync and async paths.
+    ///
+    /// `applied` must be the gap-free, in-order span selection from
+    /// [`dedupe_overlaps`] and `replacements` its parallel resolved output (one
+    /// entry per applied span, same order). The rewrite copies the verbatim gaps
+    /// between spans and pushes each replacement in place, reading output offsets
+    /// from the length built so far so any replacement size stays aligned. This
+    /// function performs **no operator dispatch and no I/O**; all transforms are
+    /// already resolved by the caller.
+    fn splice(
+        &self,
+        text: &str,
+        applied: &[&RecognizerResult],
+        replacements: &[Replacement],
+    ) -> Result<EngineResult> {
         let mut output = String::with_capacity(text.len());
-        let mut items: Vec<OperatorResult> = Vec::new();
+        let mut items: Vec<OperatorResult> = Vec::with_capacity(applied.len());
         let mut cursor: usize = 0;
 
-        for span in &resolved {
-            // Skip spans that overlap already-consumed text (possible under the
-            // `None` strategy, which performs no overlap resolution).
-            if span.start < cursor {
-                continue;
-            }
-
+        for (span, replacement) in applied.iter().zip(replacements) {
             // Copy the verbatim gap before this span.
             let gap = text
                 .get(cursor..span.start)
                 .ok_or_else(|| span_error(text, cursor, span.start))?;
             output.push_str(gap);
 
-            // Extract the original span text (validates bounds + char boundary).
-            let original = text
-                .get(span.start..span.end)
-                .ok_or_else(|| span_error(text, span.start, span.end))?;
-
-            let config = self.config_for(&span.entity_type, operators);
-            let operator = self.lookup(&config.operator_name)?;
-            let replacement = operator.operate(original, &span.entity_type, &config)?;
-
             let out_start = output.len();
-            output.push_str(&replacement);
+            output.push_str(&replacement.text);
             let out_end = output.len();
 
             items.push(OperatorResult::new(
                 span.entity_type.clone(),
                 out_start,
                 out_end,
-                Some(replacement),
-                Some(operator.operator_name().to_string()),
+                Some(replacement.text.clone()),
+                Some(replacement.operator.clone()),
             )?);
 
             cursor = span.end;
@@ -255,6 +477,10 @@ impl AnonymizerEngine {
 
     /// Validates the operator config for every distinct entity type in
     /// `results`, ensuring each names a registered operator that accepts it.
+    ///
+    /// An operator name is satisfied by either the synchronous registry or the
+    /// async registry, so a config naming an async-only operator validates on
+    /// both paths (it simply never runs on the sync path).
     fn validate_operators(
         &self,
         results: &[RecognizerResult],
@@ -262,8 +488,12 @@ impl AnonymizerEngine {
     ) -> Result<()> {
         for span in results {
             let config = self.config_for(&span.entity_type, operators);
-            let operator = self.lookup(&config.operator_name)?;
-            operator.validate(&config)?;
+            if let Some(operator) = self.async_registry.get(&config.operator_name) {
+                operator.validate(&config)?;
+            } else {
+                let operator = self.lookup(&config.operator_name)?;
+                operator.validate(&config)?;
+            }
         }
         Ok(())
     }
@@ -310,6 +540,29 @@ impl AnonymizerEngine {
             ConflictResolutionStrategy::RemoveIntersections => remove_intersections(results),
         }
     }
+}
+
+/// Selects, from conflict-resolved and `(start, end)`-sorted detections, the
+/// spans that will actually be applied — dropping any span that overlaps text a
+/// kept span already consumed.
+///
+/// This is the post-resolution skip that the `None`
+/// [`ConflictResolutionStrategy`] leaves to the rewrite (other strategies
+/// already remove overlaps). It is factored out of the splice loop so a
+/// replacement is resolved exactly once per applied span: critical on the async
+/// path, where resolving a span may mint a vault token — a skipped span must
+/// never mint one.
+fn dedupe_overlaps(resolved: &[RecognizerResult]) -> Vec<&RecognizerResult> {
+    let mut applied: Vec<&RecognizerResult> = Vec::with_capacity(resolved.len());
+    let mut cursor: usize = 0;
+    for span in resolved {
+        if span.start < cursor {
+            continue;
+        }
+        applied.push(span);
+        cursor = span.end;
+    }
+    applied
 }
 
 /// Builds a [`Problem`] describing a span that is out of bounds or not on a
@@ -685,5 +938,263 @@ mod tests {
             .anonymize("Bob", vec![rr("PERSON", 0, 3, 0.9)], &HashMap::new())
             .expect("anon");
         assert_eq!(out.text.as_deref(), Some("<PERSON>"));
+    }
+
+    // --- Async session-aware path -------------------------------------------
+
+    use std::sync::{Arc, RwLock};
+
+    use async_trait::async_trait;
+
+    use crate::anonymize::{EntityKey, OperatorType};
+
+    /// An in-test [`StateStore`] keyed by `(session, entity_type, original)`.
+    /// Mirrors the vault's private test mock (which is not exported); exists so
+    /// the engine's async path can be exercised end to end.
+    #[derive(Default)]
+    struct MemStore {
+        inner: RwLock<HashMap<(String, String, String), String>>,
+    }
+
+    #[async_trait]
+    impl StateStore for MemStore {
+        async fn get(&self, session: &SessionId, key: &EntityKey) -> Result<Option<String>> {
+            let g = self
+                .inner
+                .read()
+                .map_err(|e| Problem::Runtime(format!("poison: {e}")))?;
+            Ok(g.get(&(
+                session.as_str().to_string(),
+                key.entity_type.clone(),
+                key.original.clone(),
+            ))
+            .cloned())
+        }
+
+        async fn put(&self, session: &SessionId, key: &EntityKey, value: String) -> Result<()> {
+            let mut g = self
+                .inner
+                .write()
+                .map_err(|e| Problem::Runtime(format!("poison: {e}")))?;
+            g.insert(
+                (
+                    session.as_str().to_string(),
+                    key.entity_type.clone(),
+                    key.original.clone(),
+                ),
+                value,
+            );
+            Ok(())
+        }
+
+        async fn list(
+            &self,
+            session: &SessionId,
+            entity_type: &str,
+        ) -> Result<Vec<(String, String)>> {
+            let g = self
+                .inner
+                .read()
+                .map_err(|e| Problem::Runtime(format!("poison: {e}")))?;
+            Ok(g.iter()
+                .filter(|((s, e, _), _)| s == session.as_str() && e == entity_type)
+                .map(|((_, _, o), t)| (o.clone(), t.clone()))
+                .collect())
+        }
+
+        async fn flush(&self, session: &SessionId) -> Result<()> {
+            let mut g = self
+                .inner
+                .write()
+                .map_err(|e| Problem::Runtime(format!("poison: {e}")))?;
+            g.retain(|(s, _, _), _| s != session.as_str());
+            Ok(())
+        }
+    }
+
+    /// A store-backed `InstanceCounter`-style operator: mints `<TYPE_n>` tokens,
+    /// stable per original within a session.
+    struct Counter;
+
+    #[async_trait]
+    impl AsyncOperator for Counter {
+        async fn operate_async(
+            &self,
+            text: &str,
+            entity_type: &str,
+            _config: &OperatorConfig,
+            store: &dyn StateStore,
+            session: &SessionId,
+        ) -> Result<String> {
+            let key = EntityKey::new(entity_type, text);
+            if let Some(token) = store.get(session, &key).await? {
+                return Ok(token);
+            }
+            let idx = store.list(session, entity_type).await?.len();
+            let token = format!("<{entity_type}_{idx}>");
+            store.put(session, &key, token.clone()).await?;
+            Ok(token)
+        }
+
+        fn operator_name(&self) -> &'static str {
+            "counter"
+        }
+    }
+
+    /// The reverse of [`Counter`]: resolves a token span back to its original by
+    /// reading the session's mappings out of the store.
+    struct CounterReverse;
+
+    #[async_trait]
+    impl AsyncOperator for CounterReverse {
+        async fn operate_async(
+            &self,
+            text: &str,
+            entity_type: &str,
+            _config: &OperatorConfig,
+            store: &dyn StateStore,
+            session: &SessionId,
+        ) -> Result<String> {
+            for (original, token) in store.list(session, entity_type).await? {
+                if token == text {
+                    return Ok(original);
+                }
+            }
+            Ok(text.to_string())
+        }
+
+        fn operator_name(&self) -> &'static str {
+            "counter_reverse"
+        }
+
+        fn operator_type(&self) -> OperatorType {
+            OperatorType::Deanonymize
+        }
+    }
+
+    fn counter_ops(name: &str) -> HashMap<String, OperatorConfig> {
+        let mut ops = HashMap::new();
+        ops.insert(
+            DEFAULT_OPERATOR_KEY.to_string(),
+            OperatorConfig::new(name).expect("valid config"),
+        );
+        ops
+    }
+
+    #[tokio::test]
+    async fn async_path_mints_stable_tokens_per_session() {
+        let store: Arc<dyn StateStore> = Arc::new(MemStore::default());
+        let engine = AnonymizerEngine::new()
+            .with_async_operator(Box::new(Counter))
+            .with_store(Arc::clone(&store));
+        let session = SessionId::new("chat-1");
+
+        // "Jane" appears twice (same token) and "Bob" once (next index).
+        let text = "Jane and Jane and Bob";
+        let results = vec![
+            rr("PERSON", 0, 4, 0.9),
+            rr("PERSON", 9, 13, 0.9),
+            rr("PERSON", 18, 21, 0.9),
+        ];
+
+        let out = engine
+            .anonymize_async(text, results, &counter_ops("counter"), &session)
+            .await
+            .expect("anonymize_async");
+
+        assert_eq!(
+            out.text.as_deref(),
+            Some("<PERSON_0> and <PERSON_0> and <PERSON_1>")
+        );
+        assert_eq!(out.items.len(), 3);
+        assert_eq!(
+            out.items.first().expect("item").operator.as_deref(),
+            Some("counter")
+        );
+    }
+
+    #[tokio::test]
+    async fn async_round_trip_restores_originals() {
+        let store: Arc<dyn StateStore> = Arc::new(MemStore::default());
+        let session = SessionId::new("chat-2");
+        let text = "Jane met Jane";
+
+        // Anonymize through the counter.
+        let anon_engine = AnonymizerEngine::new()
+            .with_async_operator(Box::new(Counter))
+            .with_store(Arc::clone(&store));
+        let anon = anon_engine
+            .anonymize_async(
+                text,
+                vec![rr("PERSON", 0, 4, 0.9), rr("PERSON", 9, 13, 0.9)],
+                &counter_ops("counter"),
+                &session,
+            )
+            .await
+            .expect("anonymize_async");
+        let anon_text = anon.text.clone().expect("text");
+        assert_eq!(anon_text, "<PERSON_0> met <PERSON_0>");
+
+        // Build reverse detections from the produced token spans, then
+        // deanonymize through the reverse operator against the same store.
+        let reverse_results: Vec<RecognizerResult> = anon
+            .items
+            .iter()
+            .map(|item| rr(&item.entity_type, item.start, item.end, 1.0))
+            .collect();
+
+        let deanon_engine = AnonymizerEngine::new()
+            .with_async_operator(Box::new(CounterReverse))
+            .with_store(Arc::clone(&store));
+        let restored = deanon_engine
+            .deanonymize_async(
+                &anon_text,
+                reverse_results,
+                &counter_ops("counter_reverse"),
+                &session,
+            )
+            .await
+            .expect("deanonymize_async");
+
+        assert_eq!(restored.text.as_deref(), Some(text));
+    }
+
+    #[tokio::test]
+    async fn async_path_falls_back_to_sync_operators() {
+        // With no async operator configured, the async path applies the same
+        // fixed transforms as the sync path — no store needed.
+        let engine = AnonymizerEngine::new();
+        let session = SessionId::new("chat-3");
+        let out = engine
+            .anonymize_async(
+                "SSN 123-45-6789.",
+                vec![rr("US_SSN", 4, 15, 0.9)],
+                &HashMap::new(),
+                &session,
+            )
+            .await
+            .expect("anonymize_async");
+        assert_eq!(out.text.as_deref(), Some("SSN <US_SSN>."));
+        assert_eq!(
+            out.items.first().expect("item").operator.as_deref(),
+            Some("replace")
+        );
+    }
+
+    #[tokio::test]
+    async fn async_operator_without_store_errors() {
+        // A configured async operator that needs the vault but no store was
+        // injected fails clearly rather than silently dropping the span.
+        let engine = AnonymizerEngine::new().with_async_operator(Box::new(Counter));
+        let session = SessionId::new("chat-4");
+        let err = engine
+            .anonymize_async(
+                "Bob",
+                vec![rr("PERSON", 0, 3, 0.9)],
+                &counter_ops("counter"),
+                &session,
+            )
+            .await;
+        assert!(err.is_err());
     }
 }

--- a/crates/octarine/src/anonymize/mod.rs
+++ b/crates/octarine/src/anonymize/mod.rs
@@ -14,8 +14,14 @@
 //! - `ConflictResolutionStrategy` — overlap-resolution selector.
 //! - `PiiSpan` — shared half-open span algebra (intersects, contains, …).
 //! - `Operator` — the transformation trait every operator implements.
+//! - `AsyncOperator` — the session-aware async counterpart to `Operator`,
+//!   handed a `StateStore` + `SessionId` to mint and reverse reversible tokens.
+//!   Reached only through the engine's async path; the sync path never touches
+//!   the vault (see the operator module's sync/async boundary invariant).
 //! - `AnonymizerEngine` — applies operators to detected spans with conflict
-//!   resolution and offset tracking.
+//!   resolution and offset tracking. Its synchronous `anonymize` applies fixed
+//!   transforms; `anonymize_async` / `deanonymize_async` inject an
+//!   `Arc<dyn StateStore>` to resolve reversible tokens through the vault.
 //! - `Replace` / `Redact` / `Mask` — the stateless built-in operators.
 //!   `Replace` substitutes a fixed value (or `<ENTITY_TYPE>`), `Redact` deletes
 //!   the span, and `Mask` positionally masks characters (multi-char units and
@@ -56,7 +62,7 @@ mod types;
 mod vault;
 
 pub use engine::AnonymizerEngine;
-pub use operator::Operator;
+pub use operator::{AsyncOperator, Operator};
 pub use operators::{Custom, Mask, Redact, Replace};
 pub use shortcuts::{anonymize, redact_all};
 pub use types::{

--- a/crates/octarine/src/anonymize/operator.rs
+++ b/crates/octarine/src/anonymize/operator.rs
@@ -1,11 +1,35 @@
-//! The [`Operator`] trait — the transformation contract every anonymize
-//! operator implements.
+//! The [`Operator`] / [`AsyncOperator`] transformation contracts every
+//! anonymize operator implements.
 //!
 //! An operator takes the text of a single detected span plus its
 //! [`OperatorConfig`] and returns the replacement text. The
 //! [`AnonymizerEngine`](crate::anonymize::AnonymizerEngine) owns the
 //! orchestration (sorting, conflict resolution, offset tracking) and calls
 //! operators one span at a time; operators themselves are pure and stateless.
+//!
+//! # Sync / async boundary (load-bearing invariant)
+//!
+//! There are two operator contracts and they are deliberately separate:
+//!
+//! - [`Operator`] is **synchronous** and applies a **fixed transform** — the
+//!   replacement is a pure function of the span text and config (`replace`,
+//!   `redact`, `mask`, a pure `custom` closure). It does **no I/O**.
+//! - [`AsyncOperator`] is **asynchronous** and **session-aware** — it is handed
+//!   an `&dyn StateStore` and a `&SessionId` so it can mint or reverse stable
+//!   tokens through the vault (the `InstanceCounter` family in #543).
+//!
+//! > **Invariant:** the synchronous path only ever applies fixed transforms;
+//! > vault ([`StateStore`](crate::anonymize::StateStore)) access is
+//! > **async-only**.
+//!
+//! This is a documented assumption, not an accident. It keeps the
+//! `observe/pii/redactor` (epic #604, "redaction == anonymization by
+//! construction") fully synchronous, so the hot per-log-line path never has to
+//! `block_on(...)` a store inside a tokio runtime — a panic/deadlock footgun —
+//! and it avoids dual-colouring every pure primitive. If a synchronous caller
+//! ever genuinely needs to read the vault, `StateStore` itself would need a
+//! sync face; that is the trigger to revisit this split **deliberately** rather
+//! than break it silently. See `docs/anonymize/token-vault.md`.
 //!
 //! # Implementing an operator
 //!
@@ -38,9 +62,10 @@
 //! # Ok::<(), octarine_problem::Problem>(())
 //! ```
 
+use async_trait::async_trait;
 use octarine_problem::Result;
 
-use super::{OperatorConfig, OperatorType};
+use super::{OperatorConfig, OperatorType, SessionId, StateStore};
 
 /// A pure, stateless transformation applied to one detected span.
 ///
@@ -89,6 +114,81 @@ pub trait Operator: Send + Sync {
     ///
     /// Must match the `operator_name` callers place in an [`OperatorConfig`]
     /// (e.g. `"replace"`, `"redact"`). Lowercase by convention.
+    fn operator_name(&self) -> &'static str;
+
+    /// The direction this operator works in. Defaults to
+    /// [`OperatorType::Anonymize`]; deanonymizers override it.
+    fn operator_type(&self) -> OperatorType {
+        OperatorType::Anonymize
+    }
+}
+
+/// A session-aware transformation that may read or write the token vault.
+///
+/// `AsyncOperator` is the asynchronous counterpart to [`Operator`]. Where a
+/// sync operator applies a fixed transform with no I/O, an async operator is
+/// handed an [`&dyn StateStore`](crate::anonymize::StateStore) and a
+/// [`SessionId`] so it can mint a stable token for an original value (and find
+/// the same token again on the next occurrence within the session) or reverse a
+/// previously minted token back to its original. The store-backed
+/// `InstanceCounter` operators (#543) implement this trait.
+///
+/// The [`AnonymizerEngine`](crate::anonymize::AnonymizerEngine) reaches async
+/// operators only through
+/// [`anonymize_async`](crate::anonymize::AnonymizerEngine::anonymize_async) and
+/// [`deanonymize_async`](crate::anonymize::AnonymizerEngine::deanonymize_async),
+/// which inject the store. The synchronous
+/// [`anonymize`](crate::anonymize::AnonymizerEngine::anonymize) path never
+/// touches an async operator or the vault — see the module-level invariant.
+///
+/// Implementors must be `Send + Sync` so an engine can be shared across
+/// threads. The store and session are passed per call (rather than held by the
+/// operator) so one operator instance serves every session and backend.
+#[async_trait]
+pub trait AsyncOperator: Send + Sync {
+    /// Transforms the matched span `text` into its replacement, resolving any
+    /// stable token through `store` within `session`.
+    ///
+    /// `entity_type` is the label of the detected entity (e.g. `"PERSON"`),
+    /// supplied separately so the caller's [`OperatorConfig`] is never mutated.
+    /// `config` carries operator-specific parameters. The returned string may be
+    /// empty, shorter, longer, or the same length as `text` — the engine
+    /// recomputes output offsets either way.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Problem`](octarine_problem::Problem) if the store I/O fails or
+    /// the transformation cannot be performed.
+    async fn operate_async(
+        &self,
+        text: &str,
+        entity_type: &str,
+        config: &OperatorConfig,
+        store: &dyn StateStore,
+        session: &SessionId,
+    ) -> Result<String>;
+
+    /// Validates `config` before any span is processed.
+    ///
+    /// Like [`Operator::validate`], the engine calls this once per distinct
+    /// operator config up front so an invalid configuration fails fast. This
+    /// method is **synchronous and must not touch the store** — it inspects
+    /// config only. The default implementation accepts any config.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`Problem`](octarine_problem::Problem) if `config` is invalid
+    /// for this operator.
+    fn validate(&self, config: &OperatorConfig) -> Result<()> {
+        let _ = config;
+        Ok(())
+    }
+
+    /// The canonical name used to register and look up this operator.
+    ///
+    /// Must match the `operator_name` callers place in an [`OperatorConfig`].
+    /// Lowercase by convention. A name registered as an async operator shadows a
+    /// sync operator of the same name on the async path.
     fn operator_name(&self) -> &'static str;
 
     /// The direction this operator works in. Defaults to

--- a/docs/anonymize/token-vault.md
+++ b/docs/anonymize/token-vault.md
@@ -9,9 +9,10 @@ This is the headline pattern for protecting LLM prompts — anonymize a prompt
 before sending it to a model, then rehydrate the model's response with the
 original identities.
 
-> **Status**: this page documents the foundational surface
-> (`StateStore` + `SessionId` + `EntityKey`). Backends and the InstanceCounter
-> operators that consume it are tracked as follow-up work (see
+> **Status**: the foundational surface (`StateStore` + `SessionId` + `EntityKey`)
+> and the async, session-aware engine path that consumes it (`anonymize_async` /
+> `deanonymize_async` + the `AsyncOperator` trait) have landed. Concrete store
+> backends and the InstanceCounter operators are tracked as follow-up work (see
 > [Roadmap](#roadmap)).
 
 ## Surface
@@ -63,21 +64,91 @@ callers never mint divergent tokens for the same original.
 
 A store is shared across threads as `Arc<dyn StateStore>`.
 
+## Async execution model
+
+Reversible pseudonymization is inherently asynchronous: minting a stable token
+or reversing one is `StateStore` I/O. But the engine is **not** async-first.
+Epic #604 converges the synchronous `observe/pii/redactor` onto the same
+`AnonymizerEngine` ("redaction == anonymization by construction"), and that hot
+per-log-line path must never `block_on(..)` a store inside a tokio runtime — a
+panic/deadlock footgun. So the engine is split **sans-IO**: one shared
+synchronous rewrite core, with a sync shell and an async shell over it.
+
+```text
+        ┌─────────────────────────────┐
+        │  sync rewrite CORE           │  ← the shared primitive
+        │  (conflict res, offsets,     │     pure CPU, no I/O, no async
+        │   span splicing)             │
+        └─────────────────────────────┘
+            ▲                    ▲
+   sync shell                async shell
+   (logs/redactor:           (LLM prompt / stream filter:
+    no store, fixed           await StateStore to resolve
+    transforms)               tokens, then call the core)
+```
+
+- **Sync shell** — `AnonymizerEngine::anonymize(text, results, operators)`
+  applies synchronous [`Operator`]s (fixed transforms: `replace`, `redact`,
+  `mask`, pure `custom`). No store, no session, unchanged from before.
+- **Async shell** — `anonymize_async(text, results, operators, &session)` and
+  `deanonymize_async(..)` are handed an injected `Arc<dyn StateStore>` (via
+  `with_store(..)`). For each applied span they prefer a registered
+  `AsyncOperator` (via `with_async_operator(..)`), handing it the store and
+  `SessionId` so it can `get`/`put` a stable token, and fall back to a
+  synchronous fixed transform when no async operator is configured for that
+  entity. Both shells then delegate to the **same** sync core for offset
+  tracking and splicing, so a replacement of any length stays aligned.
+
+`AsyncOperator` is the session-aware counterpart to `Operator`; the two coexist.
+Store-backed operators (the `InstanceCounter` family, #543) implement the async
+one — pure operators stay sync.
+
+### The load-bearing invariant
+
+> **The synchronous path only ever applies fixed transforms; vault
+> (`StateStore`) access is async-only.**
+
+This is a deliberate, documented assumption — not an accident — confirmed with
+the maintainer. Its rationale:
+
+- keeps the redactor (#604) fully synchronous, so the hot path never blocks on a
+  store;
+- avoids the `block_on(..)` panic/deadlock footgun inside a tokio runtime; and
+- avoids dual-colouring every pure primitive (detection, format, classification,
+  the redactor's fixed transforms do no I/O and are already callable from async
+  contexts for free).
+
+There is no foreseen requirement for a synchronous caller to read from the
+vault. **Revisit trigger:** if such a requirement ever appears, `StateStore`
+itself would need a synchronous face — at which point this split must be
+reconsidered *deliberately*, not broken silently. The same invariant is
+documented in the `anonymize::operator` and `anonymize::engine` module docs.
+
 ## Worked example (planned)
 
-Once an in-memory backend and the InstanceCounter operators land, the full
+The async engine path and the `AsyncOperator` trait have landed (#609); once an
+in-memory backend (#540) and the InstanceCounter operators (#543) land, the full
 round trip looks like this:
 
 ```text
 let store: Arc<dyn StateStore> = Arc::new(InMemoryStore::new());
+let engine = AnonymizerEngine::new()
+    .with_async_operator(Box::new(InstanceCounter::new()))
+    .with_store(Arc::clone(&store));
 let session = SessionId::new("chat-42");
 
 // 1. Anonymize: "Email Jane Doe at jane@acme.com"
+//    engine.anonymize_async(prompt, results, &operators, &session).await
 //             -> "Email <PERSON_0> at <EMAIL_0>"
 // 2. Send the anonymized prompt to the model.
-// 3. Deanonymize the reply, reversing tokens back to originals.
-// 4. flush(&session) when the conversation ends.
+// 3. Deanonymize the reply, reversing tokens back to originals:
+//    engine.deanonymize_async(reply, results, &operators, &session).await
+// 4. store.flush(&session) when the conversation ends.
 ```
+
+The injected `Arc<dyn StateStore>` and the `anonymize_async` / `deanonymize_async`
+shells exist today (see [Async execution model](#async-execution-model)); only
+the concrete store backend and operator are still follow-up work.
 
 ## Why octarine over Presidio
 
@@ -91,6 +162,7 @@ promotes it to a first-class, backend-agnostic trait where each backend
 | Capability                       | Issue |
 | -------------------------------- | ----- |
 | `StateStore` trait + value types | #539  |
+| Async session-aware engine path  | #609  |
 | In-memory backend (default)      | #540  |
 | Redis backend (`redis` feature)  | #541  |
 | Postgres backend                 | #542  |


### PR DESCRIPTION
## Summary

Adds an **async, session-aware execution path** to `AnonymizerEngine` so store-backed operators (the InstanceCounter family, #543, and any future vault operator) can mint and reverse tokens through the async `StateStore` — built as a **sans-IO core** with thin sync and async shells, **without** making the core engine or the sync `Operator` trait async.

### What changed

- **Sans-IO split** in `engine.rs`: factored the rewrite into a pure `splice()` core (gap-copy, length-based offsets, audit construction) plus a pure `dedupe_overlaps()` span-selection pass. The post-conflict `None`-strategy skip moves **out** of the splice loop into `dedupe_overlaps`, so each applied span resolves its replacement **exactly once** — an async store-backed operator never double-mints a token for a span that would be skipped.
- **`AsyncOperator` trait** (`#[async_trait]`, session- and store-aware) added in `operator.rs`, coexisting with the unchanged sync `Operator`. The four built-ins (`Replace`, `Redact`, `Mask`, `Custom`) stay synchronous.
- **Store injection**: `with_store(Arc<dyn StateStore>)` + `with_async_operator(..)` builders; `anonymize_async(text, results, operators, &session)` and `deanonymize_async(..)` await the store to resolve tokens, then delegate to the **same** sync core. Validation now checks both registries.
- **Documented invariant**: *the sync path only ever applies fixed transforms; vault (`StateStore`) access is async-only* — in the `operator`/`engine` module docs and `docs/anonymize/token-vault.md`, with rationale (keeps the #604 redactor sync, avoids the `block_on` footgun, avoids dual-colouring every primitive) and the revisit trigger.

The synchronous `anonymize()` and the sync `Operator` trait are **unchanged** in signature and behaviour.

## Test plan

- `just preflight` green (fmt + clippy `-D warnings` + arch-check + full test suite + doctests).
- `just doc` green (strict rustdoc).
- New `#[tokio::test]` round-trip coverage in `engine.rs` against an in-test `StateStore`: stable per-session token minting, full anonymize → deanonymize restoration, sync-operator fallback on the async path, and the clear error when an async operator needs a store but none was injected.
- Existing sync engine + integration + operator tests pass untouched (proves the sync path is unchanged).

## Scope

Delivers the async **path and trait only**, proven with an in-test mock. Concrete InstanceCounter operators (#543) and the production in-memory backend (#540) remain follow-up work. Unblocks #543; protects #604 (redactor stays sync). Consumes #608 (StateStore/SessionId/EntityKey).

Closes #609