### PR TITLE
feat(anonymize): Hash operator over SHA-2/BLAKE3/HMAC/Argon2 (#484)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +472,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -798,6 +824,12 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -2766,6 +2798,7 @@ dependencies = [
  "axum",
  "base64",
  "bech32",
+ "blake3",
  "bs58",
  "bytes",
  "chacha20poly1305",
@@ -5079,7 +5112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b36a9dd327e9f401320a2cb4572cc76ff43742bcfc3291f871691050f140ba"
 dependencies = [
  "base32",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "hmac 0.12.1",
  "rand 0.9.4",
  "sha1 0.10.6",

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -51,6 +51,7 @@ uuid = { workspace = true }
 base64 = "0.22"
 sha2 = "0.11"
 sha3 = "0.12"
+blake3 = "1"
 hex = "0.4"
 zeroize = { version = "1.8", features = ["derive"] }
 chacha20poly1305 = "0.10.1"

--- a/crates/octarine/src/anonymize/engine.rs
+++ b/crates/octarine/src/anonymize/engine.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use octarine_problem::{Problem, Result};
 
-use super::operators::{Decrypt, Encrypt, Mask, Redact, Replace};
+use super::operators::{Decrypt, Encrypt, Hash, Mask, Redact, Replace};
 use super::{
     AsyncOperator, ConflictResolutionStrategy, EngineResult, Operator, OperatorConfig,
     OperatorResult, PiiSpan, RecognizerResult, SessionId, StateStore,
@@ -105,7 +105,7 @@ impl Default for AnonymizerEngine {
 
 impl AnonymizerEngine {
     /// Creates an engine with the built-in operators (`replace`, `redact`,
-    /// `mask`, `encrypt`, `decrypt`) and the default
+    /// `mask`, `hash`, `encrypt`, `decrypt`) and the default
     /// [`ConflictResolutionStrategy::MergeSimilarOrContained`].
     #[must_use]
     pub fn new() -> Self {
@@ -119,6 +119,7 @@ impl AnonymizerEngine {
         engine.register(Box::new(Replace));
         engine.register(Box::new(Redact));
         engine.register(Box::new(Mask));
+        engine.register(Box::new(Hash));
         engine.register(Box::new(Encrypt));
         engine.register(Box::new(Decrypt));
         engine

--- a/crates/octarine/src/anonymize/mod.rs
+++ b/crates/octarine/src/anonymize/mod.rs
@@ -22,16 +22,18 @@
 //!   resolution and offset tracking. Its synchronous `anonymize` applies fixed
 //!   transforms; `anonymize_async` / `deanonymize_async` inject an
 //!   `Arc<dyn StateStore>` to resolve reversible tokens through the vault.
-//! - `Replace` / `Redact` / `Mask` — the stateless built-in operators.
+//! - `Replace` / `Redact` / `Mask` / `Hash` — the stateless built-in operators.
 //!   `Replace` substitutes a fixed value (or `<ENTITY_TYPE>`), `Redact` deletes
-//!   the span, and `Mask` positionally masks characters (multi-char units and
-//!   tail-masking via `from_end`). `Custom` wraps a caller-supplied closure
-//!   (`Fn(&str) -> Result<String>`) for one-off transforms and stateful
+//!   the span, `Mask` positionally masks characters (multi-char units and
+//!   tail-masking via `from_end`), and `Hash` replaces the span with a salted
+//!   one-way digest (SHA-256/512, BLAKE3, HMAC-SHA3-256, or Argon2) under an
+//!   explicit salt-determinism contract. `Custom` wraps a caller-supplied
+//!   closure (`Fn(&str) -> Result<String>`) for one-off transforms and stateful
 //!   pseudonymization. `Encrypt` / `Decrypt` seal and open spans with
 //!   authenticated encryption (ChaCha20-Poly1305 or AES-256-GCM), binding the
 //!   ciphertext to the entity type via AAD and offering an opt-in deterministic
-//!   mode for joinable output. Further operators (hash, keep) land as
-//!   follow-up work under the `anonymize/` umbrella.
+//!   mode for joinable output. Further operators (keep) land as follow-up work
+//!   under the `anonymize/` umbrella.
 //! - `StateStore` / `SessionId` / `EntityKey` — the token-vault surface: the
 //!   backend-agnostic persistence contract behind reversible pseudonymization,
 //!   recording each `(session, original) → stable token` mapping. Pluggable
@@ -66,7 +68,7 @@ mod vault;
 
 pub use engine::AnonymizerEngine;
 pub use operator::{AsyncOperator, Operator};
-pub use operators::{Custom, Decrypt, Encrypt, Mask, Redact, Replace};
+pub use operators::{Custom, Decrypt, Encrypt, Hash, Mask, Redact, Replace};
 pub use shortcuts::{anonymize, redact_all};
 pub use types::{
     ConflictResolutionStrategy, EngineResult, OperatorConfig, OperatorResult, OperatorType,

--- a/crates/octarine/src/anonymize/operators/hash.rs
+++ b/crates/octarine/src/anonymize/operators/hash.rs
@@ -1,0 +1,594 @@
+//! Hash operator — replaces a span with a salted cryptographic digest.
+//!
+//! `Hash` is the one-way (irreversible) anonymization operator. It supports five
+//! algorithms and an explicit salt-determinism contract, wiring octarine's
+//! existing crypto primitives rather than reimplementing any digest.
+//!
+//! # Octarine vs Presidio
+//!
+//! Presidio's hash operator offers **two** algorithms (SHA-256, SHA-512) and,
+//! when no salt is supplied, generates a 32-byte random salt that is *discarded
+//! after use* — so identical inputs hash differently every call and the result
+//! is silently **non-joinable** across documents (audit §F.4 #494). Octarine
+//! fixes both:
+//!
+//! - **Five algorithms**: `sha256`, `sha512`, `blake3`, `hmac` (HMAC-SHA3-256),
+//!   and `argon2`. BLAKE3 and Argon2 have no Presidio equivalent.
+//! - **Explicit salt contract** instead of a silent footgun:
+//!   - **Stable** (`salt` param, ≥ 16 bytes) — deterministic, joinable output.
+//!   - **KdfDerived** (`kdf_ikm` [+ `kdf_info`]) — salt derived via HKDF-SHA3-256
+//!     from caller key material, also deterministic.
+//!   - **PerCallRandom** — the default *only* for keyless algorithms when no
+//!     salt is configured. Output is non-joinable, and an [`observe::warn`] is
+//!     emitted disclosing exactly that. Presidio never tells you.
+//! - **Always tagged**: every digest is prefixed with `algorithm_tag:` (e.g.
+//!   `sha256:…`, `argon2:…`) so callers know which algorithm produced it.
+//! - **Argon2 is gated**: only permitted for secret-bearing entity types
+//!   (`PiiType::is_secret()`), bridging the credential redactor surface.
+//!
+//! # The digests are single-sourced
+//!
+//! All hashing is delegated to Layer 1 primitives
+//! ([`primitives::crypto::hash`](crate::primitives::crypto::hash),
+//! [`hmac_sha3_256_hex`](crate::primitives::crypto::auth::hmac_sha3_256_hex),
+//! and the Argon2 KDF). This operator only parses parameters and assembles the
+//! salted input — so "hash an SSN" has exactly one implementation, the same one
+//! the PII redactor converges on (epic #604).
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use octarine_problem::{Problem, Result};
+use zeroize::Zeroizing;
+
+use super::super::operator::Operator;
+use super::super::{OperatorConfig, OperatorType};
+use crate::observe;
+use crate::observe::pii::PiiType;
+use crate::primitives::crypto::auth::hmac_sha3_256_hex;
+use crate::primitives::crypto::hash::{blake3_hex, sha256_hex, sha512_hex};
+use crate::primitives::crypto::keys::{
+    DomainSeparator, derive_key_from_password_sync, hkdf_sha3_256, random_salt_sized,
+};
+
+/// Algorithm selector (`sha256` default | `sha512` | `blake3` | `hmac` | `argon2`).
+const PARAM_ALGO: &str = "algo";
+/// Stable salt (UTF-8 string, ≥ 16 bytes). Presence selects deterministic output.
+const PARAM_SALT: &str = "salt";
+/// Base64 (`URL_SAFE_NO_PAD`) HMAC key. Required for `algo = "hmac"`.
+const PARAM_HMAC_KEY: &str = "hmac_key";
+/// Base64 (`URL_SAFE_NO_PAD`) input key material for KDF-derived salt.
+const PARAM_KDF_IKM: &str = "kdf_ikm";
+/// Optional domain-separation context for KDF-derived salt.
+const PARAM_KDF_INFO: &str = "kdf_info";
+
+/// Minimum length of a caller-supplied stable salt, in bytes (Presidio hardening).
+const MIN_SALT_LEN: usize = 16;
+/// Length of a generated per-call or KDF-derived salt, in bytes.
+const DERIVED_SALT_LEN: usize = 16;
+/// Length of a KDF-derived salt, in bytes.
+const KDF_SALT_LEN: usize = 32;
+/// Argon2 derived-key length, in bytes.
+const ARGON2_KEY_LEN: usize = 32;
+/// Default domain separator for KDF-derived salts.
+const DEFAULT_KDF_INFO: &str = "octarine:anonymize:hash:salt";
+
+/// The hashing algorithm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HashAlgorithm {
+    Sha256,
+    Sha512,
+    Blake3,
+    /// HMAC-SHA3-256 (octarine's only HMAC construction; post-quantum margin).
+    Hmac,
+    /// Argon2id password hashing (gated to secret entity types).
+    Argon2,
+}
+
+impl HashAlgorithm {
+    /// The output tag prefix for this algorithm.
+    fn tag(self) -> &'static str {
+        match self {
+            Self::Sha256 => "sha256",
+            Self::Sha512 => "sha512",
+            Self::Blake3 => "blake3",
+            Self::Hmac => "hmac-sha3-256",
+            Self::Argon2 => "argon2",
+        }
+    }
+
+    /// Keyless algorithms derive joinability from the salt alone, so an absent
+    /// salt falls back to per-call random (with disclosure). HMAC is keyed and
+    /// is excluded — its key is the stability anchor.
+    fn is_keyless(self) -> bool {
+        !matches!(self, Self::Hmac)
+    }
+}
+
+/// How the salt is sourced for this invocation.
+enum SaltSource {
+    /// Caller-supplied fixed salt (deterministic, joinable).
+    Stable(Vec<u8>),
+    /// Salt derived via HKDF-SHA3-256 from caller key material (deterministic).
+    KdfDerived {
+        ikm: Zeroizing<Vec<u8>>,
+        info: String,
+    },
+    /// Fresh random salt per call (non-joinable; keyless default).
+    PerCallRandom,
+}
+
+/// The validated `hash` parameters, shared by `validate` and `operate`.
+struct HashParams {
+    algo: HashAlgorithm,
+    salt: SaltSource,
+    /// Present only for [`HashAlgorithm::Hmac`].
+    hmac_key: Option<Zeroizing<Vec<u8>>>,
+}
+
+/// Replaces each span with a salted, one-way cryptographic digest.
+///
+/// Parameters (read from the [`OperatorConfig`]):
+///
+/// - `algo` (optional, default `"sha256"`): `"sha256"`, `"sha512"`, `"blake3"`,
+///   `"hmac"` (HMAC-SHA3-256), or `"argon2"`.
+/// - Salt source — at most one of:
+///   - `salt`: a UTF-8 string of **≥ 16 bytes** → deterministic, joinable.
+///   - `kdf_ikm`: base64 key material → salt derived via HKDF (deterministic);
+///     `kdf_info` optionally sets the domain separator.
+///   - neither → per-call random salt for keyless algorithms (non-joinable; a
+///     warning is emitted). HMAC needs no salt — its `hmac_key` is the anchor.
+/// - `hmac_key` (**required** for `algo = "hmac"`): base64 (`URL_SAFE_NO_PAD`).
+/// - `argon2` is only permitted for entity types whose
+///   [`PiiType::is_secret()`] is true (e.g. `PASSWORD`, `API_KEY`).
+///
+/// The output is always `algorithm_tag:hexdigest` (e.g. `sha256:9f86d0…`).
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// use octarine::anonymize::{Hash, Operator, OperatorConfig};
+/// use serde_json::json;
+///
+/// // Deterministic hashing with a stable salt: the same input always maps to
+/// // the same token, so anonymized datasets remain joinable.
+/// let mut params = HashMap::new();
+/// params.insert("algo".to_string(), json!("sha256"));
+/// params.insert("salt".to_string(), json!("a-stable-salt-of-16+"));
+/// let config = OperatorConfig::with_params("hash", params)?;
+///
+/// let a = Hash.operate("alice@example.com", "EMAIL_ADDRESS", &config)?;
+/// let b = Hash.operate("alice@example.com", "EMAIL_ADDRESS", &config)?;
+/// assert_eq!(a, b);
+/// assert!(a.starts_with("sha256:"));
+/// # Ok::<(), octarine_problem::Problem>(())
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Hash;
+
+impl Hash {
+    /// Parses and validates the operator parameters once, so
+    /// [`validate`](Operator::validate) and [`operate`](Operator::operate) share
+    /// a single source of truth.
+    fn parse_params(config: &OperatorConfig) -> Result<HashParams> {
+        let algo = Self::parse_algo(config)?;
+        let salt = Self::parse_salt(config)?;
+
+        // HMAC requires a key; the other algorithms must not be given one.
+        let hmac_key = if algo == HashAlgorithm::Hmac {
+            let encoded = config.param_str(PARAM_HMAC_KEY).ok_or_else(|| {
+                Problem::Validation(
+                    "hash operator: 'hmac_key' (base64) is required for algo 'hmac'".to_string(),
+                )
+            })?;
+            let bytes = Zeroizing::new(URL_SAFE_NO_PAD.decode(encoded).map_err(|e| {
+                Problem::Validation(format!(
+                    "hash operator: 'hmac_key' is not valid base64: {e}"
+                ))
+            })?);
+            if bytes.is_empty() {
+                return Err(Problem::Validation(
+                    "hash operator: 'hmac_key' must not be empty".to_string(),
+                ));
+            }
+            Some(bytes)
+        } else {
+            None
+        };
+
+        Ok(HashParams {
+            algo,
+            salt,
+            hmac_key,
+        })
+    }
+
+    /// Resolve the algorithm, defaulting to SHA-256.
+    fn parse_algo(config: &OperatorConfig) -> Result<HashAlgorithm> {
+        match config.param_str(PARAM_ALGO) {
+            None => Ok(HashAlgorithm::Sha256),
+            Some(name) => match name.to_ascii_lowercase().as_str() {
+                "sha256" | "sha-256" => Ok(HashAlgorithm::Sha256),
+                "sha512" | "sha-512" => Ok(HashAlgorithm::Sha512),
+                "blake3" => Ok(HashAlgorithm::Blake3),
+                "hmac" | "hmac-sha3-256" => Ok(HashAlgorithm::Hmac),
+                "argon2" | "argon2id" => Ok(HashAlgorithm::Argon2),
+                other => Err(Problem::Validation(format!(
+                    "hash operator: unsupported algo '{other}'; use 'sha256', 'sha512', \
+                     'blake3', 'hmac', or 'argon2'"
+                ))),
+            },
+        }
+    }
+
+    /// Resolve the salt source from config, enforcing the minimum stable-salt
+    /// length and rejecting conflicting salt parameters.
+    fn parse_salt(config: &OperatorConfig) -> Result<SaltSource> {
+        let has_salt = config.params.contains_key(PARAM_SALT);
+        let has_ikm = config.params.contains_key(PARAM_KDF_IKM);
+
+        if has_salt && has_ikm {
+            return Err(Problem::Validation(
+                "hash operator: provide at most one of 'salt' or 'kdf_ikm', not both".to_string(),
+            ));
+        }
+
+        if has_salt {
+            let salt = config.param_str(PARAM_SALT).ok_or_else(|| {
+                Problem::Validation("hash operator: 'salt' must be a string".to_string())
+            })?;
+            if salt.len() < MIN_SALT_LEN {
+                return Err(Problem::Validation(format!(
+                    "hash operator: 'salt' must be at least {MIN_SALT_LEN} bytes, got {}",
+                    salt.len()
+                )));
+            }
+            return Ok(SaltSource::Stable(salt.as_bytes().to_vec()));
+        }
+
+        if has_ikm {
+            let encoded = config.param_str(PARAM_KDF_IKM).ok_or_else(|| {
+                Problem::Validation("hash operator: 'kdf_ikm' must be a base64 string".to_string())
+            })?;
+            let ikm = Zeroizing::new(URL_SAFE_NO_PAD.decode(encoded).map_err(|e| {
+                Problem::Validation(format!("hash operator: 'kdf_ikm' is not valid base64: {e}"))
+            })?);
+            if ikm.is_empty() {
+                return Err(Problem::Validation(
+                    "hash operator: 'kdf_ikm' must not be empty".to_string(),
+                ));
+            }
+            let info = config
+                .param_str(PARAM_KDF_INFO)
+                .unwrap_or(DEFAULT_KDF_INFO)
+                .to_string();
+            return Ok(SaltSource::KdfDerived { ikm, info });
+        }
+
+        Ok(SaltSource::PerCallRandom)
+    }
+
+    /// Materialize the salt bytes for this call, applying the keyless per-call
+    /// random default (with disclosure) where appropriate.
+    fn resolve_salt_bytes(params: &HashParams) -> Result<Vec<u8>> {
+        match &params.salt {
+            SaltSource::Stable(bytes) => Ok(bytes.clone()),
+            SaltSource::KdfDerived { ikm, info } => {
+                hkdf_sha3_256(ikm, None, DomainSeparator::new(info), KDF_SALT_LEN)
+                    .map_err(Problem::from)
+            }
+            SaltSource::PerCallRandom => {
+                if params.algo.is_keyless() {
+                    observe::warn(
+                        "anonymize.hash",
+                        "no salt configured for a keyless hash algorithm; using a per-call \
+                         random salt — output is NOT joinable across calls. Supply 'salt' \
+                         (>=16 bytes) or 'kdf_ikm' for deterministic output.",
+                    );
+                    random_salt_sized(DERIVED_SALT_LEN).map_err(Problem::from)
+                } else {
+                    // HMAC: the key is the stability anchor; no salt needed.
+                    Ok(Vec::new())
+                }
+            }
+        }
+    }
+
+    /// Concatenate `salt || text` into a single buffer for digesting.
+    fn salted(salt: &[u8], text: &str) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(salt.len().saturating_add(text.len()));
+        buf.extend_from_slice(salt);
+        buf.extend_from_slice(text.as_bytes());
+        buf
+    }
+}
+
+impl Operator for Hash {
+    fn operate(&self, text: &str, entity_type: &str, config: &OperatorConfig) -> Result<String> {
+        let params = Self::parse_params(config)?;
+
+        // Argon2 is gated to secret-bearing entity types. The classification
+        // authority is PiiType::is_secret(); unknown labels are treated as
+        // non-secret and rejected (conservative default).
+        if params.algo == HashAlgorithm::Argon2 && !entity_is_secret(entity_type) {
+            return Err(Problem::Validation(format!(
+                "hash operator: 'argon2' is only permitted for secret entity types \
+                 (e.g. PASSWORD, API_KEY, JWT), not '{entity_type}'"
+            )));
+        }
+
+        let salt = Self::resolve_salt_bytes(&params)?;
+
+        let digest = match params.algo {
+            HashAlgorithm::Sha256 => sha256_hex(&Self::salted(&salt, text)),
+            HashAlgorithm::Sha512 => sha512_hex(&Self::salted(&salt, text)),
+            HashAlgorithm::Blake3 => blake3_hex(&Self::salted(&salt, text)),
+            HashAlgorithm::Hmac => {
+                // Key presence is guaranteed by parse_params for the HMAC algo.
+                let key = params.hmac_key.as_ref().ok_or_else(|| {
+                    Problem::Validation("hash operator: missing HMAC key".to_string())
+                })?;
+                hmac_sha3_256_hex(key, &Self::salted(&salt, text))
+            }
+            HashAlgorithm::Argon2 => {
+                let derived = Zeroizing::new(
+                    derive_key_from_password_sync(text, &salt, ARGON2_KEY_LEN)
+                        .map_err(Problem::from)?,
+                );
+                hex::encode(&*derived)
+            }
+        };
+
+        Ok(format!("{}:{digest}", params.algo.tag()))
+    }
+
+    /// Validates the algorithm, salt source, and key material before any output
+    /// is built.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Problem::Validation`] if `algo` is unknown, if both `salt` and
+    /// `kdf_ikm` are supplied, if a stable `salt` is shorter than 16 bytes, if
+    /// `kdf_ikm`/`hmac_key` are not valid base64, or if `hmac_key` is missing
+    /// for `algo = "hmac"`. The Argon2 entity-type gate is enforced per span in
+    /// [`operate`](Operator::operate), where the entity type is available.
+    fn validate(&self, config: &OperatorConfig) -> Result<()> {
+        Self::parse_params(config).map(|_| ())
+    }
+
+    fn operator_name(&self) -> &'static str {
+        "hash"
+    }
+
+    fn operator_type(&self) -> OperatorType {
+        OperatorType::Anonymize
+    }
+}
+
+/// Resolve a recognizer entity label (e.g. `"PASSWORD"`) to its [`PiiType`] for
+/// the secret-bearing labels relevant to the Argon2 gate.
+///
+/// Operators receive only the string label, never a `PiiType`. This is a
+/// deliberately conservative bridge: it covers the credential and token labels a
+/// caller would plausibly hash with Argon2, and returns `None` for anything
+/// else. Classification stays single-sourced in [`PiiType::is_secret()`] —
+/// routing through it means a mismapped non-secret label is still rejected.
+fn resolve_secret_pii_type(entity_type: &str) -> Option<PiiType> {
+    Some(match entity_type.to_ascii_uppercase().as_str() {
+        // Credential domain
+        "PASSWORD" => PiiType::Password,
+        "PIN" => PiiType::Pin,
+        "PASSPHRASE" => PiiType::Passphrase,
+        "SECURITY_ANSWER" => PiiType::SecurityAnswer,
+        // Token domain (secret-bearing)
+        "API_KEY" | "APIKEY" => PiiType::ApiKey,
+        "JWT" => PiiType::Jwt,
+        "SESSION_ID" | "SESSION" => PiiType::SessionId,
+        "OAUTH_TOKEN" => PiiType::OAuthToken,
+        "SSH_KEY" => PiiType::SshKey,
+        "BEARER_TOKEN" => PiiType::BearerToken,
+        "CONNECTION_STRING" => PiiType::ConnectionString,
+        "URL_WITH_CREDENTIALS" => PiiType::UrlWithCredentials,
+        _ => return None,
+    })
+}
+
+/// Whether `entity_type` names a secret-bearing entity (Argon2 gate).
+fn entity_is_secret(entity_type: &str) -> bool {
+    resolve_secret_pii_type(entity_type).is_some_and(|t| t.is_secret())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+
+    use std::collections::HashMap;
+
+    use proptest::prelude::*;
+    use serde_json::{Value, json};
+
+    use super::*;
+
+    /// A 16-byte stable salt (meets the minimum length).
+    const STABLE_SALT: &str = "0123456789abcdef";
+    /// 32 key bytes (all `0x07`), base64url-no-pad — an HMAC test key.
+    const HMAC_KEY_B64: &str = "BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc";
+    /// 32 key bytes (all `0x01`), base64url-no-pad — KDF input key material.
+    const KDF_IKM_B64: &str = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE";
+    /// 32 key bytes (all `0x09`), base64url-no-pad — alternate KDF input.
+    const KDF_IKM_ALT_B64: &str = "CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk";
+
+    fn config_with(params: &[(&str, Value)]) -> OperatorConfig {
+        let mut map = HashMap::new();
+        for (k, v) in params {
+            map.insert((*k).to_string(), v.clone());
+        }
+        OperatorConfig::with_params("hash", map).expect("config")
+    }
+
+    #[test]
+    fn defaults_to_sha256_tag() {
+        let config = config_with(&[("salt", json!(STABLE_SALT))]);
+        let out = Hash
+            .operate("secret", "EMAIL_ADDRESS", &config)
+            .expect("hash");
+        assert!(out.starts_with("sha256:"), "got {out}");
+    }
+
+    #[test]
+    fn each_algorithm_produces_its_tag() {
+        let cases = [
+            ("sha256", "sha256:"),
+            ("sha512", "sha512:"),
+            ("blake3", "blake3:"),
+        ];
+        for (algo, prefix) in cases {
+            let config = config_with(&[("algo", json!(algo)), ("salt", json!(STABLE_SALT))]);
+            let out = Hash
+                .operate("data", "EMAIL_ADDRESS", &config)
+                .expect("hash");
+            assert!(out.starts_with(prefix), "algo {algo} => {out}");
+        }
+
+        // HMAC is keyed.
+        let hmac = config_with(&[("algo", json!("hmac")), ("hmac_key", json!(HMAC_KEY_B64))]);
+        let out = Hash.operate("data", "EMAIL_ADDRESS", &hmac).expect("hmac");
+        assert!(out.starts_with("hmac-sha3-256:"), "got {out}");
+
+        // Argon2 requires a secret entity type.
+        let argon2 = config_with(&[("algo", json!("argon2")), ("salt", json!(STABLE_SALT))]);
+        let out = Hash
+            .operate("hunter2", "PASSWORD", &argon2)
+            .expect("argon2");
+        assert!(out.starts_with("argon2:"), "got {out}");
+    }
+
+    #[test]
+    fn rejects_unknown_algorithm() {
+        let config = config_with(&[("algo", json!("md5")), ("salt", json!(STABLE_SALT))]);
+        assert!(Hash.validate(&config).is_err());
+        assert!(Hash.operate("x", "EMAIL_ADDRESS", &config).is_err());
+    }
+
+    #[test]
+    fn rejects_short_stable_salt() {
+        let config = config_with(&[("salt", json!("tooshort"))]);
+        assert!(Hash.validate(&config).is_err());
+    }
+
+    #[test]
+    fn rejects_both_salt_and_kdf_ikm() {
+        let config = config_with(&[
+            ("salt", json!(STABLE_SALT)),
+            ("kdf_ikm", json!(KDF_IKM_B64)),
+        ]);
+        assert!(Hash.validate(&config).is_err());
+    }
+
+    #[test]
+    fn hmac_requires_key() {
+        let config = config_with(&[("algo", json!("hmac"))]);
+        assert!(Hash.validate(&config).is_err());
+        assert!(Hash.operate("x", "EMAIL_ADDRESS", &config).is_err());
+    }
+
+    #[test]
+    fn hmac_rejects_bad_base64_key() {
+        let config = config_with(&[("algo", json!("hmac")), ("hmac_key", json!("not base64!!"))]);
+        assert!(Hash.validate(&config).is_err());
+    }
+
+    #[test]
+    fn stable_salt_is_deterministic() {
+        let config = config_with(&[("salt", json!(STABLE_SALT))]);
+        let a = Hash.operate("alice", "EMAIL_ADDRESS", &config).expect("a");
+        let b = Hash.operate("alice", "EMAIL_ADDRESS", &config).expect("b");
+        assert_eq!(a, b, "stable salt must be joinable");
+    }
+
+    #[test]
+    fn per_call_random_differs_each_call() {
+        // No salt configured for a keyless algorithm => per-call random.
+        let config = config_with(&[("algo", json!("sha256"))]);
+        let a = Hash.operate("alice", "EMAIL_ADDRESS", &config).expect("a");
+        let b = Hash.operate("alice", "EMAIL_ADDRESS", &config).expect("b");
+        assert_ne!(a, b, "per-call random salt must differ each call");
+        assert!(a.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn kdf_derived_salt_is_deterministic() {
+        let config = config_with(&[
+            ("algo", json!("sha512")),
+            ("kdf_ikm", json!(KDF_IKM_ALT_B64)),
+        ]);
+        let a = Hash.operate("bob", "EMAIL_ADDRESS", &config).expect("a");
+        let b = Hash.operate("bob", "EMAIL_ADDRESS", &config).expect("b");
+        assert_eq!(a, b, "KDF-derived salt must be deterministic");
+        assert!(a.starts_with("sha512:"));
+    }
+
+    #[test]
+    fn argon2_rejected_for_non_secret_entity() {
+        let config = config_with(&[("algo", json!("argon2")), ("salt", json!(STABLE_SALT))]);
+        // US_SSN is sensitive but not a secret per PiiType::is_secret().
+        assert!(Hash.operate("123-45-6789", "US_SSN", &config).is_err());
+    }
+
+    #[test]
+    fn argon2_allowed_for_secret_entity() {
+        let config = config_with(&[("algo", json!("argon2")), ("salt", json!(STABLE_SALT))]);
+        for label in ["PASSWORD", "API_KEY", "JWT", "PIN"] {
+            assert!(
+                Hash.operate("s3cr3t", label, &config).is_ok(),
+                "argon2 should be allowed for {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn entity_secret_resolution_uses_pii_type_authority() {
+        assert!(entity_is_secret("PASSWORD"));
+        assert!(entity_is_secret("password")); // case-insensitive
+        assert!(!entity_is_secret("EMAIL_ADDRESS"));
+        assert!(!entity_is_secret("UNKNOWN_LABEL"));
+    }
+
+    #[test]
+    fn hmac_is_deterministic_without_salt() {
+        // HMAC is keyed: a stable key yields joinable output even with no salt.
+        let config = config_with(&[("algo", json!("hmac")), ("hmac_key", json!(HMAC_KEY_B64))]);
+        let a = Hash.operate("carol", "EMAIL_ADDRESS", &config).expect("a");
+        let b = Hash.operate("carol", "EMAIL_ADDRESS", &config).expect("b");
+        assert_eq!(a, b, "stable HMAC key must be joinable");
+    }
+
+    #[test]
+    fn reports_operator_identity() {
+        assert_eq!(Hash.operator_name(), "hash");
+        assert_eq!(Hash.operator_type(), OperatorType::Anonymize);
+    }
+
+    proptest! {
+        /// A stable salt makes any keyless algorithm deterministic over
+        /// arbitrary UTF-8 input.
+        #[test]
+        fn stable_salt_joinable_for_all_keyless(
+            text in ".*",
+            algo in prop::sample::select(vec!["sha256", "sha512", "blake3"]),
+        ) {
+            let config = config_with(&[("algo", json!(algo)), ("salt", json!(STABLE_SALT))]);
+            let a = Hash.operate(&text, "EMAIL_ADDRESS", &config).expect("a");
+            let b = Hash.operate(&text, "EMAIL_ADDRESS", &config).expect("b");
+            prop_assert_eq!(a, b);
+        }
+
+        /// Output is always `algorithm_tag:` prefixed.
+        #[test]
+        fn output_always_tagged(text in ".{0,64}") {
+            let config = config_with(&[("salt", json!(STABLE_SALT))]);
+            let out = Hash.operate(&text, "EMAIL_ADDRESS", &config).expect("hash");
+            prop_assert!(out.starts_with("sha256:"));
+        }
+    }
+}

--- a/crates/octarine/src/anonymize/operators/mod.rs
+++ b/crates/octarine/src/anonymize/operators/mod.rs
@@ -4,14 +4,15 @@
 //! [`Operator`](crate::anonymize::Operator) trait. The
 //! [`AnonymizerEngine`](crate::anonymize::AnonymizerEngine) seeds its default
 //! registry with the stateless built-ins here ([`Replace`], [`Redact`],
-//! [`Mask`], [`Encrypt`], [`Decrypt`]); [`Custom`] carries a caller-supplied
-//! closure and is registered explicitly via
+//! [`Mask`], [`Hash`], [`Encrypt`], [`Decrypt`]); [`Custom`] carries a
+//! caller-supplied closure and is registered explicitly via
 //! [`with_operator`](crate::anonymize::AnonymizerEngine::with_operator).
 //! Additional operators land as follow-up work under the `anonymize/` umbrella.
 
 mod custom;
 mod decrypt;
 mod encrypt;
+mod hash;
 mod keyed_config;
 mod mask;
 mod redact;
@@ -20,6 +21,7 @@ mod replace;
 pub use custom::Custom;
 pub use decrypt::Decrypt;
 pub use encrypt::Encrypt;
+pub use hash::Hash;
 pub use mask::Mask;
 pub use redact::Redact;
 pub use replace::Replace;

--- a/crates/octarine/src/primitives/crypto/hash/mod.rs
+++ b/crates/octarine/src/primitives/crypto/hash/mod.rs
@@ -1,0 +1,176 @@
+//! Plain cryptographic digests — SHA-256, SHA-512, and BLAKE3.
+//!
+//! Pure one-shot digest helpers with **no** observe dependencies, mirroring the
+//! HMAC primitive's style ([`hmac_sha3_256`](super::auth::hmac_sha3_256)). These
+//! are the single source of truth for "hash these bytes" across octarine — the
+//! anonymizer `Hash` operator and (per epic #604) the PII redactor both build on
+//! them, so a digest is computed in exactly one place.
+//!
+//! ## Algorithm choice
+//!
+//! | Function   | Algorithm | Output | Use case                                  |
+//! |------------|-----------|--------|-------------------------------------------|
+//! | [`sha256`] | SHA-256   | 32 B   | Presidio-compatible PII tokenization      |
+//! | [`sha512`] | SHA-512   | 64 B   | Wider digest, same SHA-2 family           |
+//! | [`blake3`] | BLAKE3    | 32 B   | Fast modern digest (Presidio has none)    |
+//!
+//! For *keyed* authentication use [`hmac_sha3_256`](super::auth::hmac_sha3_256);
+//! for *password* hashing use the Argon2 KDF in
+//! [`keys`](super::keys). These plain digests are unkeyed and must be combined
+//! with a salt by the caller when collision/pre-image resistance over
+//! low-entropy inputs matters.
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use crate::primitives::crypto::hash::{sha256_hex, blake3_hex};
+//!
+//! let digest = sha256_hex(b"alice@example.com");
+//! assert_eq!(digest.len(), 64); // 32 bytes = 64 hex chars
+//!
+//! let fast = blake3_hex(b"alice@example.com");
+//! assert_eq!(fast.len(), 64);
+//! ```
+
+// Allow dead_code: Layer 1 primitives used by Layer 3 modules (anonymize, #604 redactor).
+#![allow(dead_code)]
+
+use sha2::{Digest, Sha256, Sha512};
+
+/// SHA-256 output size in bytes (256 bits).
+pub const SHA256_LENGTH: usize = 32;
+
+/// SHA-512 output size in bytes (512 bits).
+pub const SHA512_LENGTH: usize = 64;
+
+/// BLAKE3 default output size in bytes (256 bits).
+pub const BLAKE3_LENGTH: usize = 32;
+
+/// Compute the SHA-256 digest of `data`.
+///
+/// # Example
+///
+/// ```ignore
+/// use crate::primitives::crypto::hash::sha256;
+///
+/// let digest = sha256(b"data");
+/// assert_eq!(digest.len(), 32);
+/// ```
+#[must_use]
+pub fn sha256(data: &[u8]) -> [u8; SHA256_LENGTH] {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
+/// Compute the SHA-256 digest of `data` as a lowercase hex string.
+#[must_use]
+pub fn sha256_hex(data: &[u8]) -> String {
+    hex::encode(sha256(data))
+}
+
+/// Compute the SHA-512 digest of `data`.
+///
+/// # Example
+///
+/// ```ignore
+/// use crate::primitives::crypto::hash::sha512;
+///
+/// let digest = sha512(b"data");
+/// assert_eq!(digest.len(), 64);
+/// ```
+#[must_use]
+pub fn sha512(data: &[u8]) -> [u8; SHA512_LENGTH] {
+    let mut hasher = Sha512::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
+/// Compute the SHA-512 digest of `data` as a lowercase hex string.
+#[must_use]
+pub fn sha512_hex(data: &[u8]) -> String {
+    hex::encode(sha512(data))
+}
+
+/// Compute the BLAKE3 digest of `data` (32-byte default output).
+///
+/// # Example
+///
+/// ```ignore
+/// use crate::primitives::crypto::hash::blake3;
+///
+/// let digest = blake3(b"data");
+/// assert_eq!(digest.len(), 32);
+/// ```
+#[must_use]
+pub fn blake3(data: &[u8]) -> [u8; BLAKE3_LENGTH] {
+    *::blake3::hash(data).as_bytes()
+}
+
+/// Compute the BLAKE3 digest of `data` as a lowercase hex string.
+#[must_use]
+pub fn blake3_hex(data: &[u8]) -> String {
+    hex::encode(blake3(data))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+
+    use super::*;
+
+    // Known-answer vectors (NIST / official test vectors).
+
+    #[test]
+    fn sha256_matches_known_vector() {
+        // SHA-256("abc")
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn sha256_empty_input() {
+        // SHA-256("")
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sha512_matches_known_vector() {
+        // SHA-512("abc")
+        assert_eq!(
+            sha512_hex(b"abc"),
+            "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a\
+             2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+        );
+    }
+
+    #[test]
+    fn blake3_matches_known_vector() {
+        // BLAKE3("abc") — official test vector.
+        assert_eq!(
+            blake3_hex(b"abc"),
+            "6437b3ac38465133ffb63b75273a8db548c558465d79db03fd359c6cd5bd9d85"
+        );
+    }
+
+    #[test]
+    fn digest_lengths_are_correct() {
+        assert_eq!(sha256(b"x").len(), SHA256_LENGTH);
+        assert_eq!(sha512(b"x").len(), SHA512_LENGTH);
+        assert_eq!(blake3(b"x").len(), BLAKE3_LENGTH);
+        assert_eq!(sha256_hex(b"x").len(), SHA256_LENGTH * 2);
+        assert_eq!(sha512_hex(b"x").len(), SHA512_LENGTH * 2);
+        assert_eq!(blake3_hex(b"x").len(), BLAKE3_LENGTH * 2);
+    }
+
+    #[test]
+    fn distinct_inputs_distinct_digests() {
+        assert_ne!(sha256_hex(b"a"), sha256_hex(b"b"));
+        assert_ne!(blake3_hex(b"a"), blake3_hex(b"b"));
+    }
+}

--- a/crates/octarine/src/primitives/crypto/mod.rs
+++ b/crates/octarine/src/primitives/crypto/mod.rs
@@ -94,6 +94,7 @@
 // Domain modules - accessible as crate::primitives::crypto::<domain>::*
 pub(crate) mod auth;
 pub(crate) mod encryption;
+pub(crate) mod hash;
 pub(crate) mod keys;
 pub(crate) mod secrets;
 
@@ -124,6 +125,7 @@ pub use error::CryptoError;
 // Domain modules are accessed via their namespace:
 //   crate::primitives::crypto::auth::*
 //   crate::primitives::crypto::encryption::*
+//   crate::primitives::crypto::hash::*
 //   crate::primitives::crypto::keys::*
 //   crate::primitives::crypto::secrets::*
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds the one-way **`Hash`** anonymize operator, wiring octarine's existing crypto rather than reinventing it. Beats Presidio on two axes: **five algorithms** (SHA-256, SHA-512, BLAKE3, HMAC-SHA3-256, Argon2 — vs Presidio's SHA-256/512 only) and an **explicit salt-determinism contract** that fixes the silent non-joinable-salt anti-pattern (audit §F.4 #494).

- **New Layer 1 digest primitive** `primitives/crypto/hash/` (`sha256`/`sha512`/`blake3` + `_hex` variants) — the single source of truth the PII redactor converges on per epic #604. Adds the `blake3` dependency.
- **Salt contract**: `Stable` (≥16-byte salt → joinable), `KdfDerived` (HKDF-SHA3-256 from key material → joinable), `PerCallRandom` (keyless default when no salt → non-joinable, with a loud `observe::warn` disclosure).
- **Delegates, never reinvents**: HMAC via `hmac_sha3_256`, Argon2 via the existing KDF, salt via the secure-random primitive.
- **Argon2 gated** to secret-bearing entity types via `PiiType::is_secret()`.
- **Always tagged**: output is `algorithm_tag:hexdigest`.
- Registered in the engine's default registry and re-exported from `anonymize`.

## Test plan

- Operator tests: five algorithms produce tagged digests; `Stable`/`KdfDerived` deterministic; `PerCallRandom` differs per call; salt <16 bytes rejected; Argon2 rejected for non-secret entity (`US_SSN`) and accepted for secret entities (`PASSWORD`/`API_KEY`/`JWT`/`PIN`); HMAC requires a key; proptests for joinability and tagging.
- Primitive digest unit tests against NIST/official known-answer vectors (SHA-256/512, BLAKE3).
- Full suite green via `just`: `fmt-check`, `clippy` (`-D warnings`), `test-mod anonymize` (126 passed), doctests, `doc` (strict rustdoc), `arch-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #484