### PR TITLE
feat(identifiers): Swedish Personnummer + Organisationsnummer (#435)

### DIFF
--- a/crates/octarine/src/identifiers/builder/government/europe.rs
+++ b/crates/octarine/src/identifiers/builder/government/europe.rs
@@ -1,5 +1,6 @@
 //! European national-identifier methods — Finland (HETU), Spain (NIF + NIE),
-//! Italy (Codice Fiscale), Poland (PESEL).
+//! Italy (Codice Fiscale), Poland (PESEL), Sweden (Personnummer +
+//! Organisationsnummer).
 
 use super::*;
 
@@ -444,5 +445,127 @@ impl GovernmentBuilder {
     /// Validate Polish PESEL with weighted checksum verification
     pub fn validate_poland_pesel_with_checksum(&self, pesel: &str) -> Result<(), Problem> {
         self.inner.validate_poland_pesel_with_checksum(pesel)
+    }
+
+    // ---- Sweden Personnummer -------------------------------------------------
+
+    /// Check if value matches a Swedish personnummer pattern
+    #[must_use]
+    pub fn is_sweden_personnummer(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_sweden_personnummer(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Validate Swedish personnummer format
+    pub fn validate_sweden_personnummer(&self, value: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_sweden_personnummer(value);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "sweden_personnummer_validation_failed",
+                    "Invalid Sweden personnummer format",
+                );
+            }
+        }
+        result
+    }
+
+    /// Validate Swedish personnummer with Luhn checksum verification
+    pub fn validate_sweden_personnummer_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        self.inner.validate_sweden_personnummer_with_checksum(value)
+    }
+
+    /// Find all Swedish personnummer mentions in text
+    #[must_use]
+    pub fn find_sweden_personnummers_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_sweden_personnummers_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    // ---- Sweden Organisationsnummer ------------------------------------------
+
+    /// Check if value matches a Swedish organisationsnummer pattern
+    #[must_use]
+    pub fn is_sweden_orgnummer(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_sweden_orgnummer(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Validate Swedish organisationsnummer format
+    pub fn validate_sweden_orgnummer(&self, value: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_sweden_orgnummer(value);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "sweden_orgnummer_validation_failed",
+                    "Invalid Sweden organisationsnummer format",
+                );
+            }
+        }
+        result
+    }
+
+    /// Validate Swedish organisationsnummer with Luhn checksum verification
+    pub fn validate_sweden_orgnummer_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        self.inner.validate_sweden_orgnummer_with_checksum(value)
+    }
+
+    /// Find all Swedish organisationsnummer mentions in text
+    #[must_use]
+    pub fn find_sweden_orgnummers_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_sweden_orgnummers_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+            }
+        }
+        matches
     }
 }

--- a/crates/octarine/src/identifiers/shortcuts/government.rs
+++ b/crates/octarine/src/identifiers/shortcuts/government.rs
@@ -512,6 +512,70 @@ pub fn validate_turkey_license_plate(plate: &str) -> Result<(), Problem> {
     GovernmentBuilder::new().validate_turkey_license_plate(plate)
 }
 
+// ============================================================================
+// Sweden
+// ============================================================================
+
+/// Check if value is a Sweden personnummer (shape + date sanity)
+#[must_use]
+pub fn is_sweden_personnummer(value: &str) -> bool {
+    GovernmentBuilder::new().is_sweden_personnummer(value)
+}
+
+/// Find all Sweden personnummers in text (label-anchored only)
+#[must_use]
+pub fn find_sweden_personnummers(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_sweden_personnummers_in_text(text)
+}
+
+/// Validate a Sweden personnummer format
+///
+/// # Errors
+///
+/// Returns `Problem` if the format or date is invalid.
+pub fn validate_sweden_personnummer(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_sweden_personnummer(value)
+}
+
+/// Validate a Sweden personnummer with Luhn checksum verification
+///
+/// # Errors
+///
+/// Returns `Problem` if the format, date, or checksum is invalid.
+pub fn validate_sweden_personnummer_with_checksum(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_sweden_personnummer_with_checksum(value)
+}
+
+/// Check if value is a Sweden organisationsnummer (shape + third-digit rule)
+#[must_use]
+pub fn is_sweden_orgnummer(value: &str) -> bool {
+    GovernmentBuilder::new().is_sweden_orgnummer(value)
+}
+
+/// Find all Sweden organisationsnummers in text (label-anchored only)
+#[must_use]
+pub fn find_sweden_orgnummers(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_sweden_orgnummers_in_text(text)
+}
+
+/// Validate a Sweden organisationsnummer format
+///
+/// # Errors
+///
+/// Returns `Problem` if the format or third-digit rule is invalid.
+pub fn validate_sweden_orgnummer(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_sweden_orgnummer(value)
+}
+
+/// Validate a Sweden organisationsnummer with Luhn checksum verification
+///
+/// # Errors
+///
+/// Returns `Problem` if the format or checksum is invalid.
+pub fn validate_sweden_orgnummer_with_checksum(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_sweden_orgnummer_with_checksum(value)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
@@ -659,5 +723,33 @@ mod tests {
         assert!(validate_turkey_license_plate("34 ABC 123").is_ok());
         assert!(validate_turkey_license_plate("34 QBC 123").is_err()); // reserved letter
         assert!(!find_turkey_license_plates("Plaka: 34 ABC 123").is_empty());
+    }
+
+    #[test]
+    fn test_sweden_personnummer_shortcuts() {
+        // Canonical Swedish test personnummer.
+        assert!(is_sweden_personnummer("19121212-1212"));
+        assert!(validate_sweden_personnummer("19121212-1212").is_ok());
+        assert!(validate_sweden_personnummer_with_checksum("19121212-1212").is_ok());
+        assert!(validate_sweden_personnummer("").is_err());
+        // Bad month rejected.
+        assert!(validate_sweden_personnummer("811328-1234").is_err());
+        // Text scanning requires a label — bare digits collide with dates/phones.
+        assert!(!find_sweden_personnummers("personnummer: 19121212-1212").is_empty());
+        assert!(find_sweden_personnummers("19121212-1212").is_empty());
+    }
+
+    #[test]
+    fn test_sweden_orgnummer_shortcuts() {
+        // 556016-0680 has third digit 6 (>= 2) and a valid Luhn check digit.
+        assert!(is_sweden_orgnummer("556016-0680"));
+        assert!(validate_sweden_orgnummer("556016-0680").is_ok());
+        assert!(validate_sweden_orgnummer_with_checksum("556016-0680").is_ok());
+        // Third digit < 2 is a personnummer shape, not an orgnummer.
+        assert!(!is_sweden_orgnummer("551016-0680"));
+        assert!(validate_sweden_orgnummer("").is_err());
+        // Label-gated text scanning.
+        assert!(!find_sweden_orgnummers("orgnr: 556016-0680").is_empty());
+        assert!(find_sweden_orgnummers("556016-0680").is_empty());
     }
 }

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -207,7 +207,9 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             | PiiType::UkNi
             | PiiType::UkNhs
             | PiiType::UkPassport
-            | PiiType::UkDrivingLicence => {
+            | PiiType::UkDrivingLicence
+            | PiiType::SwedenPersonnummer
+            | PiiType::SwedenOrgnummer => {
                 // Generic government ID redaction routes through
                 // redact_all_government_ids_in_text_with_policy, which already
                 // covers all country-specific finders.

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -269,6 +269,14 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
             GovernmentIdentifierBuilder::find_uk_driving_licences_in_text,
             PiiType::UkDrivingLicence,
         ),
+        (
+            GovernmentIdentifierBuilder::find_sweden_personnummers_in_text,
+            PiiType::SwedenPersonnummer,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_sweden_orgnummers_in_text,
+            PiiType::SwedenOrgnummer,
+        ),
     ];
 
     let government = GovernmentIdentifierBuilder::new();

--- a/crates/octarine/src/observe/pii/types/classification.rs
+++ b/crates/octarine/src/observe/pii/types/classification.rs
@@ -30,6 +30,7 @@ impl PiiType {
             Self::ItalyVat | Self::ItalyPassport | Self::ItalyIdentityCard | Self::ItalyDriverLicense |
             Self::SpainNif | Self::SpainNie | Self::UkNi |
             Self::UkNhs | Self::UkPassport | Self::UkDrivingLicence |
+            Self::SwedenPersonnummer | Self::SwedenOrgnummer |
             // Medical (HIPAA)
             Self::Mrn | Self::Npi | Self::InsuranceNumber | Self::DeaNumber | Self::IcdCode | Self::PrescriptionNumber |
             // Biometric (irreplaceable)
@@ -76,6 +77,7 @@ impl PiiType {
             Self::ItalyVat | Self::ItalyPassport | Self::ItalyIdentityCard | Self::ItalyDriverLicense |
             Self::SpainNif | Self::SpainNie | Self::UkNi |
             Self::UkNhs | Self::UkPassport | Self::UkDrivingLicence |
+            Self::SwedenPersonnummer | Self::SwedenOrgnummer |
             // Financial — IBAN identifies an EU account holder (Recital 30 /
             // Art. 4(1)). Crypto addresses are pseudonymous by design and are
             // excluded unless linked to an identifiable person upstream.

--- a/crates/octarine/src/observe/pii/types/core.rs
+++ b/crates/octarine/src/observe/pii/types/core.rs
@@ -71,6 +71,8 @@ impl PiiType {
             Self::UkNhs => "uk_nhs",
             Self::UkPassport => "uk_passport",
             Self::UkDrivingLicence => "uk_driving_licence",
+            Self::SwedenPersonnummer => "sweden_personnummer",
+            Self::SwedenOrgnummer => "sweden_orgnummer",
             // Medical
             Self::Mrn => "mrn",
             Self::Npi => "npi",
@@ -225,7 +227,9 @@ impl PiiType {
             | Self::UkNi
             | Self::UkNhs
             | Self::UkPassport
-            | Self::UkDrivingLicence => "government",
+            | Self::UkDrivingLicence
+            | Self::SwedenPersonnummer
+            | Self::SwedenOrgnummer => "government",
             Self::Mrn
             | Self::Npi
             | Self::InsuranceNumber

--- a/crates/octarine/src/observe/pii/types/mapping.rs
+++ b/crates/octarine/src/observe/pii/types/mapping.rs
@@ -118,6 +118,8 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::UkNhs => Self::UkNhs,
             IdentifierType::UkPassport => Self::UkPassport,
             IdentifierType::UkDrivingLicence => Self::UkDrivingLicence,
+            IdentifierType::SwedenPersonnummer => Self::SwedenPersonnummer,
+            IdentifierType::SwedenOrgnummer => Self::SwedenOrgnummer,
 
             // Organizational
             IdentifierType::EmployeeId => Self::EmployeeId,

--- a/crates/octarine/src/observe/pii/types/mod.rs
+++ b/crates/octarine/src/observe/pii/types/mod.rs
@@ -173,6 +173,10 @@ pub enum PiiType {
     UkPassport,
     /// UK DVLA Driving Licence (16-char structural format)
     UkDrivingLicence,
+    /// Swedish personal identity number (personnummer)
+    SwedenPersonnummer,
+    /// Swedish organisationsnummer (company identity number)
+    SwedenOrgnummer,
 
     // =========================================================================
     // Medical Domain (PHI - Protected Health Information)

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -44,8 +44,9 @@ pub(crate) use personal::{
     italy_identity_card, italy_passport, italy_vat, korea_brn, korea_driver_license, korea_frn,
     korea_passport, korea_rrn, mexico_curp, national_id, nigeria_bvn, nigeria_nin,
     nigeria_vehicle_reg, passport, personal_name, poland_pesel, singapore_nric, singapore_uen,
-    spain_nie, spain_nif, ssn, student_id, tax_id, thailand_tnin, turkey_license_plate,
-    turkey_tckn, uk_driving_licence, uk_nhs, uk_ni, uk_passport,
+    spain_nie, spain_nif, ssn, student_id, sweden_orgnummer, sweden_personnummer, tax_id,
+    thailand_tnin, turkey_license_plate, turkey_tckn, uk_driving_licence, uk_nhs, uk_ni,
+    uk_passport,
 };
 
 // medical, biometric, location, and vehicle modules are already accessible via pub mod declarations

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use regional_identifiers::{
     birthdate, brazil_cnpj, brazil_cpf, finland_hetu, italy_driver_license, italy_fiscal_code,
     italy_identity_card, italy_passport, italy_vat, mexico_curp, nigeria_bvn, nigeria_nin,
     nigeria_vehicle_reg, personal_name, poland_pesel, singapore_nric, singapore_uen, spain_nie,
-    spain_nif, thailand_tnin, turkey_license_plate, turkey_tckn, uk_driving_licence, uk_nhs, uk_ni,
-    uk_passport,
+    spain_nif, sweden_orgnummer, sweden_personnummer, thailand_tnin, turkey_license_plate,
+    turkey_tckn, uk_driving_licence, uk_nhs, uk_ni, uk_passport,
 };
 pub(crate) use us_identifiers::{driver_license, employee_id, passport, ssn, student_id, tax_id};

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
@@ -2,8 +2,9 @@
 //!
 //! Brazil (CPF, CNPJ), Mexico (CURP), Nigeria (NIN), Thailand (TNIN),
 //! Turkey (TCKN, License Plate), Singapore (NRIC), Finland (HETU), UK NI,
-//! Spain (NIF, NIE), Italy (codice fiscale), Poland (PESEL), plus generic
-//! personal names and birthdate patterns.
+//! Spain (NIF, NIE), Italy (codice fiscale), Poland (PESEL), Sweden
+//! (Personnummer, Organisationsnummer), plus generic personal names and
+//! birthdate patterns.
 
 // arch-check: allow file-length — country-specific regex registry that grows
 // by ~30 LOC per identifier. A follow-up should split into regional submodules
@@ -692,6 +693,72 @@ pub(crate) mod poland_pesel {
 
     pub fn all() -> Vec<&'static Regex> {
         vec![&*LABELED, &*STANDARD]
+    }
+}
+
+/// Sweden Personnummer patterns
+///
+/// Format: `YYMMDD-NNNC`, `YYMMDD+NNNC` (10-digit core, `+` marks 100+ years),
+/// or `YYYYMMDDNNNC` (12-digit). The trailing `NNNC` is a 3-digit individual
+/// number plus a Luhn check digit. `is_sweden_personnummer` /
+/// `validate_sweden_personnummer` apply month/day sanity (including
+/// samordningsnummer, day 61-91) on top of these shape-only patterns.
+pub(crate) mod sweden_personnummer {
+    use super::*;
+
+    /// Shape: 6 or 8 leading digits + optional `-`/`+` + 4 digits.
+    pub static STANDARD: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b\d{6}(?:\d{2})?[-+]?\d{4}\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// Personnummer with explicit label (Swedish + English aliases)
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:personnummer|personnr|pers\.?\s?nr|samordningsnummer|pnr)[\s:#-]*(\d{6}(?:\d{2})?[-+]?\d{4})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
+    }
+
+    /// Label-anchored only — used by text scanners. A bare 10/12-digit run
+    /// collides with dates, phone numbers, and Swedish orgnummer.
+    pub fn labeled_only() -> Vec<&'static Regex> {
+        vec![&*LABELED]
+    }
+}
+
+/// Sweden Organisationsnummer patterns
+///
+/// Format: `NNNNNN-NNNN` or 10 bare digits. The third digit is `>= 2`, which
+/// distinguishes an orgnummer from a personnummer. `is_sweden_orgnummer` /
+/// `validate_sweden_orgnummer` enforce the third-digit rule and Luhn on top of
+/// these shape-only patterns.
+pub(crate) mod sweden_orgnummer {
+    use super::*;
+
+    /// Shape: 6 digits + optional `-` + 4 digits.
+    pub static STANDARD: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\b\d{6}-?\d{4}\b").expect("BUG: Invalid regex pattern"));
+
+    /// Orgnummer with explicit label (Swedish + English aliases)
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:organisationsnummer|org\.?\s?nr|orgnr|organization[\s-]?number)[\s:#-]*(\d{6}-?\d{4})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
+    }
+
+    /// Label-anchored only — used by text scanners. A bare 10-digit run
+    /// collides with phone numbers and Swedish personnummer.
+    pub fn labeled_only() -> Vec<&'static Regex> {
+        vec![&*LABELED]
     }
 }
 

--- a/crates/octarine/src/primitives/identifiers/government/builder/europe.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/europe.rs
@@ -1,6 +1,7 @@
 //! European national identifier operations on `GovernmentIdentifierBuilder`.
 //!
-//! Covers Finland HETU, Spain NIF and NIE, Italy Codice Fiscale, and Poland PESEL.
+//! Covers Finland HETU, Spain NIF and NIE, Italy Codice Fiscale, Poland PESEL,
+//! and Sweden Personnummer + Organisationsnummer.
 
 use super::*;
 
@@ -311,5 +312,81 @@ impl GovernmentIdentifierBuilder {
     #[must_use]
     pub fn is_test_poland_pesel(&self, pesel: &str) -> bool {
         validation::is_test_poland_pesel(pesel)
+    }
+
+    // ---- Sweden Personnummer -------------------------------------------------
+
+    /// Check if value matches Sweden personnummer format (shape + date sanity)
+    #[must_use]
+    pub fn is_sweden_personnummer(&self, value: &str) -> bool {
+        detection::is_sweden_personnummer(value)
+    }
+
+    /// Find all Sweden personnummers in text (label-anchored)
+    #[must_use]
+    pub fn find_sweden_personnummers_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_sweden_personnummers_in_text(text)
+    }
+
+    /// Validate Sweden personnummer format (without checksum)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the format or date is invalid
+    pub fn validate_sweden_personnummer(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_sweden_personnummer(value)
+    }
+
+    /// Validate Sweden personnummer with Luhn checksum
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the format, date, or checksum is invalid
+    pub fn validate_sweden_personnummer_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_sweden_personnummer_with_checksum(value)
+    }
+
+    /// Check if a Sweden personnummer is a test/dummy pattern
+    #[must_use]
+    pub fn is_test_sweden_personnummer(&self, value: &str) -> bool {
+        validation::is_test_sweden_personnummer(value)
+    }
+
+    // ---- Sweden Organisationsnummer -----------------------------------------
+
+    /// Check if value matches Sweden organisationsnummer format (shape + third-digit rule)
+    #[must_use]
+    pub fn is_sweden_orgnummer(&self, value: &str) -> bool {
+        detection::is_sweden_orgnummer(value)
+    }
+
+    /// Find all Sweden organisationsnummers in text (label-anchored)
+    #[must_use]
+    pub fn find_sweden_orgnummers_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_sweden_orgnummers_in_text(text)
+    }
+
+    /// Validate Sweden organisationsnummer format (without checksum)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the format or third-digit rule is invalid
+    pub fn validate_sweden_orgnummer(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_sweden_orgnummer(value)
+    }
+
+    /// Validate Sweden organisationsnummer with Luhn checksum
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the format or checksum is invalid
+    pub fn validate_sweden_orgnummer_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_sweden_orgnummer_with_checksum(value)
+    }
+
+    /// Check if a Sweden organisationsnummer is a test/dummy pattern
+    #[must_use]
+    pub fn is_test_sweden_orgnummer(&self, value: &str) -> bool {
+        validation::is_test_sweden_orgnummer(value)
     }
 }

--- a/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
@@ -61,6 +61,7 @@ mod nigeria;
 mod passport;
 mod singapore;
 mod ssn;
+mod sweden;
 mod tax_id;
 mod thailand;
 mod turkey;
@@ -108,6 +109,10 @@ pub use singapore::{
     find_singapore_nrics_in_text, find_singapore_uens_in_text, is_singapore_nric, is_singapore_uen,
 };
 pub use ssn::{find_ssns_in_text, is_ssn};
+pub use sweden::{
+    find_sweden_orgnummers_in_text, find_sweden_personnummers_in_text, is_sweden_orgnummer,
+    is_sweden_personnummer,
+};
 pub use tax_id::{find_eins_in_text, find_tax_ids_in_text, is_ein, is_tax_id};
 pub use thailand::{find_thailand_tnins_in_text, is_thailand_tnin};
 pub use turkey::{
@@ -200,6 +205,12 @@ pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
         Some(IdentifierType::FinlandHetu)
     } else if is_poland_pesel(value) {
         Some(IdentifierType::PolandPesel)
+    } else if is_sweden_personnummer(value) {
+        // Personnummer (month-constrained, third digit 0/1) is checked before
+        // orgnummer (third digit >= 2); the two are mutually exclusive.
+        Some(IdentifierType::SwedenPersonnummer)
+    } else if is_sweden_orgnummer(value) {
+        Some(IdentifierType::SwedenOrgnummer)
     } else if is_italy_fiscal_code(value) {
         Some(IdentifierType::ItalyFiscalCode)
     } else if is_spain_nif(value) {
@@ -281,6 +292,8 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
     all_matches.extend(find_singapore_uens_in_text(text));
     all_matches.extend(find_finland_hetus_in_text(text));
     all_matches.extend(find_poland_pesels_in_text(text));
+    all_matches.extend(find_sweden_personnummers_in_text(text));
+    all_matches.extend(find_sweden_orgnummers_in_text(text));
     all_matches.extend(find_italy_fiscal_codes_in_text(text));
     all_matches.extend(find_italy_vats_in_text(text));
     all_matches.extend(find_italy_passports_in_text(text));

--- a/crates/octarine/src/primitives/identifiers/government/detection/sweden.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/sweden.rs
@@ -1,0 +1,245 @@
+//! Sweden identifier detection — Personnummer and Organisationsnummer.
+//!
+//! Detection functions are pattern-based (shape) plus the structural rules that
+//! distinguish the two identifiers: a valid personnummer encodes a calendar
+//! month (`MM` = 01-12), so its third digit is always 0 or 1, whereas an
+//! organisationsnummer requires a third digit `>= 2`. This makes the two
+//! mutually exclusive. Checksum (Luhn) verification is intentionally NOT done
+//! here — use
+//! [`super::super::validation::validate_sweden_personnummer_with_checksum`] and
+//! [`super::super::validation::validate_sweden_orgnummer_with_checksum`].
+
+use super::super::super::common::patterns;
+use super::super::super::types::{IdentifierMatch, IdentifierType};
+use super::helpers::{
+    MAX_IDENTIFIER_LENGTH, MAX_INPUT_LENGTH, deduplicate_matches, exceeds_safe_length,
+    get_full_match,
+};
+
+/// Extract the 10-digit personnummer core (`YYMMDD` + `NNN` + check) from a
+/// value, accepting the 10-digit (`YYMMDD-NNNC` / `YYMMDD+NNNC`) and 12-digit
+/// (`YYYYMMDDNNNC`) forms. At most one `-`/`+` separator is allowed; any other
+/// non-digit character rejects the value. Returns the 10 core digits.
+pub(super) fn personnummer_core(value: &str) -> Option<Vec<u8>> {
+    let trimmed = value.trim();
+    if trimmed
+        .chars()
+        .any(|c| !c.is_ascii_digit() && c != '-' && c != '+')
+    {
+        return None;
+    }
+    if trimmed.chars().filter(|c| *c == '-' || *c == '+').count() > 1 {
+        return None;
+    }
+    let digits: Vec<u8> = trimmed
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+    match digits.len() {
+        10 => Some(digits),
+        12 => digits.get(2..).map(<[u8]>::to_vec),
+        _ => None,
+    }
+}
+
+/// Check the date portion of a 10-digit personnummer core.
+///
+/// Month must be 01-12. Day must be 01-31, or 61-91 for a samordningsnummer
+/// (coordination number, where the real day is `day - 60`).
+pub(super) fn personnummer_date_ok(core: &[u8]) -> bool {
+    let two = |i: usize| -> u32 {
+        let a = u32::from(core.get(i).copied().unwrap_or(9));
+        let b = u32::from(core.get(i.saturating_add(1)).copied().unwrap_or(9));
+        a.saturating_mul(10).saturating_add(b)
+    };
+    let month = two(2);
+    let day = two(4);
+    (1..=12).contains(&month) && ((1..=31).contains(&day) || (61..=91).contains(&day))
+}
+
+/// Extract the 10 digits of an organisationsnummer (`NNNNNN-NNNN` or bare).
+/// At most one `-` separator is allowed.
+pub(super) fn orgnummer_digits(value: &str) -> Option<Vec<u8>> {
+    let trimmed = value.trim();
+    if trimmed.chars().any(|c| !c.is_ascii_digit() && c != '-') {
+        return None;
+    }
+    if trimmed.chars().filter(|c| *c == '-').count() > 1 {
+        return None;
+    }
+    let digits: Vec<u8> = trimmed
+        .chars()
+        .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+        .collect();
+    (digits.len() == 10).then_some(digits)
+}
+
+/// Check if a value matches Sweden personnummer format
+///
+/// Shape plus date sanity (month 01-12, day 01-31 or 61-91 for
+/// samordningsnummer). Use
+/// [`super::super::validation::validate_sweden_personnummer_with_checksum`] for
+/// Luhn verification.
+#[must_use]
+pub fn is_sweden_personnummer(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    if !patterns::sweden_personnummer::all()
+        .iter()
+        .any(|p| p.is_match(value))
+    {
+        return false;
+    }
+    personnummer_core(value).is_some_and(|core| personnummer_date_ok(&core))
+}
+
+/// Find all Sweden personnummer patterns in text
+///
+/// Label-anchored only — a bare 10/12-digit run collides with dates, phone
+/// numbers, and organisationsnummer, so text scanning requires context.
+#[must_use]
+pub fn find_sweden_personnummers_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::sweden_personnummer::labeled_only() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::SwedenPersonnummer,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+/// Check if a value matches Sweden organisationsnummer format
+///
+/// Shape (10 digits) plus the third-digit `>= 2` rule that distinguishes an
+/// orgnummer from a personnummer. Use
+/// [`super::super::validation::validate_sweden_orgnummer_with_checksum`] for
+/// Luhn verification.
+#[must_use]
+pub fn is_sweden_orgnummer(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    if !patterns::sweden_orgnummer::all()
+        .iter()
+        .any(|p| p.is_match(value))
+    {
+        return false;
+    }
+    orgnummer_digits(value).is_some_and(|d| d.get(2).copied().unwrap_or(0) >= 2)
+}
+
+/// Find all Sweden organisationsnummer patterns in text
+///
+/// Label-anchored only — a bare 10-digit run collides with phone numbers and
+/// personnummer, so text scanning requires context.
+#[must_use]
+pub fn find_sweden_orgnummers_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::sweden_orgnummer::labeled_only() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::SwedenOrgnummer,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_sweden_personnummer_accepts_known_value() {
+        // 19121212-1212 is the canonical Swedish test personnummer.
+        assert!(is_sweden_personnummer("19121212-1212"));
+        assert!(is_sweden_personnummer("121212-1212"));
+        assert!(is_sweden_personnummer("1212121212"));
+    }
+
+    #[test]
+    fn test_is_sweden_personnummer_plus_separator() {
+        assert!(is_sweden_personnummer("121212+1212"));
+    }
+
+    #[test]
+    fn test_is_sweden_personnummer_samordningsnummer() {
+        // Day 62 (= real day 2) is a valid coordination number.
+        assert!(is_sweden_personnummer("811262-1234"));
+        // Day 32 is in the dead gap between 31 and 61.
+        assert!(!is_sweden_personnummer("811232-1234"));
+    }
+
+    #[test]
+    fn test_is_sweden_personnummer_rejects_bad_month() {
+        assert!(!is_sweden_personnummer("811328-1234")); // month 13
+        assert!(!is_sweden_personnummer("810028-1234")); // month 00
+    }
+
+    #[test]
+    fn test_is_sweden_personnummer_rejects_wrong_length() {
+        assert!(!is_sweden_personnummer("12345"));
+        assert!(!is_sweden_personnummer("12121212345")); // 11 digits
+    }
+
+    #[test]
+    fn test_is_sweden_orgnummer_third_digit_rule() {
+        // Third digit >= 2 → valid orgnummer shape.
+        assert!(is_sweden_orgnummer("556016-0680"));
+        assert!(is_sweden_orgnummer("5560160680"));
+        // Third digit < 2 → not an orgnummer (would be a personnummer shape).
+        assert!(!is_sweden_orgnummer("551016-0680"));
+    }
+
+    #[test]
+    fn test_personnummer_and_orgnummer_mutually_exclusive() {
+        // A valid personnummer (month 01-12 → third digit 0/1) is never an
+        // orgnummer, and vice versa.
+        assert!(is_sweden_personnummer("121212-1212"));
+        assert!(!is_sweden_orgnummer("121212-1212"));
+        assert!(is_sweden_orgnummer("556016-0680"));
+        assert!(!is_sweden_personnummer("556016-0680"));
+    }
+
+    #[test]
+    fn test_find_sweden_personnummers_label_required() {
+        let bare = find_sweden_personnummers_in_text("Random 19121212-1212 in the middle.");
+        assert!(bare.is_empty(), "bare value must not match without a label");
+
+        let labeled = find_sweden_personnummers_in_text("Patient personnummer: 19121212-1212.");
+        assert_eq!(labeled.len(), 1);
+    }
+
+    #[test]
+    fn test_find_sweden_orgnummers_label_required() {
+        let bare = find_sweden_orgnummers_in_text("Random 556016-0680 in the middle.");
+        assert!(bare.is_empty(), "bare value must not match without a label");
+
+        let labeled = find_sweden_orgnummers_in_text("Company orgnr: 556016-0680.");
+        assert_eq!(labeled.len(), 1);
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
@@ -58,6 +58,7 @@ mod poland;
 mod singapore;
 mod spain;
 mod ssn;
+mod sweden;
 mod thailand;
 mod turkey;
 mod uk;
@@ -118,6 +119,13 @@ pub use italy::{
 pub use spain::{
     is_test_spain_nie, is_test_spain_nif, validate_spain_nie, validate_spain_nie_with_checksum,
     validate_spain_nif, validate_spain_nif_with_checksum,
+};
+
+// Re-export Sweden functions
+pub use sweden::{
+    is_test_sweden_orgnummer, is_test_sweden_personnummer, validate_sweden_orgnummer,
+    validate_sweden_orgnummer_with_checksum, validate_sweden_personnummer,
+    validate_sweden_personnummer_with_checksum,
 };
 
 // Re-export India functions

--- a/crates/octarine/src/primitives/identifiers/government/validation/national_id.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/national_id.rs
@@ -253,7 +253,10 @@ pub fn validate_canada_sin(sin: &str) -> Result<(), Problem> {
 }
 
 /// Luhn algorithm checksum validation
-fn luhn_check(digits: &str) -> bool {
+///
+/// Shared within the `validation` module so country modules (e.g. `sweden`)
+/// can reuse the same mod-10 implementation rather than duplicating it.
+pub(super) fn luhn_check(digits: &str) -> bool {
     let mut sum: u32 = 0;
     let mut double = false;
 

--- a/crates/octarine/src/primitives/identifiers/government/validation/sweden.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/sweden.rs
@@ -1,0 +1,361 @@
+//! Sweden Personnummer and Organisationsnummer validation
+//!
+//! - **Personnummer**: `YYMMDD-NNNC`, `YYMMDD+NNNC` (`+` marks 100+ years), or
+//!   `YYYYMMDDNNNC`. Month 01-12; day 01-31, or 61-91 for a samordningsnummer
+//!   (coordination number, real day = day - 60). Checksum is Luhn (mod-10)
+//!   over the 10-digit core `YYMMDD` + `NNN` + check.
+//! - **Organisationsnummer**: 10 digits (`NNNNNN-NNNN` or bare). The third
+//!   digit is `>= 2`, distinguishing it from a personnummer. Checksum is Luhn
+//!   over all 10 digits.
+//!
+//! Luhn is shared with [`super::national_id::luhn_check`] rather than
+//! reimplemented.
+
+use super::national_id::luhn_check;
+use crate::primitives::types::Problem;
+
+// ============================================================================
+// Personnummer
+// ============================================================================
+
+/// Reduce a personnummer to its 10-digit core, validating the separator rules.
+///
+/// Accepts the 10-digit (`YYMMDD-NNNC` / `YYMMDD+NNNC` / bare `YYMMDDNNNC`) and
+/// 12-digit (`YYYYMMDDNNNC`) forms. At most one `-`/`+` separator is allowed.
+fn personnummer_core_digits(value: &str) -> Result<String, Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation(
+            "Sweden personnummer cannot be empty".to_string(),
+        ));
+    }
+
+    let separators = trimmed.chars().filter(|c| *c == '-' || *c == '+').count();
+    if separators > 1 {
+        return Err(Problem::Validation(
+            "Sweden personnummer may contain at most one separator".to_string(),
+        ));
+    }
+
+    if let Some(bad) = trimmed
+        .chars()
+        .find(|c| !c.is_ascii_digit() && *c != '-' && *c != '+')
+    {
+        return Err(Problem::Validation(format!(
+            "Sweden personnummer contains invalid character '{bad}'"
+        )));
+    }
+
+    let digits: String = trimmed.chars().filter(char::is_ascii_digit).collect();
+    match digits.len() {
+        10 => Ok(digits),
+        // Drop the two century digits to obtain the 10-digit core.
+        12 => Ok(digits.get(2..).unwrap_or("").to_string()),
+        other => Err(Problem::Validation(format!(
+            "Sweden personnummer must have 10 or 12 digits, got {other}"
+        ))),
+    }
+}
+
+/// Parse two ASCII digits of `core` at `offset` into a number (0-99).
+fn two_digits(core: &str, offset: usize) -> u32 {
+    let bytes = core.as_bytes();
+    let d = |i: usize| -> u32 {
+        bytes
+            .get(i)
+            .map(|b| u32::from(b.saturating_sub(b'0')))
+            .unwrap_or(99)
+    };
+    d(offset)
+        .saturating_mul(10)
+        .saturating_add(d(offset.saturating_add(1)))
+}
+
+/// Validate Sweden personnummer format (without checksum)
+///
+/// Checks length/separator rules and date sanity: month 01-12, day 01-31 or
+/// 61-91 (samordningsnummer).
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format or date is invalid.
+pub fn validate_sweden_personnummer(value: &str) -> Result<(), Problem> {
+    let core = personnummer_core_digits(value)?;
+
+    let month = two_digits(&core, 2);
+    if !(1..=12).contains(&month) {
+        return Err(Problem::Validation(format!(
+            "Sweden personnummer month must be 01-12, got {month:02}"
+        )));
+    }
+
+    let day = two_digits(&core, 4);
+    let day_ok = (1..=31).contains(&day) || (61..=91).contains(&day);
+    if !day_ok {
+        return Err(Problem::Validation(format!(
+            "Sweden personnummer day must be 01-31 or 61-91 (samordningsnummer), got {day:02}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate Sweden personnummer with Luhn checksum over the 10-digit core
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if format, date, or checksum is invalid.
+pub fn validate_sweden_personnummer_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_sweden_personnummer(value)?;
+
+    let core = personnummer_core_digits(value)?;
+    if !luhn_check(&core) {
+        return Err(Problem::Validation(
+            "Sweden personnummer checksum (Luhn) validation failed".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check if a Sweden personnummer is a test/dummy pattern (all-zero core)
+#[must_use]
+pub fn is_test_sweden_personnummer(value: &str) -> bool {
+    matches!(personnummer_core_digits(value), Ok(core) if core.chars().all(|c| c == '0'))
+}
+
+// ============================================================================
+// Organisationsnummer
+// ============================================================================
+
+/// Extract the 10 digits of an organisationsnummer, validating separator rules.
+fn orgnummer_core_digits(value: &str) -> Result<String, Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation(
+            "Sweden organisationsnummer cannot be empty".to_string(),
+        ));
+    }
+
+    if trimmed.chars().filter(|c| *c == '-').count() > 1 {
+        return Err(Problem::Validation(
+            "Sweden organisationsnummer may contain at most one separator".to_string(),
+        ));
+    }
+
+    if let Some(bad) = trimmed.chars().find(|c| !c.is_ascii_digit() && *c != '-') {
+        return Err(Problem::Validation(format!(
+            "Sweden organisationsnummer contains invalid character '{bad}'"
+        )));
+    }
+
+    let digits: String = trimmed.chars().filter(char::is_ascii_digit).collect();
+    if digits.len() != 10 {
+        return Err(Problem::Validation(format!(
+            "Sweden organisationsnummer must have 10 digits, got {}",
+            digits.len()
+        )));
+    }
+
+    Ok(digits)
+}
+
+/// Validate Sweden organisationsnummer format (without checksum)
+///
+/// Checks length and the third-digit `>= 2` rule that distinguishes an
+/// orgnummer from a personnummer.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format is invalid.
+pub fn validate_sweden_orgnummer(value: &str) -> Result<(), Problem> {
+    let digits = orgnummer_core_digits(value)?;
+
+    let third = digits
+        .as_bytes()
+        .get(2)
+        .map(|b| b.saturating_sub(b'0'))
+        .unwrap_or(0);
+    if third < 2 {
+        return Err(Problem::Validation(format!(
+            "Sweden organisationsnummer third digit must be >= 2, got {third}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate Sweden organisationsnummer with Luhn checksum over all 10 digits
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if format or checksum is invalid.
+pub fn validate_sweden_orgnummer_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_sweden_orgnummer(value)?;
+
+    let digits = orgnummer_core_digits(value)?;
+    if !luhn_check(&digits) {
+        return Err(Problem::Validation(
+            "Sweden organisationsnummer checksum (Luhn) validation failed".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check if a Sweden organisationsnummer is a test/dummy pattern (all-zero)
+#[must_use]
+pub fn is_test_sweden_orgnummer(value: &str) -> bool {
+    matches!(orgnummer_core_digits(value), Ok(digits) if digits.chars().all(|c| c == '0'))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::panic, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Append the Luhn check digit to a 9-digit stem, producing a 10-digit core.
+    fn with_luhn_check(stem9: &str) -> String {
+        assert_eq!(stem9.len(), 9, "stem must be 9 digits");
+        // Find the check digit d such that stem9 + d passes Luhn.
+        for d in 0..=9u32 {
+            let candidate = format!("{stem9}{d}");
+            if luhn_check(&candidate) {
+                return candidate;
+            }
+        }
+        panic!("no Luhn check digit found for {stem9}");
+    }
+
+    // ---- Personnummer: format + date sanity --------------------------------
+
+    #[test]
+    fn test_personnummer_known_value_accepted() {
+        // 19121212-1212 is the canonical Swedish test personnummer; its 10-digit
+        // core 1212121212 has a valid Luhn check digit.
+        assert!(validate_sweden_personnummer("19121212-1212").is_ok());
+        assert!(validate_sweden_personnummer("121212-1212").is_ok());
+        assert!(validate_sweden_personnummer("1212121212").is_ok());
+        assert!(validate_sweden_personnummer_with_checksum("19121212-1212").is_ok());
+        assert!(validate_sweden_personnummer_with_checksum("121212-1212").is_ok());
+    }
+
+    #[test]
+    fn test_personnummer_plus_separator_accepted() {
+        assert!(validate_sweden_personnummer("121212+1212").is_ok());
+    }
+
+    #[test]
+    fn test_personnummer_samordningsnummer() {
+        // Day 62 (= real day 2) is a valid coordination number.
+        assert!(validate_sweden_personnummer("811262-1234").is_ok());
+        // Day 32 is in the dead gap between 31 and 61.
+        assert!(validate_sweden_personnummer("811232-1234").is_err());
+        // Day 92 is above the samordningsnummer range.
+        assert!(validate_sweden_personnummer("811292-1234").is_err());
+    }
+
+    #[test]
+    fn test_personnummer_rejects_bad_month() {
+        assert!(validate_sweden_personnummer("811328-1234").is_err()); // month 13
+        assert!(validate_sweden_personnummer("810028-1234").is_err()); // month 00
+    }
+
+    #[test]
+    fn test_personnummer_rejects_wrong_length() {
+        assert!(validate_sweden_personnummer("12345").is_err());
+        assert!(validate_sweden_personnummer("12121212345").is_err()); // 11 digits
+        assert!(validate_sweden_personnummer("").is_err());
+    }
+
+    #[test]
+    fn test_personnummer_rejects_extra_separators() {
+        assert!(validate_sweden_personnummer("12-12-12-1212").is_err());
+        assert!(validate_sweden_personnummer("121212/1212").is_err());
+    }
+
+    // ---- Personnummer: checksum --------------------------------------------
+
+    #[test]
+    fn test_personnummer_bad_luhn_rejected() {
+        // Build a valid-date stem, take the correct check digit, then tamper it.
+        let core = with_luhn_check("811218987"); // 18 Dec 1981 + individual 987
+        assert!(validate_sweden_personnummer_with_checksum(&core).is_ok());
+
+        let mut chars: Vec<char> = core.chars().collect();
+        if let Some(last) = chars.last_mut() {
+            *last = if *last == '0' { '1' } else { '0' };
+        }
+        let tampered: String = chars.into_iter().collect();
+        // Date still valid, so format passes; only the checksum fails.
+        assert!(validate_sweden_personnummer(&tampered).is_ok());
+        assert!(validate_sweden_personnummer_with_checksum(&tampered).is_err());
+    }
+
+    #[test]
+    fn test_personnummer_twelve_digit_checksum() {
+        // 12-digit form: drop century, Luhn over the last 10.
+        let core = with_luhn_check("900101001");
+        let twelve = format!("19{core}");
+        assert!(validate_sweden_personnummer_with_checksum(&twelve).is_ok());
+    }
+
+    #[test]
+    fn test_is_test_personnummer() {
+        assert!(is_test_sweden_personnummer("000000-0000"));
+        assert!(!is_test_sweden_personnummer("19121212-1212"));
+    }
+
+    // ---- Organisationsnummer -----------------------------------------------
+
+    #[test]
+    fn test_orgnummer_third_digit_rule() {
+        let valid = with_luhn_check("556016068"); // third digit = 6
+        assert!(validate_sweden_orgnummer(&valid).is_ok());
+        assert!(validate_sweden_orgnummer_with_checksum(&valid).is_ok());
+
+        // Third digit < 2 → rejected (that shape is a personnummer).
+        let bad_third = with_luhn_check("551016068"); // third digit = 1
+        assert!(validate_sweden_orgnummer(&bad_third).is_err());
+    }
+
+    #[test]
+    fn test_orgnummer_formatted_and_bare() {
+        let valid = with_luhn_check("556016068");
+        let head = valid.get(..6).unwrap_or_default();
+        let tail = valid.get(6..).unwrap_or_default();
+        let formatted = format!("{head}-{tail}");
+        assert!(validate_sweden_orgnummer(&formatted).is_ok());
+        assert!(validate_sweden_orgnummer(&valid).is_ok());
+    }
+
+    #[test]
+    fn test_orgnummer_bad_luhn_rejected() {
+        let valid = with_luhn_check("556016068");
+        let mut chars: Vec<char> = valid.chars().collect();
+        if let Some(last) = chars.last_mut() {
+            *last = if *last == '0' { '1' } else { '0' };
+        }
+        let tampered: String = chars.into_iter().collect();
+        assert!(validate_sweden_orgnummer(&tampered).is_ok());
+        assert!(validate_sweden_orgnummer_with_checksum(&tampered).is_err());
+    }
+
+    #[test]
+    fn test_orgnummer_rejects_wrong_length() {
+        assert!(validate_sweden_orgnummer("12345").is_err());
+        assert!(validate_sweden_orgnummer("55601606801").is_err()); // 11 digits
+        assert!(validate_sweden_orgnummer("").is_err());
+    }
+
+    #[test]
+    fn test_is_test_orgnummer() {
+        assert!(is_test_sweden_orgnummer("000000-0000"));
+        let valid = with_luhn_check("556016068");
+        assert!(!is_test_sweden_orgnummer(&valid));
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -482,6 +482,14 @@ impl StreamingScanner {
                 GovernmentIdentifierBuilder::find_uk_nis_in_text,
             ),
             (
+                |t| matches!(t, IdentifierType::SwedenPersonnummer),
+                GovernmentIdentifierBuilder::find_sweden_personnummers_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::SwedenOrgnummer),
+                GovernmentIdentifierBuilder::find_sweden_orgnummers_in_text,
+            ),
+            (
                 |t| matches!(t, IdentifierType::VehicleId),
                 GovernmentIdentifierBuilder::find_vehicle_ids_in_text,
             ),

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -108,6 +108,8 @@ pub enum IdentifierType {
     UkNhs,              // UK NHS Number (10 digits, mod-11 weighted checksum)
     UkPassport,         // UK Passport (2 letters + 7 digits)
     UkDrivingLicence,   // UK DVLA Driving Licence (16-char DVLA structural format)
+    SwedenPersonnummer, // Swedish personal identity number (YYMMDD/YYYYMMDD + NNN + Luhn)
+    SwedenOrgnummer,    // Swedish organisationsnummer (10 digits, third digit >= 2, Luhn)
 
     // Organizational identifiers
     EmployeeId,

--- a/docs/presidio-gap-analysis.md
+++ b/docs/presidio-gap-analysis.md
@@ -116,6 +116,18 @@ Each gap includes the source domain report reference. Severity rule: blocks a Pr
 
 ### CRIT-11. Swedish Personnummer + Organisationsnummer missing
 
+- **Status**: ✅ Closed in #435. `SwedenPersonnummer` (Luhn over the 10-digit
+  core, month 1-12 + day 1-31/61-91 samordningsnummer, accepts `YYMMDD`,
+  `YYMMDD-`/`YYMMDD+`, and 12-digit `YYYYMMDD` forms) and `SwedenOrgnummer`
+  (10 digits, third digit ≥ 2, Luhn) implemented in
+  `primitives/identifiers/government/{detection/sweden.rs,validation/sweden.rs}`
+  plus `builder/europe.rs`, reusing `national_id::luhn_check`. Wired through the
+  Layer 3 `GovernmentBuilder`/shortcuts, the PII bridge
+  (`PiiType::SwedenPersonnummer`, `PiiType::SwedenOrgnummer`), `scan_government()`,
+  and the streaming scanner. Classification: `is_high_risk = true` and
+  `is_gdpr_protected = true` (Sweden is an EU member). Text scanning is
+  label-gated (context keywords `personnummer`, `personnr`, `samordningsnummer`,
+  `organisationsnummer`, `orgnr`).
 - **Presidio**: `SePersonnummerRecognizer` (Luhn over 10 digits + date sanity, includes samordningsnummer where day ≥ 61 means day - 60; accepts `YYMMDDXXXX` and `YYYYMMDDXXXX`, optional `-`/`+` separator where `+` marks 100+ years). `SeOrganisationsnummerRecognizer` (10 digits, third digit ≥ 2 to distinguish from personnummer, Luhn).
 - **Octarine**: Neither identifier exists. No Swedish anything in `government/`.
 - **Impact**: Personnummer is the unique Swedish national ID, universally used for healthcare / banking / government. Considered the most sensitive non-credential PII in Sweden; identity theft via leaked personnummer is endemic.


### PR DESCRIPTION
## Summary

Adds two Swedish government identifiers, closing Presidio gap **CRIT-11**:

- **`SwedenPersonnummer`** — the Swedish national ID. Luhn over the 10-digit core, month 1-12 and day 1-31 or 61-91 (samordningsnummer / coordination number); accepts `YYMMDD`, `YYMMDD-`/`YYMMDD+`, and 12-digit `YYYYMMDD` forms (`+` marks 100+ years).
- **`SwedenOrgnummer`** — company ID. 10 digits, third digit ≥ 2 (distinguishes it from a personnummer), Luhn.

Implemented as a full vertical slice mirroring the Finland HETU / Brazil CPF+CNPJ patterns:

- Primitive detection (`detection/sweden.rs`) + validation (`validation/sweden.rs`), reusing `national_id::luhn_check` (promoted to `pub(super)` — Luhn is **not** reimplemented).
- Primitive + Layer 3 builders (`GovernmentBuilder`, observe-instrumented) and shortcut functions.
- PII bridge kept in sync across all registries: `IdentifierType`, `PiiType` (+ `name`/`domain`/`is_high_risk`/`is_gdpr_protected`), the `From<IdentifierType>` mapping, the redactor match, `scan_government()`, and the streaming scanner.
- Classified **high-risk** and **GDPR-protected** (Sweden is an EU member).

### Design decisions

- **Label-gated text scanning** — `find_*_in_text` matches only with a context keyword (`personnummer`, `personnr`, `samordningsnummer`, `organisationsnummer`, `orgnr`), mirroring Turkey TCKN, to avoid date/phone collisions. Direct `is_*`/`validate_*` still accept bare values.
- **Lenient detection** — `is_*`/`find_*` check shape + date/third-digit sanity only; Luhn is enforced only in `validate_*_with_checksum`, per the project's detection-is-lenient convention.

## Test plan

All from the issue test plan, plus analog coverage (25 new Sweden tests):

- `19121212-1212` (canonical test personnummer) accepted.
- Samordningsnummer day=62 accepted; day=32 rejected (dead gap 32-60).
- Orgnummer third digit < 2 rejected.
- Bad Luhn rejected (tampered check digit); `+` separator and 12-digit form accepted.
- Personnummer / orgnummer mutually exclusive; label-gated scanning verified.

Verified locally: `just clippy`, `just fmt-check`, `just arch-check`, `just doc` (strict rustdoc) all clean; government (754), pii (169), and identifier (2926) suites all pass.

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)