### PR TITLE
feat(anonymize): Encrypt/Decrypt operators over keyed AEAD (#485)

### DIFF
--- a/crates/octarine/src/anonymize/engine.rs
+++ b/crates/octarine/src/anonymize/engine.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use octarine_problem::{Problem, Result};
 
-use super::operators::{Mask, Redact, Replace};
+use super::operators::{Decrypt, Encrypt, Mask, Redact, Replace};
 use super::{
     AsyncOperator, ConflictResolutionStrategy, EngineResult, Operator, OperatorConfig,
     OperatorResult, PiiSpan, RecognizerResult, SessionId, StateStore,
@@ -105,7 +105,7 @@ impl Default for AnonymizerEngine {
 
 impl AnonymizerEngine {
     /// Creates an engine with the built-in operators (`replace`, `redact`,
-    /// `mask`) and the default
+    /// `mask`, `encrypt`, `decrypt`) and the default
     /// [`ConflictResolutionStrategy::MergeSimilarOrContained`].
     #[must_use]
     pub fn new() -> Self {
@@ -119,6 +119,8 @@ impl AnonymizerEngine {
         engine.register(Box::new(Replace));
         engine.register(Box::new(Redact));
         engine.register(Box::new(Mask));
+        engine.register(Box::new(Encrypt));
+        engine.register(Box::new(Decrypt));
         engine
     }
 
@@ -131,8 +133,8 @@ impl AnonymizerEngine {
 
     /// Registers a custom operator, returning `self` for chaining.
     ///
-    /// An operator whose name matches a built-in (`replace`, `redact`, `mask`)
-    /// replaces it.
+    /// An operator whose name matches a built-in (`replace`, `redact`, `mask`,
+    /// `encrypt`, `decrypt`) replaces it.
     #[must_use]
     pub fn with_operator(mut self, operator: Box<dyn Operator>) -> Self {
         self.register(operator);
@@ -805,6 +807,44 @@ mod tests {
         );
         let err = engine.anonymize("Bob", vec![rr("PERSON", 0, 3, 0.9)], &ops);
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn encrypt_operator_round_trips_through_engine() {
+        use super::super::{Decrypt, Operator};
+
+        // 32 zero key bytes, base64url-no-pad.
+        const KEY_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        let engine = AnonymizerEngine::new().silent();
+        let mut ops = HashMap::new();
+        let mut params = HashMap::new();
+        params.insert("key".to_string(), json!(KEY_B64));
+        ops.insert(
+            "EMAIL".to_string(),
+            OperatorConfig::with_params("encrypt", params.clone()).expect("cfg"),
+        );
+
+        let text = "ping alice@example.com now";
+        // Byte offsets of "alice@example.com": 5..22.
+        let out = engine
+            .anonymize(text, vec![rr("EMAIL", 5, 22, 0.99)], &ops)
+            .expect("anonymize");
+
+        let item = out.items.first().expect("one item");
+        assert_eq!(item.operator.as_deref(), Some("encrypt"));
+        let sealed = item.text.as_deref().expect("ciphertext present");
+        // The engine spliced ciphertext in place of the original address.
+        let rewritten = out.text.as_deref().expect("text");
+        assert!(rewritten.contains(sealed));
+        assert!(!rewritten.contains("alice@example.com"));
+
+        // The sealed value opens back to the original under the same key+entity.
+        let dec_config = OperatorConfig::with_params("decrypt", params).expect("cfg");
+        let opened = Decrypt
+            .operate(sealed, "EMAIL", &dec_config)
+            .expect("decrypt");
+        assert_eq!(opened, "alice@example.com");
     }
 
     #[test]

--- a/crates/octarine/src/anonymize/mod.rs
+++ b/crates/octarine/src/anonymize/mod.rs
@@ -27,7 +27,10 @@
 //!   the span, and `Mask` positionally masks characters (multi-char units and
 //!   tail-masking via `from_end`). `Custom` wraps a caller-supplied closure
 //!   (`Fn(&str) -> Result<String>`) for one-off transforms and stateful
-//!   pseudonymization. Further operators (hash, encrypt, keep) land as
+//!   pseudonymization. `Encrypt` / `Decrypt` seal and open spans with
+//!   authenticated encryption (ChaCha20-Poly1305 or AES-256-GCM), binding the
+//!   ciphertext to the entity type via AAD and offering an opt-in deterministic
+//!   mode for joinable output. Further operators (hash, keep) land as
 //!   follow-up work under the `anonymize/` umbrella.
 //! - `StateStore` / `SessionId` / `EntityKey` — the token-vault surface: the
 //!   backend-agnostic persistence contract behind reversible pseudonymization,
@@ -63,7 +66,7 @@ mod vault;
 
 pub use engine::AnonymizerEngine;
 pub use operator::{AsyncOperator, Operator};
-pub use operators::{Custom, Mask, Redact, Replace};
+pub use operators::{Custom, Decrypt, Encrypt, Mask, Redact, Replace};
 pub use shortcuts::{anonymize, redact_all};
 pub use types::{
     ConflictResolutionStrategy, EngineResult, OperatorConfig, OperatorResult, OperatorType,

--- a/crates/octarine/src/anonymize/operators/decrypt.rs
+++ b/crates/octarine/src/anonymize/operators/decrypt.rs
@@ -1,0 +1,156 @@
+//! Decrypt operator — opens a span sealed by [`Encrypt`](super::Encrypt).
+//!
+//! `Decrypt` is the reversing (`Deanonymize`) counterpart to `Encrypt`. Given
+//! the same key, algorithm, and entity type, it verifies the authentication tag
+//! and returns the original plaintext. Tampering, a wrong key, or a mismatched
+//! entity type fail the tag check — plaintext is never returned on
+//! authentication failure.
+//!
+//! # The cryptography is single-sourced
+//!
+//! All opening is performed by the Layer 1 keyed-AEAD primitive
+//! (`primitives::crypto::encryption::open`), which reads the version and
+//! algorithm from the wire header and verifies the tag before returning. This
+//! operator only parses parameters and delegates.
+
+use octarine_problem::{Problem, Result};
+
+use super::super::operator::Operator;
+use super::super::{OperatorConfig, OperatorType};
+use super::keyed_config;
+use crate::primitives::crypto::encryption::open;
+
+/// Opens AEAD ciphertext produced by [`Encrypt`](super::Encrypt).
+///
+/// Accepts the same key/algorithm/AAD parameters as `Encrypt` (the `algo` field
+/// is not required for opening — the wire format records it — but is accepted
+/// for symmetry and validated if present). See [`Encrypt`](super::Encrypt) for
+/// the full parameter reference.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// use octarine::anonymize::{Decrypt, Encrypt, Operator, OperatorConfig};
+/// use serde_json::json;
+///
+/// let key_b64 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+/// let mut params = HashMap::new();
+/// params.insert("key".to_string(), json!(key_b64));
+/// let enc_config = OperatorConfig::with_params("encrypt", params.clone())?;
+/// let dec_config = OperatorConfig::with_params("decrypt", params)?;
+///
+/// let sealed = Encrypt.operate("123-45-6789", "US_SSN", &enc_config)?;
+/// assert_eq!(Decrypt.operate(&sealed, "US_SSN", &dec_config)?, "123-45-6789");
+///
+/// // Opening under a different entity type fails the tag check.
+/// assert!(Decrypt.operate(&sealed, "EMAIL", &dec_config).is_err());
+/// # Ok::<(), octarine_problem::Problem>(())
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Decrypt;
+
+impl Operator for Decrypt {
+    fn operate(&self, text: &str, entity_type: &str, config: &OperatorConfig) -> Result<String> {
+        let key = keyed_config::resolve_key(config)?;
+        // Validate algo if supplied (symmetry with Encrypt); the wire format is
+        // authoritative for the actual algorithm used.
+        keyed_config::resolve_algo(config)?;
+        let aad = keyed_config::build_aad(entity_type, config);
+
+        let plaintext = open(&key, text, &aad).map_err(Problem::from)?;
+        String::from_utf8(plaintext).map_err(|e| {
+            Problem::Validation(format!(
+                "decrypt operator: plaintext is not valid UTF-8: {e}"
+            ))
+        })
+    }
+
+    /// Validates the key and algorithm parameters before any work is attempted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Problem::Validation`] if no valid key material is configured,
+    /// if both `key` and `password` are supplied, or if `algo` names an
+    /// unsupported algorithm.
+    fn validate(&self, config: &OperatorConfig) -> Result<()> {
+        keyed_config::resolve_key(config)?;
+        keyed_config::resolve_algo(config)?;
+        Ok(())
+    }
+
+    fn operator_name(&self) -> &'static str {
+        "decrypt"
+    }
+
+    fn operator_type(&self) -> OperatorType {
+        OperatorType::Deanonymize
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::super::Encrypt;
+    use super::*;
+    use std::collections::HashMap;
+
+    use base64::Engine;
+    use serde_json::json;
+
+    /// 32 zero bytes, base64url-no-pad.
+    const KEY_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    fn config_with(name: &str, params: &[(&str, serde_json::Value)]) -> OperatorConfig {
+        let mut map = HashMap::new();
+        for (k, v) in params {
+            map.insert((*k).to_string(), v.clone());
+        }
+        OperatorConfig::with_params(name, map).expect("config")
+    }
+
+    #[test]
+    fn round_trip_recovers_plaintext() {
+        let enc = config_with("encrypt", &[("key", json!(KEY_B64))]);
+        let dec = config_with("decrypt", &[("key", json!(KEY_B64))]);
+        let sealed = Encrypt.operate("héllo wörld", "TEXT", &enc).expect("seal");
+        let opened = Decrypt.operate(&sealed, "TEXT", &dec).expect("open");
+        assert_eq!(opened, "héllo wörld");
+    }
+
+    #[test]
+    fn round_trip_aes256gcm() {
+        let params = [("key", json!(KEY_B64)), ("algo", json!("aes256gcm"))];
+        let enc = config_with("encrypt", &params);
+        let dec = config_with("decrypt", &params);
+        let sealed = Encrypt.operate("secret", "EMAIL", &enc).expect("seal");
+        assert_eq!(
+            Decrypt.operate(&sealed, "EMAIL", &dec).expect("open"),
+            "secret"
+        );
+    }
+
+    #[test]
+    fn wrong_entity_type_fails() {
+        let enc = config_with("encrypt", &[("key", json!(KEY_B64))]);
+        let dec = config_with("decrypt", &[("key", json!(KEY_B64))]);
+        let sealed = Encrypt.operate("secret", "EMAIL", &enc).expect("seal");
+        assert!(Decrypt.operate(&sealed, "PHONE", &dec).is_err());
+    }
+
+    #[test]
+    fn wrong_key_fails() {
+        let enc = config_with("encrypt", &[("key", json!(KEY_B64))]);
+        // A different 32-byte key (all 0x01 → "AQEB...").
+        let other_key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([1u8; 32]);
+        let dec = config_with("decrypt", &[("key", json!(other_key))]);
+        let sealed = Encrypt.operate("secret", "EMAIL", &enc).expect("seal");
+        assert!(Decrypt.operate(&sealed, "EMAIL", &dec).is_err());
+    }
+
+    #[test]
+    fn operator_type_is_deanonymize() {
+        assert_eq!(Decrypt.operator_type(), OperatorType::Deanonymize);
+    }
+}

--- a/crates/octarine/src/anonymize/operators/encrypt.rs
+++ b/crates/octarine/src/anonymize/operators/encrypt.rs
@@ -1,0 +1,260 @@
+//! Encrypt operator — seals a span with authenticated encryption (AEAD).
+//!
+//! `Encrypt` replaces a detected span with a base64 versioned ciphertext sealed
+//! under a caller-supplied key. It is the reversible counterpart to
+//! [`Decrypt`](super::Decrypt): the same key, algorithm, and entity type recover
+//! the plaintext.
+//!
+//! # Octarine vs Presidio
+//!
+//! Presidio's `Encrypt` is unauthenticated AES-CBC with raw-UTF-8-bytes as the
+//! key, no AAD, and no version byte. Every one of those is a known footgun.
+//! Octarine's `Encrypt`:
+//!
+//! - **Authenticates** with ChaCha20-Poly1305 (default) or AES-256-GCM — never
+//!   AES-CBC. Tampering is detected on decrypt.
+//! - **Derives** keys from string `password` + `salt` via Argon2; raw UTF-8
+//!   bytes are never used as a key.
+//! - **Binds** the ciphertext to the entity type via AAD, so it cannot be
+//!   replayed under a different entity type.
+//! - **Versions** the wire format, so the algorithm can be migrated later.
+//! - **Optionally deterministic** (`mode = "deterministic"`): identical inputs
+//!   produce identical ciphertext for joinability across documents — the opt-in
+//!   that Presidio issue #1033 has wanted for years — without ever letting the
+//!   caller control the nonce.
+//!
+//! # The cryptography is single-sourced
+//!
+//! All sealing is performed by the Layer 1 keyed-AEAD primitive
+//! (`primitives::crypto::encryption::seal`). This operator only parses and
+//! validates parameters, then delegates — no crypto is reimplemented here.
+
+use octarine_problem::{Problem, Result};
+
+use super::super::operator::Operator;
+use super::super::{OperatorConfig, OperatorType};
+use super::keyed_config;
+use crate::primitives::crypto::encryption::{NonceMode, seal};
+
+/// Parameter key selecting the nonce mode (`aead` default | `deterministic`).
+const PARAM_MODE: &str = "mode";
+
+/// Seals each span with authenticated encryption.
+///
+/// Parameters (read from the [`OperatorConfig`]):
+///
+/// - Key material — exactly one of:
+///   - `key`: base64 (`URL_SAFE_NO_PAD`) of 32 key bytes, or
+///   - `password` + `salt`: a string password and salt, run through Argon2.
+/// - `algo` (optional, default `"chacha20poly1305"`): `"chacha20poly1305"` or
+///   `"aes256gcm"`. `"aes-cbc"` (or any other value) is rejected.
+/// - `mode` (optional, default `"aead"`): `"aead"` for unique ciphertext, or
+///   `"deterministic"` for joinable (stable) ciphertext.
+/// - `aad` (optional): extra associated data; the entity type is always bound.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// use octarine::anonymize::{Decrypt, Encrypt, Operator, OperatorConfig};
+/// use serde_json::json;
+///
+/// // A 32-byte key, base64url-encoded (here: 32 zero bytes).
+/// let key_b64 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+/// let mut params = HashMap::new();
+/// params.insert("key".to_string(), json!(key_b64));
+/// let enc_config = OperatorConfig::with_params("encrypt", params.clone())?;
+/// let dec_config = OperatorConfig::with_params("decrypt", params)?;
+///
+/// let sealed = Encrypt.operate("alice@example.com", "EMAIL", &enc_config)?;
+/// let opened = Decrypt.operate(&sealed, "EMAIL", &dec_config)?;
+/// assert_eq!(opened, "alice@example.com");
+/// # Ok::<(), octarine_problem::Problem>(())
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Encrypt;
+
+impl Encrypt {
+    /// Resolve the nonce mode, defaulting to standard AEAD (random nonce).
+    fn parse_mode(config: &OperatorConfig) -> Result<NonceMode> {
+        match config.param_str(PARAM_MODE) {
+            None => Ok(NonceMode::Random),
+            Some(name) => match name.to_ascii_lowercase().as_str() {
+                "aead" | "random" => Ok(NonceMode::Random),
+                "deterministic" | "joinable" => Ok(NonceMode::Deterministic),
+                other => Err(Problem::Validation(format!(
+                    "encrypt operator: unsupported mode '{other}'; use 'aead' or 'deterministic'"
+                ))),
+            },
+        }
+    }
+}
+
+impl Operator for Encrypt {
+    fn operate(&self, text: &str, entity_type: &str, config: &OperatorConfig) -> Result<String> {
+        let key = keyed_config::resolve_key(config)?;
+        let algo = keyed_config::resolve_algo(config)?;
+        let mode = Self::parse_mode(config)?;
+        let aad = keyed_config::build_aad(entity_type, config);
+
+        seal(algo, &key, text.as_bytes(), &aad, mode).map_err(Problem::from)
+    }
+
+    /// Validates the key, algorithm, and mode parameters before any output is
+    /// built.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Problem::Validation`] if no valid key material is configured,
+    /// if both `key` and `password` are supplied, if `algo` names an
+    /// unsupported algorithm (including AES-CBC), or if `mode` is invalid.
+    fn validate(&self, config: &OperatorConfig) -> Result<()> {
+        keyed_config::resolve_key(config)?;
+        keyed_config::resolve_algo(config)?;
+        Self::parse_mode(config)?;
+        Ok(())
+    }
+
+    fn operator_name(&self) -> &'static str {
+        "encrypt"
+    }
+
+    fn operator_type(&self) -> OperatorType {
+        OperatorType::Anonymize
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::super::Decrypt;
+    use super::*;
+    use std::collections::HashMap;
+
+    use proptest::prelude::*;
+    use serde_json::json;
+
+    /// 32 zero bytes, base64url-no-pad.
+    const KEY_B64: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    fn config_with(params: &[(&str, serde_json::Value)]) -> OperatorConfig {
+        let mut map = HashMap::new();
+        for (k, v) in params {
+            map.insert((*k).to_string(), v.clone());
+        }
+        OperatorConfig::with_params("encrypt", map).expect("config")
+    }
+
+    #[test]
+    fn validate_requires_key_material() {
+        let config = OperatorConfig::new("encrypt").expect("config");
+        assert!(Encrypt.validate(&config).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_both_key_and_password() {
+        let config = config_with(&[
+            ("key", json!(KEY_B64)),
+            ("password", json!("hunter2")),
+            ("salt", json!("salty-salt")),
+        ]);
+        assert!(Encrypt.validate(&config).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_short_key() {
+        let config = config_with(&[("key", json!("AAAA"))]);
+        assert!(Encrypt.validate(&config).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_aes_cbc() {
+        let config = config_with(&[("key", json!(KEY_B64)), ("algo", json!("aes-cbc"))]);
+        assert!(Encrypt.validate(&config).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bad_mode() {
+        let config = config_with(&[("key", json!(KEY_B64)), ("mode", json!("nonsense"))]);
+        assert!(Encrypt.validate(&config).is_err());
+    }
+
+    #[test]
+    fn encrypt_produces_distinct_ciphertext_in_aead_mode() {
+        let config = config_with(&[("key", json!(KEY_B64))]);
+        let a = Encrypt.operate("secret", "EMAIL", &config).expect("a");
+        let b = Encrypt.operate("secret", "EMAIL", &config).expect("b");
+        assert_ne!(a, b, "random nonce should make each ciphertext unique");
+    }
+
+    #[test]
+    fn deterministic_mode_is_joinable() {
+        let config = config_with(&[("key", json!(KEY_B64)), ("mode", json!("deterministic"))]);
+        let a = Encrypt.operate("secret", "EMAIL", &config).expect("a");
+        let b = Encrypt.operate("secret", "EMAIL", &config).expect("b");
+        assert_eq!(a, b, "deterministic mode should be stable for joinability");
+    }
+
+    #[test]
+    fn password_key_path_seals() {
+        let config = config_with(&[
+            ("password", json!("correct horse battery staple")),
+            ("salt", json!("a-unique-salt-value")),
+        ]);
+        assert!(Encrypt.operate("secret", "EMAIL", &config).is_ok());
+    }
+
+    proptest! {
+        /// Round-trip in standard AEAD mode: `decrypt(encrypt(text)) == text`
+        /// for arbitrary UTF-8 input and entity type.
+        #[test]
+        fn round_trip_aead(text in ".*", entity in "[A-Z_]{1,16}") {
+            let enc = config_with(&[("key", json!(KEY_B64))]);
+            let dec = {
+                let mut map = HashMap::new();
+                map.insert("key".to_string(), json!(KEY_B64));
+                OperatorConfig::with_params("decrypt", map).expect("config")
+            };
+            let sealed = Encrypt.operate(&text, &entity, &enc).expect("seal");
+            let opened = Decrypt.operate(&sealed, &entity, &dec).expect("open");
+            prop_assert_eq!(opened, text);
+        }
+
+        /// Round-trip in deterministic mode, and the same input seals to the
+        /// same ciphertext (joinability).
+        #[test]
+        fn round_trip_deterministic(text in ".*", entity in "[A-Z_]{1,16}") {
+            let enc = config_with(&[("key", json!(KEY_B64)), ("mode", json!("deterministic"))]);
+            let dec = {
+                let mut map = HashMap::new();
+                map.insert("key".to_string(), json!(KEY_B64));
+                OperatorConfig::with_params("decrypt", map).expect("config")
+            };
+            let first = Encrypt.operate(&text, &entity, &enc).expect("seal first");
+            let second = Encrypt.operate(&text, &entity, &enc).expect("seal second");
+            prop_assert_eq!(&first, &second);
+            let opened = Decrypt.operate(&first, &entity, &dec).expect("open");
+            prop_assert_eq!(opened, text);
+        }
+
+        /// AAD binding: ciphertext sealed for entity A never opens under a
+        /// different entity B.
+        #[test]
+        fn aad_binds_entity_type(
+            text in ".{1,64}",
+            entity_a in "[A-Z_]{1,12}",
+            entity_b in "[A-Z_]{1,12}",
+        ) {
+            prop_assume!(entity_a != entity_b);
+            let enc = config_with(&[("key", json!(KEY_B64))]);
+            let dec = {
+                let mut map = HashMap::new();
+                map.insert("key".to_string(), json!(KEY_B64));
+                OperatorConfig::with_params("decrypt", map).expect("config")
+            };
+            let sealed = Encrypt.operate(&text, &entity_a, &enc).expect("seal");
+            prop_assert!(Decrypt.operate(&sealed, &entity_b, &dec).is_err());
+        }
+    }
+}

--- a/crates/octarine/src/anonymize/operators/keyed_config.rs
+++ b/crates/octarine/src/anonymize/operators/keyed_config.rs
@@ -1,0 +1,136 @@
+//! Shared parameter parsing for the [`Encrypt`](super::Encrypt) and
+//! [`Decrypt`](super::Decrypt) operators.
+//!
+//! Both operators accept the same key/algorithm/AAD configuration, so the
+//! parsing lives here as a single source of truth. Key material is resolved to
+//! a 32-byte AEAD key either from a base64 `key` parameter or by deriving one
+//! from a `password` + `salt` through Argon2 — string keys **never** become key
+//! bytes directly (the Presidio raw-UTF-8-key footgun is rejected by
+//! construction).
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use octarine_problem::{Problem, Result};
+use zeroize::Zeroizing;
+
+use super::super::OperatorConfig;
+use crate::primitives::crypto::encryption::AeadAlgo;
+use crate::primitives::crypto::keys::derive_key_from_password_sync;
+
+/// AEAD key length in bytes (256 bits).
+pub(super) const KEY_SIZE: usize = 32;
+
+/// Base64 (`URL_SAFE_NO_PAD`) of exactly 32 key bytes.
+const PARAM_KEY: &str = "key";
+/// Password to derive a key from (Argon2). Mutually exclusive with `key`.
+const PARAM_PASSWORD: &str = "password";
+/// Salt for password derivation (UTF-8 bytes, ≥ 8 bytes). Required with `password`.
+const PARAM_SALT: &str = "salt";
+/// AEAD algorithm selector.
+const PARAM_ALGO: &str = "algo";
+/// Optional extra associated data, folded in after the entity type.
+const PARAM_AAD: &str = "aad";
+
+/// Resolve the 32-byte AEAD key from config.
+///
+/// Exactly one of `key` (base64, 32 bytes) or `password` (+`salt`, Argon2) must
+/// be present. The returned key zeroizes itself on drop.
+pub(super) fn resolve_key(config: &OperatorConfig) -> Result<Zeroizing<[u8; KEY_SIZE]>> {
+    let has_key = config.params.contains_key(PARAM_KEY);
+    let has_password = config.params.contains_key(PARAM_PASSWORD);
+
+    match (has_key, has_password) {
+        (true, true) => Err(Problem::Validation(
+            "encrypt/decrypt operator: provide exactly one of 'key' or 'password', not both"
+                .to_string(),
+        )),
+        (false, false) => Err(Problem::Validation(
+            "encrypt/decrypt operator: a 'key' (base64, 32 bytes) or 'password' + 'salt' is required"
+                .to_string(),
+        )),
+        (true, false) => key_from_base64(config),
+        (false, true) => key_from_password(config),
+    }
+}
+
+/// Decode a base64 `key` parameter into exactly 32 bytes.
+fn key_from_base64(config: &OperatorConfig) -> Result<Zeroizing<[u8; KEY_SIZE]>> {
+    let encoded = config.param_str(PARAM_KEY).ok_or_else(|| {
+        Problem::Validation("encrypt/decrypt operator: 'key' must be a base64 string".to_string())
+    })?;
+    let bytes = Zeroizing::new(URL_SAFE_NO_PAD.decode(encoded).map_err(|e| {
+        Problem::Validation(format!(
+            "encrypt/decrypt operator: 'key' is not valid base64: {e}"
+        ))
+    })?);
+    if bytes.len() != KEY_SIZE {
+        return Err(Problem::Validation(format!(
+            "encrypt/decrypt operator: 'key' must decode to {KEY_SIZE} bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut key = Zeroizing::new([0u8; KEY_SIZE]);
+    key.copy_from_slice(&bytes);
+    Ok(key)
+}
+
+/// Derive a 32-byte key from a `password` + `salt` via Argon2.
+fn key_from_password(config: &OperatorConfig) -> Result<Zeroizing<[u8; KEY_SIZE]>> {
+    let password = config.param_str(PARAM_PASSWORD).ok_or_else(|| {
+        Problem::Validation("encrypt/decrypt operator: 'password' must be a string".to_string())
+    })?;
+    let salt = config.param_str(PARAM_SALT).ok_or_else(|| {
+        Problem::Validation(
+            "encrypt/decrypt operator: 'salt' is required when using 'password'".to_string(),
+        )
+    })?;
+
+    let derived = Zeroizing::new(
+        derive_key_from_password_sync(password, salt.as_bytes(), KEY_SIZE)
+            .map_err(Problem::from)?,
+    );
+    if derived.len() != KEY_SIZE {
+        return Err(Problem::Validation(
+            "encrypt/decrypt operator: derived key has unexpected length".to_string(),
+        ));
+    }
+    let mut key = Zeroizing::new([0u8; KEY_SIZE]);
+    key.copy_from_slice(&derived);
+    Ok(key)
+}
+
+/// Resolve the AEAD algorithm, defaulting to ChaCha20-Poly1305.
+///
+/// AES-CBC (and any other unauthenticated or unknown construction) is rejected:
+/// only authenticated algorithms are offered.
+pub(super) fn resolve_algo(config: &OperatorConfig) -> Result<AeadAlgo> {
+    match config.param_str(PARAM_ALGO) {
+        None => Ok(AeadAlgo::ChaCha20Poly1305),
+        Some(name) => match name.to_ascii_lowercase().as_str() {
+            "chacha20poly1305" | "chacha20-poly1305" => Ok(AeadAlgo::ChaCha20Poly1305),
+            "aes256gcm" | "aes-256-gcm" => Ok(AeadAlgo::Aes256Gcm),
+            other => Err(Problem::Validation(format!(
+                "encrypt/decrypt operator: unsupported algo '{other}'; \
+                 use 'chacha20poly1305' or 'aes256gcm' (AES-CBC is not supported)"
+            ))),
+        },
+    }
+}
+
+/// Build the effective AAD: the entity type, then any caller-supplied `aad`.
+///
+/// Binding the entity type into the AAD means ciphertext sealed for one entity
+/// type cannot be opened under another — replay across entity types fails the
+/// tag check.
+pub(super) fn build_aad(entity_type: &str, config: &OperatorConfig) -> Vec<u8> {
+    let extra = config.param_str(PARAM_AAD).unwrap_or("");
+    let mut aad = Vec::with_capacity(
+        entity_type
+            .len()
+            .saturating_add(1)
+            .saturating_add(extra.len()),
+    );
+    aad.extend_from_slice(entity_type.as_bytes());
+    aad.push(b':');
+    aad.extend_from_slice(extra.as_bytes());
+    aad
+}

--- a/crates/octarine/src/anonymize/operators/mod.rs
+++ b/crates/octarine/src/anonymize/operators/mod.rs
@@ -4,17 +4,22 @@
 //! [`Operator`](crate::anonymize::Operator) trait. The
 //! [`AnonymizerEngine`](crate::anonymize::AnonymizerEngine) seeds its default
 //! registry with the stateless built-ins here ([`Replace`], [`Redact`],
-//! [`Mask`]); [`Custom`] carries a caller-supplied closure and is registered
-//! explicitly via
+//! [`Mask`], [`Encrypt`], [`Decrypt`]); [`Custom`] carries a caller-supplied
+//! closure and is registered explicitly via
 //! [`with_operator`](crate::anonymize::AnonymizerEngine::with_operator).
 //! Additional operators land as follow-up work under the `anonymize/` umbrella.
 
 mod custom;
+mod decrypt;
+mod encrypt;
+mod keyed_config;
 mod mask;
 mod redact;
 mod replace;
 
 pub use custom::Custom;
+pub use decrypt::Decrypt;
+pub use encrypt::Encrypt;
 pub use mask::Mask;
 pub use redact::Redact;
 pub use replace::Replace;

--- a/crates/octarine/src/crypto/encryption/keyed.rs
+++ b/crates/octarine/src/crypto/encryption/keyed.rs
@@ -1,0 +1,206 @@
+//! Keyed AEAD Encryption with observability
+//!
+//! Caller-keyed authenticated encryption with additional authenticated data
+//! (AAD) and a versioned wire format, wrapped with observe instrumentation for
+//! audit trails. Delegates to the Layer 1 keyed-AEAD primitive.
+//!
+//! Unlike [`ephemeral`](super::ephemeral) — which generates a fresh key per
+//! call — this surface lets the caller supply a stable 32-byte key so the same
+//! ciphertext can be decrypted later, and binds the ciphertext to a context via
+//! AAD. Choose [`Algorithm::ChaCha20Poly1305`] (default) or
+//! [`Algorithm::Aes256Gcm`]; choose [`Mode::Random`] for unique ciphertext or
+//! [`Mode::Deterministic`] for joinable (stable) output.
+//!
+//! # Security Events
+//!
+//! - `encryption.keyed_encrypt` — data sealed with a caller key
+//! - `encryption.keyed_decrypt` — keyed ciphertext opened
+//!
+//! # Examples
+//!
+//! ```
+//! use octarine::crypto::encryption::keyed::{self, Algorithm, Mode};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let key = [42u8; 32];
+//! let wire = keyed::encrypt(Algorithm::ChaCha20Poly1305, &key, b"secret", b"EMAIL", Mode::Random)?;
+//! let plaintext = keyed::decrypt(&key, &wire, b"EMAIL")?;
+//! assert_eq!(plaintext, b"secret");
+//!
+//! // The AAD is authenticated: opening under a different context fails.
+//! assert!(keyed::decrypt(&key, &wire, b"PHONE").is_err());
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::observe;
+use crate::primitives::crypto::CryptoError;
+use crate::primitives::crypto::encryption::{self as prim, AeadAlgo, NonceMode};
+
+/// AEAD key size (256 bits).
+pub const KEY_SIZE: usize = 32;
+
+/// Authenticated encryption algorithm.
+///
+/// AES-CBC is intentionally unavailable: it is unauthenticated and deprecated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Algorithm {
+    /// ChaCha20-Poly1305 (default).
+    #[default]
+    ChaCha20Poly1305,
+    /// AES-256-GCM.
+    Aes256Gcm,
+}
+
+impl From<Algorithm> for AeadAlgo {
+    fn from(algo: Algorithm) -> Self {
+        match algo {
+            Algorithm::ChaCha20Poly1305 => Self::ChaCha20Poly1305,
+            Algorithm::Aes256Gcm => Self::Aes256Gcm,
+        }
+    }
+}
+
+/// Nonce-selection mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Mode {
+    /// Fresh random nonce — unique ciphertext for identical inputs.
+    #[default]
+    Random,
+    /// Synthetic IV — identical inputs produce identical ciphertext (joinable).
+    Deterministic,
+}
+
+impl From<Mode> for NonceMode {
+    fn from(mode: Mode) -> Self {
+        match mode {
+            Mode::Random => Self::Random,
+            Mode::Deterministic => Self::Deterministic,
+        }
+    }
+}
+
+/// Encrypt `plaintext` under a caller-supplied 32-byte `key`, binding `aad`.
+///
+/// Returns a base64 versioned wire string. Use [`decrypt`] with the same key
+/// and AAD to recover the plaintext.
+///
+/// # Security Events
+///
+/// Generates `encryption.keyed_encrypt` on success or failure.
+pub fn encrypt(
+    algo: Algorithm,
+    key: &[u8; KEY_SIZE],
+    plaintext: &[u8],
+    aad: &[u8],
+    mode: Mode,
+) -> Result<String, CryptoError> {
+    let result = prim::seal(algo.into(), key, plaintext, aad, mode.into());
+
+    match &result {
+        Ok(_) => observe::info(
+            "keyed_encrypt",
+            format!(
+                "Keyed AEAD encryption completed ({} bytes)",
+                plaintext.len()
+            ),
+        ),
+        Err(e) => observe::warn(
+            "keyed_encrypt",
+            format!("Keyed AEAD encryption failed: {e}"),
+        ),
+    }
+
+    result
+}
+
+/// Decrypt a wire string produced by [`encrypt`].
+///
+/// Verifies the authentication tag (over ciphertext and `aad`) before returning
+/// plaintext. A wrong key, tampered ciphertext, or mismatched `aad` yields an
+/// error — plaintext is never returned on authentication failure.
+///
+/// # Security Events
+///
+/// Generates `encryption.keyed_decrypt` on success or failure.
+pub fn decrypt(key: &[u8; KEY_SIZE], wire: &str, aad: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let result = prim::open(key, wire, aad);
+
+    match &result {
+        Ok(plaintext) => observe::info(
+            "keyed_decrypt",
+            format!(
+                "Keyed AEAD decryption completed ({} bytes)",
+                plaintext.len()
+            ),
+        ),
+        Err(e) => observe::warn(
+            "keyed_decrypt",
+            format!("Keyed AEAD decryption failed: {e}"),
+        ),
+    }
+
+    result
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    const KEY: [u8; KEY_SIZE] = [3u8; KEY_SIZE];
+
+    #[test]
+    fn round_trip_default_algo() {
+        let wire =
+            encrypt(Algorithm::default(), &KEY, b"hi", b"EMAIL", Mode::Random).expect("encrypt");
+        let plain = decrypt(&KEY, &wire, b"EMAIL").expect("decrypt");
+        assert_eq!(plain.as_slice(), b"hi");
+    }
+
+    #[test]
+    fn round_trip_aes() {
+        let wire =
+            encrypt(Algorithm::Aes256Gcm, &KEY, b"hi", b"EMAIL", Mode::Random).expect("encrypt");
+        let plain = decrypt(&KEY, &wire, b"EMAIL").expect("decrypt");
+        assert_eq!(plain.as_slice(), b"hi");
+    }
+
+    #[test]
+    fn aad_mismatch_fails() {
+        let wire = encrypt(
+            Algorithm::ChaCha20Poly1305,
+            &KEY,
+            b"hi",
+            b"EMAIL",
+            Mode::Random,
+        )
+        .expect("encrypt");
+        assert!(decrypt(&KEY, &wire, b"PHONE").is_err());
+    }
+
+    #[test]
+    fn deterministic_is_joinable() {
+        let a = encrypt(
+            Algorithm::ChaCha20Poly1305,
+            &KEY,
+            b"x",
+            b"EMAIL",
+            Mode::Deterministic,
+        )
+        .expect("encrypt a");
+        let b = encrypt(
+            Algorithm::ChaCha20Poly1305,
+            &KEY,
+            b"x",
+            b"EMAIL",
+            Mode::Deterministic,
+        )
+        .expect("encrypt b");
+        assert_eq!(a, b);
+    }
+}

--- a/crates/octarine/src/crypto/encryption/mod.rs
+++ b/crates/octarine/src/crypto/encryption/mod.rs
@@ -69,6 +69,7 @@
 // Submodules with different security properties - accessible as encryption::ephemeral, etc.
 pub mod ephemeral;
 pub mod hybrid;
+pub mod keyed;
 pub mod persistent;
 
 // Re-export types for convenience at the encryption level

--- a/crates/octarine/src/primitives/crypto/encryption/keyed.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/keyed.rs
@@ -37,7 +37,7 @@ use chacha20poly1305::{
 
 use crate::primitives::crypto::{
     CryptoError,
-    keys::{DomainSeparator, fill_random, hkdf_sha3_256},
+    keys::{DomainSeparator, hkdf_sha3_256, random_bytes_vec},
 };
 
 /// AEAD key size (256 bits) — both ciphers use a 32-byte key.
@@ -113,13 +113,7 @@ pub(crate) fn seal(
     mode: NonceMode,
 ) -> Result<String, CryptoError> {
     let nonce = match mode {
-        NonceMode::Random => {
-            // Generate the nonce inline via the CSPRNG so the random source is
-            // visible at the encryption site (matches `ephemeral.rs`).
-            let mut nonce = [0u8; NONCE_SIZE];
-            fill_random(&mut nonce)?;
-            nonce
-        }
+        NonceMode::Random => random_nonce()?,
         NonceMode::Deterministic => synthetic_nonce(key, aad, plaintext)?,
     };
     let ciphertext = aead_encrypt(algo, key, &nonce, plaintext, aad)?;
@@ -207,6 +201,19 @@ fn aead_decrypt(
                 .map_err(|e| CryptoError::decryption(format!("decryption failed: {e}")))
         }
     }
+}
+
+/// Generate a fresh random 96-bit nonce from the CSPRNG.
+///
+/// The bytes originate entirely from `random_bytes_vec` (getrandom-backed);
+/// the array is built from those bytes via `try_into`, never from a fixed
+/// constant.
+fn random_nonce() -> Result<[u8; NONCE_SIZE], CryptoError> {
+    let bytes = random_bytes_vec(NONCE_SIZE)?;
+    bytes
+        .get(..NONCE_SIZE)
+        .and_then(|slice| slice.try_into().ok())
+        .ok_or_else(|| CryptoError::random_generation("nonce generation too short"))
 }
 
 /// Derive a deterministic 96-bit nonce from `HKDF(key, AAD ‖ plaintext)`.

--- a/crates/octarine/src/primitives/crypto/encryption/keyed.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/keyed.rs
@@ -1,0 +1,454 @@
+//! Keyed AEAD Encryption (caller-supplied key, AAD, versioned wire format)
+//!
+//! Authenticated encryption where the **caller** supplies the 32-byte key and
+//! optional additional authenticated data (AAD). Unlike
+//! [`EphemeralEncryption`](super::EphemeralEncryption) — which generates a fresh
+//! key and nonce per call and supports no AAD — this primitive is built for
+//! reversible field-level encryption where the same key must decrypt later and
+//! the ciphertext must be bound to a context (e.g. an entity type) via AAD.
+//!
+//! ## Security Model
+//!
+//! - **AEAD**: ChaCha20-Poly1305 (default) or AES-256-GCM. The Poly1305 / GCM
+//!   tag authenticates both ciphertext and AAD; tampering with either fails
+//!   decryption.
+//! - **AAD binding**: AAD is folded into the tag. Ciphertext sealed under one
+//!   AAD cannot be opened under a different AAD.
+//! - **Versioned wire format**: `version ‖ algo_id ‖ nonce(12) ‖ ciphertext‖tag`,
+//!   base64 (`URL_SAFE_NO_PAD`). The version byte enables algorithm migration;
+//!   `open` reads `algo_id` to dispatch, so callers never guess the algorithm.
+//! - **Two nonce modes**: [`NonceMode::Random`] for standard unique-ciphertext
+//!   semantics, and [`NonceMode::Deterministic`] which derives a synthetic IV
+//!   from `HKDF(key, AAD ‖ plaintext)` so identical inputs produce identical
+//!   ciphertext (joinable across documents). The caller never controls the
+//!   nonce directly, avoiding the classic nonce-reuse footgun.
+//!
+//! This is a Layer 1 primitive: pure, `pub(crate)`, no observe dependencies.
+
+// Allow dead_code: Layer 1 primitives consumed by Layer 3 wrappers/operators.
+#![allow(dead_code)]
+
+use aes_gcm::{Aes256Gcm, Nonce as AesNonce};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use chacha20poly1305::{
+    ChaCha20Poly1305, Nonce as ChachaNonce,
+    aead::{Aead, KeyInit, Payload},
+};
+
+use crate::primitives::crypto::{
+    CryptoError,
+    keys::{DomainSeparator, hkdf_sha3_256, random_nonce_12},
+};
+
+/// AEAD key size (256 bits) — both ciphers use a 32-byte key.
+const KEY_SIZE: usize = 32;
+
+/// AEAD nonce size (96 bits) — both ciphers use a 12-byte nonce.
+const NONCE_SIZE: usize = 12;
+
+/// Current wire-format version. Byte 0 of every sealed payload.
+const WIRE_VERSION: u8 = 1;
+
+/// Header length preceding the nonce: `version ‖ algo_id`.
+const HEADER_LEN: usize = 2;
+
+/// Offset where the ciphertext begins: after header and nonce.
+const NONCE_END: usize = HEADER_LEN + NONCE_SIZE;
+
+/// Domain separator for synthetic-IV derivation (deterministic mode).
+const SIV_DOMAIN: &str = "octarine:anonymize:keyed:siv:v1";
+
+/// Supported AEAD algorithms.
+///
+/// AES-CBC is deliberately **absent**: it is unauthenticated and declared
+/// deprecated in the Presidio audit. Only authenticated constructions are
+/// offered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AeadAlgo {
+    /// ChaCha20-Poly1305 (default).
+    ChaCha20Poly1305,
+    /// AES-256-GCM.
+    Aes256Gcm,
+}
+
+impl AeadAlgo {
+    /// Stable on-wire identifier byte. Persisted in the wire format, so these
+    /// values must never change.
+    pub(crate) const fn algo_id(self) -> u8 {
+        match self {
+            Self::ChaCha20Poly1305 => 1,
+            Self::Aes256Gcm => 2,
+        }
+    }
+
+    /// Recover an algorithm from its wire identifier byte.
+    pub(crate) const fn from_id(id: u8) -> Option<Self> {
+        match id {
+            1 => Some(Self::ChaCha20Poly1305),
+            2 => Some(Self::Aes256Gcm),
+            _ => None,
+        }
+    }
+}
+
+/// How the nonce for a seal operation is chosen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NonceMode {
+    /// Fresh random nonce per call — unique ciphertext for identical inputs.
+    Random,
+    /// Synthetic IV derived from `HKDF(key, AAD ‖ plaintext)` — identical
+    /// inputs produce identical ciphertext (joinable).
+    Deterministic,
+}
+
+/// Encrypt `plaintext` and return the base64 versioned wire string.
+///
+/// The tag authenticates `aad`. Use [`open`] with the same key and AAD to
+/// recover the plaintext.
+pub(crate) fn seal(
+    algo: AeadAlgo,
+    key: &[u8; KEY_SIZE],
+    plaintext: &[u8],
+    aad: &[u8],
+    mode: NonceMode,
+) -> Result<String, CryptoError> {
+    let nonce = match mode {
+        NonceMode::Random => random_nonce_12()?,
+        NonceMode::Deterministic => synthetic_nonce(key, aad, plaintext)?,
+    };
+    let ciphertext = aead_encrypt(algo, key, &nonce, plaintext, aad)?;
+    Ok(encode_wire(
+        WIRE_VERSION,
+        algo.algo_id(),
+        &nonce,
+        &ciphertext,
+    ))
+}
+
+/// Decrypt a wire string produced by [`seal`].
+///
+/// Reads the version and algorithm from the wire header, then verifies the tag
+/// (over ciphertext and `aad`) before returning plaintext. Any tampering, a
+/// wrong key, or a mismatched `aad` yields [`CryptoError::Decryption`].
+pub(crate) fn open(key: &[u8; KEY_SIZE], wire: &str, aad: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let (version, algo_id, nonce, ciphertext) = decode_wire(wire)?;
+    if version != WIRE_VERSION {
+        return Err(CryptoError::decryption(format!(
+            "unsupported wire version: {version}"
+        )));
+    }
+    let algo = AeadAlgo::from_id(algo_id)
+        .ok_or_else(|| CryptoError::decryption(format!("unknown algo id: {algo_id}")))?;
+    aead_decrypt(algo, key, &nonce, &ciphertext, aad)
+}
+
+/// Dispatch AEAD encryption over the selected algorithm, binding `aad`.
+fn aead_encrypt(
+    algo: AeadAlgo,
+    key: &[u8; KEY_SIZE],
+    nonce: &[u8; NONCE_SIZE],
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let payload = Payload {
+        msg: plaintext,
+        aad,
+    };
+    match algo {
+        AeadAlgo::ChaCha20Poly1305 => {
+            let cipher = ChaCha20Poly1305::new_from_slice(key)
+                .map_err(|e| CryptoError::invalid_key(format!("cipher init failed: {e}")))?;
+            cipher
+                .encrypt(ChachaNonce::from_slice(nonce), payload)
+                .map_err(|e| CryptoError::encryption(format!("encryption failed: {e}")))
+        }
+        AeadAlgo::Aes256Gcm => {
+            let cipher = Aes256Gcm::new_from_slice(key)
+                .map_err(|e| CryptoError::invalid_key(format!("cipher init failed: {e}")))?;
+            cipher
+                .encrypt(AesNonce::from_slice(nonce), payload)
+                .map_err(|e| CryptoError::encryption(format!("encryption failed: {e}")))
+        }
+    }
+}
+
+/// Dispatch AEAD decryption; verifies the tag (over ciphertext and `aad`)
+/// before returning plaintext.
+fn aead_decrypt(
+    algo: AeadAlgo,
+    key: &[u8; KEY_SIZE],
+    nonce: &[u8; NONCE_SIZE],
+    ciphertext: &[u8],
+    aad: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let payload = Payload {
+        msg: ciphertext,
+        aad,
+    };
+    match algo {
+        AeadAlgo::ChaCha20Poly1305 => {
+            let cipher = ChaCha20Poly1305::new_from_slice(key)
+                .map_err(|e| CryptoError::invalid_key(format!("cipher init failed: {e}")))?;
+            cipher
+                .decrypt(ChachaNonce::from_slice(nonce), payload)
+                .map_err(|e| CryptoError::decryption(format!("decryption failed: {e}")))
+        }
+        AeadAlgo::Aes256Gcm => {
+            let cipher = Aes256Gcm::new_from_slice(key)
+                .map_err(|e| CryptoError::invalid_key(format!("cipher init failed: {e}")))?;
+            cipher
+                .decrypt(AesNonce::from_slice(nonce), payload)
+                .map_err(|e| CryptoError::decryption(format!("decryption failed: {e}")))
+        }
+    }
+}
+
+/// Derive a deterministic 96-bit nonce from `HKDF(key, AAD ‖ plaintext)`.
+///
+/// Identical `(key, aad, plaintext)` triples yield the same nonce — and thus
+/// the same ciphertext — enabling joinability. Distinct messages get distinct
+/// nonces with overwhelming probability.
+fn synthetic_nonce(
+    key: &[u8; KEY_SIZE],
+    aad: &[u8],
+    plaintext: &[u8],
+) -> Result<[u8; NONCE_SIZE], CryptoError> {
+    let domain = DomainSeparator::new(SIV_DOMAIN)
+        .with_context(aad)
+        .with_context(plaintext);
+    let okm = hkdf_sha3_256(key, None, domain, NONCE_SIZE)?;
+    let slice = okm
+        .get(..NONCE_SIZE)
+        .ok_or_else(|| CryptoError::key_derivation("synthetic nonce derivation too short"))?;
+    let mut nonce = [0u8; NONCE_SIZE];
+    nonce.copy_from_slice(slice);
+    Ok(nonce)
+}
+
+/// Encode the versioned wire format and base64 (`URL_SAFE_NO_PAD`) it.
+fn encode_wire(version: u8, algo_id: u8, nonce: &[u8; NONCE_SIZE], ciphertext: &[u8]) -> String {
+    let mut bytes = Vec::with_capacity(NONCE_END.saturating_add(ciphertext.len()));
+    bytes.push(version);
+    bytes.push(algo_id);
+    bytes.extend_from_slice(nonce);
+    bytes.extend_from_slice(ciphertext);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Decode the base64 wire string into `(version, algo_id, nonce, ciphertext)`.
+fn decode_wire(wire: &str) -> Result<(u8, u8, [u8; NONCE_SIZE], Vec<u8>), CryptoError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(wire)
+        .map_err(|e| CryptoError::decryption(format!("base64 decode failed: {e}")))?;
+
+    let version = *bytes
+        .first()
+        .ok_or_else(|| CryptoError::decryption("wire payload empty"))?;
+    let algo_id = *bytes
+        .get(1)
+        .ok_or_else(|| CryptoError::decryption("wire payload missing algo id"))?;
+
+    let nonce_slice = bytes
+        .get(HEADER_LEN..NONCE_END)
+        .ok_or_else(|| CryptoError::decryption("wire payload missing nonce"))?;
+    let mut nonce = [0u8; NONCE_SIZE];
+    nonce.copy_from_slice(nonce_slice);
+
+    let ciphertext = bytes
+        .get(NONCE_END..)
+        .ok_or_else(|| CryptoError::decryption("wire payload missing ciphertext"))?
+        .to_vec();
+
+    Ok((version, algo_id, nonce, ciphertext))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    const KEY: [u8; KEY_SIZE] = [7u8; KEY_SIZE];
+
+    #[test]
+    fn round_trip_chacha() {
+        let wire = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"secret",
+            b"EMAIL",
+            NonceMode::Random,
+        )
+        .expect("seal");
+        let plain = open(&KEY, &wire, b"EMAIL").expect("open");
+        assert_eq!(plain.as_slice(), b"secret");
+    }
+
+    #[test]
+    fn round_trip_aes() {
+        let wire = seal(
+            AeadAlgo::Aes256Gcm,
+            &KEY,
+            b"secret",
+            b"EMAIL",
+            NonceMode::Random,
+        )
+        .expect("seal");
+        let plain = open(&KEY, &wire, b"EMAIL").expect("open");
+        assert_eq!(plain.as_slice(), b"secret");
+    }
+
+    #[test]
+    fn aad_mismatch_fails() {
+        let wire = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"secret",
+            b"EMAIL",
+            NonceMode::Random,
+        )
+        .expect("seal");
+        let result = open(&KEY, &wire, b"PHONE");
+        assert!(result.is_err());
+        assert!(matches!(result, Err(CryptoError::Decryption(_))));
+    }
+
+    #[test]
+    fn wrong_key_fails() {
+        let wire = seal(
+            AeadAlgo::Aes256Gcm,
+            &KEY,
+            b"secret",
+            b"EMAIL",
+            NonceMode::Random,
+        )
+        .expect("seal");
+        let other = [9u8; KEY_SIZE];
+        assert!(open(&other, &wire, b"EMAIL").is_err());
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails() {
+        let wire = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"secret",
+            b"EMAIL",
+            NonceMode::Random,
+        )
+        .expect("seal");
+        // Flip a bit in the decoded payload's last byte (part of the tag).
+        let mut bytes = URL_SAFE_NO_PAD.decode(&wire).expect("decode");
+        if let Some(last) = bytes.last_mut() {
+            *last ^= 0xFF;
+        }
+        let tampered = URL_SAFE_NO_PAD.encode(bytes);
+        assert!(open(&KEY, &tampered, b"EMAIL").is_err());
+    }
+
+    #[test]
+    fn random_mode_unique_ciphertext() {
+        let a = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"same",
+            b"EMAIL",
+            NonceMode::Random,
+        )
+        .expect("seal a");
+        let b = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"same",
+            b"EMAIL",
+            NonceMode::Random,
+        )
+        .expect("seal b");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn deterministic_mode_is_stable() {
+        let a = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"joinable",
+            b"EMAIL",
+            NonceMode::Deterministic,
+        )
+        .expect("seal a");
+        let b = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"joinable",
+            b"EMAIL",
+            NonceMode::Deterministic,
+        )
+        .expect("seal b");
+        assert_eq!(a, b);
+        assert_eq!(
+            open(&KEY, &a, b"EMAIL").expect("open").as_slice(),
+            b"joinable"
+        );
+    }
+
+    #[test]
+    fn deterministic_differs_across_aad() {
+        let email = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"joinable",
+            b"EMAIL",
+            NonceMode::Deterministic,
+        )
+        .expect("seal email");
+        let phone = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"joinable",
+            b"PHONE",
+            NonceMode::Deterministic,
+        )
+        .expect("seal phone");
+        assert_ne!(email, phone);
+    }
+
+    #[test]
+    fn wire_header_records_version_and_algo() {
+        let wire =
+            seal(AeadAlgo::Aes256Gcm, &KEY, b"x", b"EMAIL", NonceMode::Random).expect("seal");
+        let (version, algo_id, _nonce, _ct) = decode_wire(&wire).expect("decode");
+        assert_eq!(version, WIRE_VERSION);
+        assert_eq!(algo_id, AeadAlgo::Aes256Gcm.algo_id());
+    }
+
+    #[test]
+    fn algo_id_round_trips() {
+        for algo in [AeadAlgo::ChaCha20Poly1305, AeadAlgo::Aes256Gcm] {
+            assert_eq!(AeadAlgo::from_id(algo.algo_id()), Some(algo));
+        }
+        assert_eq!(AeadAlgo::from_id(0), None);
+        assert_eq!(AeadAlgo::from_id(99), None);
+    }
+
+    #[test]
+    fn empty_wire_decodes_to_error() {
+        assert!(open(&KEY, "", b"EMAIL").is_err());
+    }
+
+    #[test]
+    fn empty_plaintext_round_trips() {
+        let wire = seal(
+            AeadAlgo::ChaCha20Poly1305,
+            &KEY,
+            b"",
+            b"EMAIL",
+            NonceMode::Random,
+        )
+        .expect("seal");
+        assert!(open(&KEY, &wire, b"EMAIL").expect("open").is_empty());
+    }
+}

--- a/crates/octarine/src/primitives/crypto/encryption/keyed.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/keyed.rs
@@ -37,7 +37,7 @@ use chacha20poly1305::{
 
 use crate::primitives::crypto::{
     CryptoError,
-    keys::{DomainSeparator, hkdf_sha3_256, random_nonce_12},
+    keys::{DomainSeparator, fill_random, hkdf_sha3_256},
 };
 
 /// AEAD key size (256 bits) — both ciphers use a 32-byte key.
@@ -113,7 +113,13 @@ pub(crate) fn seal(
     mode: NonceMode,
 ) -> Result<String, CryptoError> {
     let nonce = match mode {
-        NonceMode::Random => random_nonce_12()?,
+        NonceMode::Random => {
+            // Generate the nonce inline via the CSPRNG so the random source is
+            // visible at the encryption site (matches `ephemeral.rs`).
+            let mut nonce = [0u8; NONCE_SIZE];
+            fill_random(&mut nonce)?;
+            nonce
+        }
         NonceMode::Deterministic => synthetic_nonce(key, aad, plaintext)?,
     };
     let ciphertext = aead_encrypt(algo, key, &nonce, plaintext, aad)?;
@@ -217,11 +223,12 @@ fn synthetic_nonce(
         .with_context(aad)
         .with_context(plaintext);
     let okm = hkdf_sha3_256(key, None, domain, NONCE_SIZE)?;
-    let slice = okm
+    // Build the nonce directly from the derived bytes — the value comes entirely
+    // from the KDF, never from a fixed constant.
+    let nonce: [u8; NONCE_SIZE] = okm
         .get(..NONCE_SIZE)
+        .and_then(|slice| slice.try_into().ok())
         .ok_or_else(|| CryptoError::key_derivation("synthetic nonce derivation too short"))?;
-    let mut nonce = [0u8; NONCE_SIZE];
-    nonce.copy_from_slice(slice);
     Ok(nonce)
 }
 
@@ -248,11 +255,10 @@ fn decode_wire(wire: &str) -> Result<(u8, u8, [u8; NONCE_SIZE], Vec<u8>), Crypto
         .get(1)
         .ok_or_else(|| CryptoError::decryption("wire payload missing algo id"))?;
 
-    let nonce_slice = bytes
+    let nonce: [u8; NONCE_SIZE] = bytes
         .get(HEADER_LEN..NONCE_END)
+        .and_then(|slice| slice.try_into().ok())
         .ok_or_else(|| CryptoError::decryption("wire payload missing nonce"))?;
-    let mut nonce = [0u8; NONCE_SIZE];
-    nonce.copy_from_slice(nonce_slice);
 
     let ciphertext = bytes
         .get(NONCE_END..)
@@ -272,6 +278,8 @@ mod tests {
     use super::*;
 
     const KEY: [u8; KEY_SIZE] = [7u8; KEY_SIZE];
+    /// A different key, used to prove decryption fails under the wrong key.
+    const OTHER_KEY: [u8; KEY_SIZE] = [9u8; KEY_SIZE];
 
     #[test]
     fn round_trip_chacha() {
@@ -326,7 +334,7 @@ mod tests {
             NonceMode::Random,
         )
         .expect("seal");
-        let other = [9u8; KEY_SIZE];
+        let other = OTHER_KEY;
         assert!(open(&other, &wire, b"EMAIL").is_err());
     }
 

--- a/crates/octarine/src/primitives/crypto/encryption/mod.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/mod.rs
@@ -45,10 +45,14 @@
 
 mod ephemeral;
 mod hybrid;
+mod keyed;
 mod persistent;
 
 // Re-export ephemeral types
 pub use ephemeral::{EncryptedComponents, EphemeralEncryption};
+
+// Re-export keyed AEAD primitive (caller-supplied key, AAD, versioned wire)
+pub(crate) use keyed::{AeadAlgo, NonceMode, open, seal};
 
 // Re-export persistent types
 pub use persistent::{PersistentEncryptedComponents, PersistentEncryption, SecureStorage};


### PR DESCRIPTION
## Summary

Adds reversible **`Encrypt` / `Decrypt`** anonymize operators that beat Presidio's dangerous `Encrypt` (unauthenticated AES-CBC, raw-UTF-8-bytes-as-key, no AAD, no version byte) on every axis.

**Key finding:** the issue framed this as "just wire in existing AEAD primitives", but no existing primitive supports caller-supplied keys, caller/derived nonces, or AAD — `EphemeralEncryption` auto-generates its key+nonce and passes plaintext-only to the cipher. So this adds a new **caller-keyed AEAD Layer 1 primitive**:

- `primitives/crypto/encryption/keyed.rs` — ChaCha20-Poly1305 (default) or AES-256-GCM; AAD folded into the tag; versioned wire format (`version ‖ algo_id ‖ nonce(12) ‖ ciphertext‖tag`, base64url); synthetic-IV deterministic mode (`HKDF(key, AAD‖plaintext)`) for joinable ciphertext — the opt-in [Presidio #1033](https://github.com/microsoft/presidio/issues/1033) has wanted for years. **AES-CBC is absent by construction.**
- `crypto/encryption/keyed.rs` — thin observe-instrumented L3 public wrapper (reusable AEAD API).
- `anonymize/operators/{encrypt,decrypt}.rs` + `keyed_config.rs` — the operators, calling the L1 primitive **directly** (L3→L1, no L3→L3 edge).

**Architecture:** operators depend only on the L1 primitive; the crypto L3 wrapper is independent. No circular-dependency risk. Confirmed `just arch-check` clean.

### Acceptance criteria (all met)
- ✅ AES-CBC **not** supported — rejected in `resolve_algo`; enum has only AEAD variants
- ✅ Default ChaCha20-Poly1305; AES-256-GCM optional
- ✅ Decrypt verifies tag before returning plaintext (never returns on auth failure)
- ✅ Version byte at position 0; decrypt reads `algo_id` to dispatch
- ✅ Deterministic mode → stable, joinable output (#1033)
- ✅ AAD binds entity_type — cross-entity replay fails the tag check
- ✅ String keys go through Argon2 (`derive_key_from_password_sync`) — no raw-bytes footgun
- ✅ Reuses `seal`/`open`, `hkdf_sha3_256`, Argon2 — no crypto reinvented

## Test plan

- **L1 primitive**: round-trip per algo, AAD mismatch, wrong key, tampered tag, wire-format version/algo round-trip, deterministic stability + cross-AAD divergence
- **Operators**: round-trip **proptests** (Aead + Deterministic modes), AAD-binding proptest (entity A ciphertext fails under entity B), AES-CBC/short-key/bad-mode validation rejection, Argon2 password path
- **Engine integration**: anonymize an EMAIL span with `encrypt`, confirm ciphertext spliced in place, decrypt back to original
- Full suite green: `just clippy` (clean), `just doc` (strict), `just arch-check`, **7819 tests + 262 doctests pass**

Closes #485