### PR TITLE
feat(identifiers): phone validation via phonenumber crate (libphonenumber)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +754,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +941,12 @@ dependencies = [
  "cast",
  "itertools 0.13.0",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1381,6 +1405,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,7 +1479,7 @@ checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1769,7 +1805,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1858,6 +1894,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +1941,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2477,6 +2536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linkify"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2587,15 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2833,11 +2907,12 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "pem",
+ "phonenumber",
  "predicates",
  "pretty_assertions",
  "proptest",
  "proptest-arbitrary-interop",
- "quick-xml",
+ "quick-xml 0.40.1",
  "rand 0.10.1",
  "rand_core 0.10.1",
  "regex",
@@ -2919,6 +2994,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oncemutex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d11de466f4a3006fe8a5e7ec84e93b79c70cb992ae0aa0eb631ad2df8abfe2"
 
 [[package]]
 name = "oorandom"
@@ -3150,6 +3231,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phonenumber"
+version = "0.3.9+9.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9114f9c1683dd09c5f4fa024c89fdad783eaae21d3d52dd23ddaaffa29ffb168"
+dependencies = [
+ "either",
+ "fnv",
+ "nom",
+ "once_cell",
+ "postcard",
+ "quick-xml 0.38.4",
+ "regex",
+ "regex-cache",
+ "serde",
+ "serde_derive",
+ "strum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,6 +3369,19 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3418,7 +3532,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3501,6 +3615,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -3720,7 +3843,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -3731,8 +3854,26 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
+
+[[package]]
+name = "regex-cache"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7b62d69743b8b94f353b6b7c3deb4c5582828328bcb8d5fedf214373808793"
+dependencies = [
+ "lru-cache",
+ "oncemutex",
+ "regex",
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4663,6 +4804,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -31,6 +31,9 @@ once_cell = "1.19"
 lazy_static = "1.4"
 aho-corasick = "1.1"
 
+# Phone number parsing and validation (Rust port of Google's libphonenumber)
+phonenumber = "0.3"
+
 # Unicode security and normalization
 unicode-normalization = "0.1"
 unicode-security = "0.1"

--- a/crates/octarine/examples/observe_compliance.rs
+++ b/crates/octarine/examples/observe_compliance.rs
@@ -21,7 +21,7 @@ fn demonstrate_pii_detection() {
         ("SSN", "My SSN is 123-45-6789"),
         ("Credit Card", "Card number: 4111-1111-1111-1111"),
         ("Email", "Contact me at user@example.com"),
-        ("Phone", "Call me at (555) 123-4567"),
+        ("Phone", "Call me at (415) 867-5309"),
         ("IPv4 Address", "Server IP: 192.168.1.100"),
         ("AWS Key", aws_key_example.as_str()),
         ("No PII", "This is a clean string with no PII"),

--- a/crates/octarine/src/identifiers/builder/personal.rs
+++ b/crates/octarine/src/identifiers/builder/personal.rs
@@ -794,8 +794,8 @@ mod tests {
     fn test_redact_phone_with_strategy() {
         let builder = PersonalBuilder::silent();
         let result = builder
-            .redact_phone_with_strategy("+1-555-123-4567", PhoneRedactionStrategy::ShowLastFour);
-        assert!(result.contains("4567"));
+            .redact_phone_with_strategy("+1-415-867-5309", PhoneRedactionStrategy::ShowLastFour);
+        assert!(result.contains("5309"));
     }
 
     #[test]

--- a/crates/octarine/src/identifiers/mod.rs
+++ b/crates/octarine/src/identifiers/mod.rs
@@ -125,9 +125,9 @@ pub use builder::{
 // Re-export types for public API
 pub use types::{
     ApiKeyProvider, BiometricTemplateRedactionStrategy, BiometricTextPolicy, CacheStats,
-    CorrelationConfig, CorrelationMatch, CredentialMatch, CredentialPairType, CredentialTextPolicy,
-    CredentialType, CreditCardType, CryptoAddressType, DetectionConfidence, DetectionResult,
-    DnaRedactionStrategy, FacialIdRedactionStrategy, FinancialTextPolicy,
+    CorrelationConfig, CorrelationMatch, CountryCode, CredentialMatch, CredentialPairType,
+    CredentialTextPolicy, CredentialType, CreditCardType, CryptoAddressType, DetectionConfidence,
+    DetectionResult, DnaRedactionStrategy, FacialIdRedactionStrategy, FinancialTextPolicy,
     FingerprintRedactionStrategy, GovernmentTextPolicy, GpsFormat, IdentifierMatch, IdentifierType,
     IrisIdRedactionStrategy, LocationTextPolicy, MedicalTextPolicy, MetricViolation,
     OrganizationalTextPolicy, PersonalTextPolicy, PhoneRegion, PostalCodeNormalization,

--- a/crates/octarine/src/identifiers/types/mod.rs
+++ b/crates/octarine/src/identifiers/types/mod.rs
@@ -27,7 +27,7 @@ pub use location::{
     AddressNormalization, GpsFormat, LocationTextPolicy, PostalCodeNormalization, PostalCodeType,
 };
 pub use network::{ApiKeyProvider, UuidVersion};
-pub use personal::{CredentialMatch, CredentialType, PhoneRegion};
+pub use personal::{CountryCode, CredentialMatch, CredentialType, PhoneRegion};
 pub use policies::{
     CredentialTextPolicy, GovernmentTextPolicy, MedicalTextPolicy, OrganizationalTextPolicy,
     PersonalTextPolicy,

--- a/crates/octarine/src/identifiers/types/personal.rs
+++ b/crates/octarine/src/identifiers/types/personal.rs
@@ -1,3 +1,5 @@
 //! Personal identifier types — re-exported from primitives
 
-pub use crate::primitives::identifiers::{CredentialMatch, CredentialType, PhoneRegion};
+pub use crate::primitives::identifiers::{
+    CountryCode, CredentialMatch, CredentialType, PhoneRegion,
+};

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_redact_phone() {
-        let text = "Phone: +1-555-123-4567";
+        let text = "Phone: +1-415-867-5309";
         let result = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
         // ProductionStrict uses Complete::Token strategy → [PHONE]
         assert_eq!(result, "Phone: [PHONE]");
@@ -474,12 +474,12 @@ mod tests {
 
     #[test]
     fn test_phone_various_formats() {
-        // Test different phone number formats
+        // Test different phone number formats (genuinely-valid US numbers)
         let formats = vec![
-            "+1-555-123-4567", // International with dashes
-            "(555) 123-4567",  // US format with parens
-            "555.123.4567",    // Dots
-            "1-555-123-4567",  // US with leading 1
+            "+1-415-867-5309", // International with dashes
+            "(415) 867-5309",  // US format with parens
+            "415.867.5309",    // Dots
+            "1-415-867-5309",  // US with leading 1
         ];
 
         for format in formats {
@@ -546,7 +546,7 @@ mod tests {
     #[test]
     fn test_unicode_with_pii() {
         // Test PII detection with unicode characters nearby
-        let text = "用户邮箱: user@example.com, 电话: +1-555-123-4567";
+        let text = "用户邮箱: user@example.com, 电话: +1-415-867-5309";
         let result = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
         // Should detect PII even with unicode
         assert!(result.contains("[EMAIL]") || result.contains("[PHONE]"));

--- a/crates/octarine/src/observe/pii/scanner/mod.rs
+++ b/crates/octarine/src/observe/pii/scanner/mod.rs
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_scan_for_pii_phone() {
-        let text = "Call: +1-555-123-4567";
+        let text = "Call: +1-415-867-5309";
         let types = scan_for_pii(text);
         assert!(types.contains(&PiiType::Phone));
     }

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -156,9 +156,15 @@ mod tests {
 
     #[test]
     fn test_phone_patterns() {
-        assert!(phone::WITH_COUNTRY_CODE.is_match("+1-555-123-4567"));
-        assert!(phone::WITH_PARENS.is_match("(555) 123-4567"));
-        assert!(phone::STANDARD.is_match("555-123-4567"));
+        // CANDIDATE is a loose matcher for text scanning; validity is decided
+        // downstream by libphonenumber, not by this regex.
+        assert!(phone::CANDIDATE.is_match("+1-555-123-4567"));
+        assert!(phone::CANDIDATE.is_match("(555) 123-4567"));
+        assert!(phone::CANDIDATE.is_match("555-123-4567"));
+
+        // Exact patterns used for classification.
+        assert!(phone::E164_EXACT.is_match("+15551234567"));
+        assert!(phone::US_EXACT.is_match("(555) 123-4567"));
     }
 
     #[test]
@@ -236,18 +242,11 @@ mod tests {
         assert!(!email::STANDARD.is_match("@example.com"));
     }
 
-    #[test]
-    fn test_phone_false_positives() {
-        // Should NOT match short numbers
-        assert!(!phone::STANDARD.is_match("555-1234"));
-        assert!(!phone::STANDARD.is_match("12-345-6789")); // Only 9 digits
-
-        // Should NOT match too many digits
-        assert!(!phone::STANDARD.is_match("5555-123-4567")); // 11 digits
-
-        // Should NOT match SSN-formatted numbers
-        assert!(!phone::STANDARD.is_match("123-45-6789")); // 3-2-4 is SSN
-    }
+    // Phone false-positive rejection is no longer a regex concern: the
+    // `CANDIDATE` pattern is deliberately loose, and validity (length, carrier
+    // prefix, SSN/date lookalikes) is decided by libphonenumber in
+    // `detect_phones_in_text`. See that module's tests for false-positive
+    // coverage.
 
     #[test]
     fn test_credit_card_false_positives() {
@@ -403,7 +402,7 @@ mod tests {
         // Empty strings should not match
         assert!(!ssn::WITH_DASHES.is_match(""));
         assert!(!email::STANDARD.is_match(""));
-        assert!(!phone::STANDARD.is_match(""));
+        assert!(!phone::E164_EXACT.is_match(""));
         assert!(!credit_card::NO_SEPARATOR.is_match(""));
 
         // Whitespace only should not match

--- a/crates/octarine/src/primitives/identifiers/common/patterns/network/contact_patterns.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/network/contact_patterns.rs
@@ -1,8 +1,10 @@
 //! Contact-related network patterns: email, phone, username
 //!
 //! Patterns for human contact identifiers — email addresses (standard and
-//! IP-literal forms), phone numbers (US plus 9 country-specific formats and
-//! E.164), and conservative usernames.
+//! IP-literal forms), phone numbers (a loose candidate matcher for text
+//! scanning plus exact E.164/US patterns for classification), and conservative
+//! usernames. Phone *validity* is determined by libphonenumber, not by these
+//! regexes — see `primitives/identifiers/personal/detection/phone.rs`.
 
 #![allow(clippy::expect_used)]
 // SAFETY: All regex patterns in this module are hardcoded and verified at compile time.
@@ -42,122 +44,33 @@ pub(crate) mod email {
 pub(crate) mod phone {
     use super::*;
 
-    /// US phone with country code
-    /// Example: "+1-555-123-4567"
-    pub static WITH_COUNTRY_CODE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\+1[-.\s]?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}")
-            .expect("BUG: Invalid regex pattern")
+    /// Loose candidate pattern for text scanning.
+    ///
+    /// Extracts substrings that *might* be phone numbers — an optional `+`,
+    /// optional country code, then a run of 7–15 digits with common separators
+    /// (spaces, `-`, `.`, parentheses). This is deliberately permissive:
+    /// candidates are subsequently parsed and validated by libphonenumber
+    /// (`phonenumber::is_valid`), which applies per-region possible-length and
+    /// carrier-prefix tables to reject false positives. The pattern therefore
+    /// favours recall; precision comes from the validation step.
+    ///
+    /// Examples: `+1-555-123-4567`, `(415) 867-5309`, `+44 20 7946 0958`,
+    /// `+5511987654321`.
+    pub static CANDIDATE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\+?\(?\d(?:[\d\s().\-]{5,20}\d)?").expect("BUG: Invalid regex pattern")
     });
-
-    /// US phone with parentheses
-    /// Example: "(555) 123-4567"
-    pub static WITH_PARENS: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\(\d{3}\)\s*\d{3}[-.\s]?\d{4}").expect("BUG: Invalid regex pattern")
-    });
-
-    /// US phone standard format
-    /// Example: "555-123-4567"
-    pub static STANDARD: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b").expect("BUG: Invalid regex pattern")
-    });
-
-    /// International format (generic 10+ digits with optional +)
-    /// Example: "+44 20 7946 0958"
-    pub static INTERNATIONAL: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"\+?\d{1,3}[-.\s]?\d{1,14}").expect("BUG: Invalid regex pattern"));
-
-    // ── Country-specific patterns for text scanning ────────────────────
-
-    /// UK phone: +44 followed by 10 digits (mobile or landline)
-    /// Examples: "+44 7911 123456", "+447911123456", "+44 20 7946 0958"
-    pub static UK: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\+44[-.\s]?\d{2,4}[-.\s]?\d{3,4}[-.\s]?\d{3,4}")
-            .expect("BUG: Invalid regex pattern")
-    });
-
-    /// German phone: +49 followed by 10-11 digits
-    /// Examples: "+49 30 12345678", "+49 170 1234567", "+4930123456"
-    pub static DE: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\+49[-.\s]?\d{2,4}[-.\s]?\d{3,8}[-.\s]?\d{0,4}")
-            .expect("BUG: Invalid regex pattern")
-    });
-
-    /// French phone: +33 followed by 9 digits
-    /// Examples: "+33 1 23 45 67 89", "+33123456789"
-    pub static FR: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\+33[-.\s]?\d[-.\s]?\d{2}[-.\s]?\d{2}[-.\s]?\d{2}[-.\s]?\d{2}")
-            .expect("BUG: Invalid regex pattern")
-    });
-
-    /// Australian phone: +61 followed by 9 digits
-    /// Examples: "+61 4 1234 5678", "+61412345678"
-    pub static AU: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\+61[-.\s]?\d[-.\s]?\d{4}[-.\s]?\d{4}").expect("BUG: Invalid regex pattern")
-    });
-
-    /// Indian phone: +91 followed by 10 digits (mobile starts with 6-9)
-    /// Examples: "+91 98765 43210", "+919876543210"
-    pub static IN_: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\+91[-.\s]?[6-9]\d{4}[-.\s]?\d{5}").expect("BUG: Invalid regex pattern")
-    });
-
-    /// Japanese phone: +81 followed by 9-10 digits
-    /// Examples: "+81 3 1234 5678", "+81 90 1234 5678"
-    pub static JP: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\+81[-.\s]?\d{1,4}[-.\s]?\d{1,4}[-.\s]?\d{4}")
-            .expect("BUG: Invalid regex pattern")
-    });
-
-    /// Brazilian phone: +55 followed by 10-11 digits (area + number)
-    /// Examples: "+55 11 98765 4321", "+5511987654321"
-    pub static BR: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\+55[-.\s]?\d{2}[-.\s]?\d{4,5}[-.\s]?\d{4}")
-            .expect("BUG: Invalid regex pattern")
-    });
-
-    /// Chinese phone: +86 followed by 11 digits (mobile starts 1[3-9])
-    /// Examples: "+86 138 1234 5678", "+8613812345678"
-    pub static CN: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r"\+86[-.\s]?1[3-9]\d[-.\s]?\d{4}[-.\s]?\d{4}")
-            .expect("BUG: Invalid regex pattern")
-    });
-
-    /// E.164 text scanning: any + followed by 7-15 digits (no separators)
-    /// Example: "+442071234567", "+5511987654321"
-    pub static E164_TEXT: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"\+[1-9]\d{6,14}").expect("BUG: Invalid regex pattern"));
 
     /// E.164 format (exact match for validation)
     /// Example: "+15551234567"
     pub static E164_EXACT: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"^\+[1-9]\d{1,14}$").expect("BUG: Invalid regex pattern"));
 
-    /// US phone exact match (for validation)
+    /// US phone exact match (for lenient classification)
     /// Example: "(555) 123-4567", "555-123-4567"
     pub static US_EXACT: Lazy<Regex> = Lazy::new(|| {
         Regex::new(r"^(\+1[-.\s]?)?(\([0-9]{3}\)|[0-9]{3})[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}$")
             .expect("BUG: Invalid regex pattern")
     });
-
-    /// All phone patterns in this submodule — US formats (with country code,
-    /// parens, or plain) plus country-specific patterns for UK, DE, FR, AU,
-    /// IN, JP, BR, CN, and a generic E.164 text-scanning fallback.
-    pub fn all() -> Vec<&'static Regex> {
-        vec![
-            &*WITH_COUNTRY_CODE,
-            &*WITH_PARENS,
-            &*STANDARD,
-            &*UK,
-            &*DE,
-            &*FR,
-            &*AU,
-            &*IN_,
-            &*JP,
-            &*BR,
-            &*CN,
-            &*E164_TEXT,
-        ]
-    }
 }
 
 pub(crate) mod username {

--- a/crates/octarine/src/primitives/identifiers/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/mod.rs
@@ -101,8 +101,8 @@ pub(crate) mod crypto;
 
 // Re-export types — pub so L3 modules can re-export them in the public API
 pub use types::{
-    CredentialMatch, CredentialType, CreditCardType, CryptoAddressType, DetectionConfidence,
-    DetectionResult, IdentifierMatch, IdentifierType, PhoneRegion,
+    CountryCode, CredentialMatch, CredentialType, CreditCardType, CryptoAddressType,
+    DetectionConfidence, DetectionResult, IdentifierMatch, IdentifierType, PhoneRegion,
 };
 
 // Re-export correlation types — pub so L3 modules can re-export them

--- a/crates/octarine/src/primitives/identifiers/personal/builder/conversion_methods.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/builder/conversion_methods.rs
@@ -6,7 +6,7 @@ use super::super::conversion;
 use super::core::{PersonalIdentifierBuilder, PhoneFormatStyle};
 
 impl PersonalIdentifierBuilder {
-    /// Normalize phone to E.164 format (+15551234567)
+    /// Normalize phone to E.164 format (+14158675309)
     pub fn normalize_phone_e164(
         &self,
         phone: &str,
@@ -42,17 +42,17 @@ mod tests {
     fn test_normalize_phone_e164() {
         let builder = PersonalIdentifierBuilder::new();
         let result = builder
-            .normalize_phone_e164("5551234567", "US")
+            .normalize_phone_e164("4158675309", "US")
             .expect("should normalize phone");
-        assert_eq!(result, "+15551234567");
+        assert_eq!(result, "+14158675309");
     }
 
     #[test]
     fn test_to_phone_display() {
         let builder = PersonalIdentifierBuilder::new();
         assert_eq!(
-            builder.to_phone_display("5551234567", PhoneFormatStyle::National),
-            "(555) 123-4567"
+            builder.to_phone_display("4158675309", PhoneFormatStyle::National),
+            "(415) 867-5309"
         );
     }
 

--- a/crates/octarine/src/primitives/identifiers/personal/builder/detection_methods.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/builder/detection_methods.rs
@@ -180,7 +180,7 @@ mod tests {
     #[test]
     fn test_is_phone_number() {
         let builder = PersonalIdentifierBuilder::new();
-        assert!(builder.is_phone_number("+15551234567"));
+        assert!(builder.is_phone_number("+14158675309"));
         assert!(!builder.is_phone_number("not-a-phone"));
     }
 
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn test_detect_phones_in_text() {
         let builder = PersonalIdentifierBuilder::new();
-        let matches = builder.detect_phones_in_text("Call +1-555-123-4567 or (555) 234-5678");
+        let matches = builder.detect_phones_in_text("Call +1-415-867-5309 or (212) 234-5678");
         assert_eq!(matches.len(), 2);
     }
 

--- a/crates/octarine/src/primitives/identifiers/personal/builder/sanitization_methods.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/builder/sanitization_methods.rs
@@ -212,10 +212,10 @@ mod tests {
         let builder = PersonalIdentifierBuilder::new();
         assert_eq!(
             builder.redact_phone_with_strategy(
-                "+1-555-123-4567",
+                "+1-415-867-5309",
                 PhoneRedactionStrategy::ShowLastFour
             ),
-            "***-***-4567"
+            "***-***-5309"
         );
         assert_eq!(
             builder.redact_phone_with_strategy("123", PhoneRedactionStrategy::Token),
@@ -251,7 +251,7 @@ mod tests {
     fn test_sanitize_phone() {
         let builder = PersonalIdentifierBuilder::new();
         let result = builder
-            .sanitize_phone("(555) 123-4567")
+            .sanitize_phone("(415) 867-5309")
             .expect("should sanitize valid phone");
         assert!(result.starts_with("+1"));
         assert!(builder.sanitize_phone("invalid").is_err());
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn test_redact_all_in_text_with_policy() {
         let builder = PersonalIdentifierBuilder::new();
-        let text = "Email: user@example.com, Phone: +1-555-123-4567";
+        let text = "Email: user@example.com, Phone: +1-415-867-5309";
         let result = builder.redact_all_in_text_with_policy(text, TextRedactionPolicy::Complete);
         assert!(result.contains("[EMAIL]"));
         assert!(result.contains("[PHONE]"));

--- a/crates/octarine/src/primitives/identifiers/personal/conversion.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/conversion.rs
@@ -98,11 +98,11 @@ pub fn calculate_age(birthdate: &str) -> Result<u32, Problem> {
 /// Phone number display format styles
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PhoneFormatStyle {
-    /// E.164 international format: +15551234567
+    /// E.164 international format: +14158675309
     E164,
-    /// National format: (555) 123-4567
+    /// National format: (415) 867-5309
     National,
-    /// International format: +1 (555) 123-4567
+    /// International format: +1 (415) 867-5309
     International,
 }
 
@@ -110,7 +110,7 @@ pub enum PhoneFormatStyle {
 // Phone Normalization
 // ============================================================================
 
-/// Normalize phone to E.164 format (+15551234567)
+/// Normalize phone to E.164 format (+14158675309)
 ///
 /// Converts various phone number formats to E.164 standard.
 /// Validates format using detection layer before conversion.
@@ -125,8 +125,8 @@ pub enum PhoneFormatStyle {
 /// ```ignore
 /// use crate::primitives::identifiers::personal::conversion;
 ///
-/// let result = conversion::normalize_phone_e164("5551234567", "US");
-/// assert_eq!(result.unwrap(), "+15551234567");
+/// let result = conversion::normalize_phone_e164("4158675309", "US");
+/// assert_eq!(result.unwrap(), "+14158675309");
 /// ```
 pub fn normalize_phone_e164(phone: &str, default_country: &str) -> Result<String, Problem> {
     // Validate phone format first using detection layer
@@ -164,8 +164,8 @@ pub fn normalize_phone_e164(phone: &str, default_country: &str) -> Result<String
 /// use crate::primitives::identifiers::personal::conversion::{to_phone_display, PhoneFormatStyle};
 ///
 /// assert_eq!(
-///     to_phone_display("5551234567", PhoneFormatStyle::National),
-///     "(555) 123-4567"
+///     to_phone_display("4158675309", PhoneFormatStyle::National),
+///     "(415) 867-5309"
 /// );
 /// ```
 #[must_use]
@@ -288,18 +288,18 @@ mod tests {
     fn test_normalize_phone_e164() {
         // US 10-digit
         let result =
-            normalize_phone_e164("5551234567", "US").expect("should normalize 10-digit US phone");
-        assert_eq!(result, "+15551234567");
+            normalize_phone_e164("4158675309", "US").expect("should normalize 10-digit US phone");
+        assert_eq!(result, "+14158675309");
 
         // Already E.164
         let result =
-            normalize_phone_e164("+15551234567", "US").expect("should preserve E.164 format");
-        assert_eq!(result, "+15551234567");
+            normalize_phone_e164("+14158675309", "US").expect("should preserve E.164 format");
+        assert_eq!(result, "+14158675309");
 
         // 11-digit with leading 1
-        let result = normalize_phone_e164("15551234567", "US")
+        let result = normalize_phone_e164("14158675309", "US")
             .expect("should normalize 11-digit with leading 1");
-        assert_eq!(result, "+15551234567");
+        assert_eq!(result, "+14158675309");
 
         // Invalid (fails detection - too short)
         let err = normalize_phone_e164("12345", "US").expect_err("should fail for short phone");
@@ -311,36 +311,36 @@ mod tests {
     #[test]
     fn test_to_phone_display_national() {
         assert_eq!(
-            to_phone_display("5551234567", PhoneFormatStyle::National),
-            "(555) 123-4567"
+            to_phone_display("4158675309", PhoneFormatStyle::National),
+            "(415) 867-5309"
         );
         assert_eq!(
-            to_phone_display("15551234567", PhoneFormatStyle::National),
-            "(555) 123-4567"
+            to_phone_display("14158675309", PhoneFormatStyle::National),
+            "(415) 867-5309"
         );
     }
 
     #[test]
     fn test_to_phone_display_international() {
         assert_eq!(
-            to_phone_display("15551234567", PhoneFormatStyle::International),
-            "+1 (555) 123-4567"
+            to_phone_display("14158675309", PhoneFormatStyle::International),
+            "+1 (415) 867-5309"
         );
         assert_eq!(
-            to_phone_display("5551234567", PhoneFormatStyle::International),
-            "(555) 123-4567"
+            to_phone_display("4158675309", PhoneFormatStyle::International),
+            "(415) 867-5309"
         );
     }
 
     #[test]
     fn test_to_phone_display_e164() {
         assert_eq!(
-            to_phone_display("5551234567", PhoneFormatStyle::E164),
-            "+15551234567"
+            to_phone_display("4158675309", PhoneFormatStyle::E164),
+            "+14158675309"
         );
         assert_eq!(
-            to_phone_display("15551234567", PhoneFormatStyle::E164),
-            "+15551234567"
+            to_phone_display("14158675309", PhoneFormatStyle::E164),
+            "+14158675309"
         );
     }
 
@@ -413,39 +413,39 @@ mod tests {
 
         // Exactly 10 digits
         assert_eq!(
-            to_phone_display("5551234567", PhoneFormatStyle::E164),
-            "+15551234567"
+            to_phone_display("4158675309", PhoneFormatStyle::E164),
+            "+14158675309"
         );
 
         // Exactly 11 digits with leading 1
         assert_eq!(
-            to_phone_display("15551234567", PhoneFormatStyle::E164),
-            "+15551234567"
+            to_phone_display("14158675309", PhoneFormatStyle::E164),
+            "+14158675309"
         );
 
         // With various separators
         assert_eq!(
-            to_phone_display("(555) 123-4567", PhoneFormatStyle::National),
-            "(555) 123-4567"
+            to_phone_display("(415) 867-5309", PhoneFormatStyle::National),
+            "(415) 867-5309"
         );
         assert_eq!(
-            to_phone_display("555.123.4567", PhoneFormatStyle::National),
-            "(555) 123-4567"
+            to_phone_display("415.867.5309", PhoneFormatStyle::National),
+            "(415) 867-5309"
         );
     }
 
     #[test]
     fn test_phone_normalization_edge_cases() {
         // Already has + prefix
-        let result = normalize_phone_e164("+15551234567", "US").expect("should handle + prefix");
-        assert_eq!(result, "+15551234567");
+        let result = normalize_phone_e164("+14158675309", "US").expect("should handle + prefix");
+        assert_eq!(result, "+14158675309");
 
         // With leading 1 (11 digits)
-        let result = normalize_phone_e164("15551234567", "US").expect("should handle 11 digits");
-        assert_eq!(result, "+15551234567");
+        let result = normalize_phone_e164("14158675309", "US").expect("should handle 11 digits");
+        assert_eq!(result, "+14158675309");
 
         // Non-US country (currently limited - detection still passes for valid phone)
-        let err = normalize_phone_e164("5551234567", "UK").expect_err("should fail for non-US");
+        let err = normalize_phone_e164("4158675309", "UK").expect_err("should fail for non-US");
         assert!(err.to_string().contains("country code"));
 
         // Too few digits (fails detection)
@@ -453,8 +453,8 @@ mod tests {
         assert!(err.to_string().contains("Invalid phone"));
 
         // Various separators should be stripped
-        let result = normalize_phone_e164("(555) 123-4567", "US").expect("should strip separators");
-        assert_eq!(result, "+15551234567");
+        let result = normalize_phone_e164("(415) 867-5309", "US").expect("should strip separators");
+        assert_eq!(result, "+14158675309");
     }
 
     #[test]
@@ -509,31 +509,31 @@ mod tests {
 
     #[test]
     fn test_phone_format_styles_comprehensive() {
-        let phone = "5551234567";
+        let phone = "4158675309";
 
         // E164
         assert_eq!(
             to_phone_display(phone, PhoneFormatStyle::E164),
-            "+15551234567"
+            "+14158675309"
         );
 
         // National
         assert_eq!(
             to_phone_display(phone, PhoneFormatStyle::National),
-            "(555) 123-4567"
+            "(415) 867-5309"
         );
 
         // International
         assert_eq!(
             to_phone_display(phone, PhoneFormatStyle::International),
-            "(555) 123-4567"
+            "(415) 867-5309"
         );
 
         // 11 digit with leading 1
-        let phone11 = "15551234567";
+        let phone11 = "14158675309";
         assert_eq!(
             to_phone_display(phone11, PhoneFormatStyle::International),
-            "+1 (555) 123-4567"
+            "+1 (415) 867-5309"
         );
     }
 

--- a/crates/octarine/src/primitives/identifiers/personal/detection/common.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/detection/common.rs
@@ -43,7 +43,7 @@ use super::phone::{detect_phones_in_text, is_phone_number};
 /// assert_eq!(result, Some(IdentifierType::Email));
 ///
 /// // Phone detection
-/// let result = find_personal_identifier("+1-555-123-4567");
+/// let result = find_personal_identifier("+1-415-867-5309");
 /// assert_eq!(result, Some(IdentifierType::PhoneNumber));
 /// ```
 ///
@@ -137,7 +137,7 @@ pub fn is_pii(value: &str) -> bool {
 /// ```ignore
 /// use crate::primitives::identifiers::personal::detection::detect_all_pii_in_text;
 ///
-/// let text = "Contact John Smith at user@example.com or +1-555-123-4567. Born: 1990-05-15";
+/// let text = "Contact John Smith at user@example.com or +1-415-867-5309. Born: 1990-05-15";
 /// let matches = detect_all_pii_in_text(text);
 ///
 /// // Should find: name, email, phone, birthdate
@@ -278,7 +278,7 @@ mod tests {
 
     #[test]
     fn test_detect_all_pii_in_text() {
-        let text = "Contact John Smith at user@example.com or +1-555-123-4567. Born: 1990-05-15";
+        let text = "Contact John Smith at user@example.com or +1-415-867-5309. Born: 1990-05-15";
         let matches = detect_all_pii_in_text(text);
 
         // Should find multiple PII types
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_is_pii_present() {
         assert!(is_pii_present("Email: user@example.com"));
-        assert!(is_pii_present("Call +1-555-123-4567"));
+        assert!(is_pii_present("Call +1-415-867-5309"));
         assert!(is_pii_present("Born on 1990-05-15"));
         assert!(!is_pii_present("No PII here"));
     }

--- a/crates/octarine/src/primitives/identifiers/personal/detection/phone.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/detection/phone.rs
@@ -1,6 +1,16 @@
 //! Phone number detection
 //!
-//! Pure detection functions for phone numbers including E.164 and US formats.
+//! Phone number detection backed by the `phonenumber` crate (the Rust port of
+//! Google's libphonenumber). Validity, region, and possible-length checks come
+//! from libphonenumber's bundled per-region metadata rather than hand-rolled
+//! regexes, which drives false positives on arbitrary digit strings (order
+//! numbers, IDs, hashes) to near-zero and adds full international coverage.
+//!
+//! In-text scanning keeps a loose candidate regex (libphonenumber has no text
+//! matcher) and validates each candidate, so only genuinely-valid numbers are
+//! reported.
+
+use phonenumber::country;
 
 use super::super::super::common::patterns;
 use super::super::super::types::{IdentifierMatch, IdentifierType, PhoneRegion};
@@ -10,148 +20,43 @@ use super::cache::PHONE_CACHE;
 /// Maximum input length for ReDoS protection
 const MAX_INPUT_LENGTH: usize = 10_000;
 
-// ============================================================================
-// False Positive Filters
-// ============================================================================
-
-/// Check if a digit string is likely a false positive phone match
+/// Default region for numbers without an explicit `+` country code.
 ///
-/// Rejects sequential numbers, repeated digits, date-like patterns, and
-/// SSN-like patterns that are commonly misidentified as phone numbers.
-fn is_likely_false_positive(digits: &str) -> bool {
-    let len = digits.len();
-    if len < 7 {
-        return false;
-    }
+/// Bare numbers like `4158675309` are interpreted as US numbers (matching the
+/// `+1` default used elsewhere, e.g. `normalize_phone_e164`).
+const DEFAULT_REGION: country::Id = country::US;
 
-    // All same digit (e.g., 1111111111)
-    if let Some(first) = digits.chars().next()
-        && digits.chars().all(|c| c == first)
-    {
-        return true;
-    }
-
-    // Entire number is ascending/descending sequential (e.g., 1234567890, 9876543210)
-    if is_fully_sequential(digits) {
-        return true;
-    }
-
-    // Date-like: 8 digits matching MMDDYYYY or YYYYMMDD
-    if len == 8 && is_date_like(digits) {
-        return true;
-    }
-
-    // SSN-like: exactly 9 digits matching XXX-XX-XXXX pattern ranges
-    if len == 9 && is_ssn_like(digits) {
-        return true;
-    }
-
-    false
-}
-
-/// Check if the entire digit string is a sequential run (ascending or descending)
-/// with wrapping allowed (e.g., "1234567890" wraps 9->0, "9876543210" wraps 1->0)
+/// Parse and validate a single phone string with libphonenumber.
 ///
-/// Only flags fully sequential numbers to avoid false-flagging legitimate phones
-/// that happen to contain short sequential subsequences like "+15551234567".
-fn is_fully_sequential(digits: &str) -> bool {
-    if digits.len() < 7 {
-        return false;
-    }
+/// Numbers already carrying an explicit `+` country code are parsed with **no**
+/// default region — passing one (e.g. `US`) makes libphonenumber wrongly reject
+/// otherwise-valid international numbers such as `+33142685300`. Numbers without
+/// a `+` fall back to the [`DEFAULT_REGION`] so bare US numbers still validate.
+fn parse_and_validate(value: &str) -> bool {
+    let region = if value.trim_start().starts_with('+') {
+        None
+    } else {
+        Some(DEFAULT_REGION)
+    };
 
-    let bytes = digits.as_bytes();
-
-    let all_ascending = bytes
-        .windows(2)
-        .all(|pair| match (pair.first(), pair.get(1)) {
-            (Some(&a), Some(&b)) => {
-                // Allow normal ascending or wrapping 9->0
-                b == a.saturating_add(1) || (a == b'9' && b == b'0')
-            }
-            _ => false,
-        });
-
-    if all_ascending {
-        return true;
-    }
-
-    bytes
-        .windows(2)
-        .all(|pair| match (pair.first(), pair.get(1)) {
-            (Some(&a), Some(&b)) => {
-                // Allow normal descending or wrapping 0->9
-                a == b.saturating_add(1) || (a == b'0' && b == b'9')
-            }
-            _ => false,
-        })
-}
-
-/// Check if 8-digit string looks like a date (MMDDYYYY or YYYYMMDD)
-fn is_date_like(digits: &str) -> bool {
-    if digits.len() != 8 {
-        return false;
-    }
-
-    // Try MMDDYYYY
-    if let (Some(mm), Some(dd), Some(yyyy)) = (
-        digits.get(0..2).and_then(|s| s.parse::<u32>().ok()),
-        digits.get(2..4).and_then(|s| s.parse::<u32>().ok()),
-        digits.get(4..8).and_then(|s| s.parse::<u32>().ok()),
-    ) && (1..=12).contains(&mm)
-        && (1..=31).contains(&dd)
-        && (1900..=2100).contains(&yyyy)
-    {
-        return true;
-    }
-
-    // Try YYYYMMDD
-    if let (Some(yyyy), Some(mm), Some(dd)) = (
-        digits.get(0..4).and_then(|s| s.parse::<u32>().ok()),
-        digits.get(4..6).and_then(|s| s.parse::<u32>().ok()),
-        digits.get(6..8).and_then(|s| s.parse::<u32>().ok()),
-    ) && (1900..=2100).contains(&yyyy)
-        && (1..=12).contains(&mm)
-        && (1..=31).contains(&dd)
-    {
-        return true;
-    }
-
-    false
-}
-
-/// Check if 9-digit string looks like a US SSN (area 001-899, group 01-99, serial 0001-9999)
-fn is_ssn_like(digits: &str) -> bool {
-    if digits.len() != 9 {
-        return false;
-    }
-
-    matches!(
-        (
-            digits.get(0..3).and_then(|s| s.parse::<u32>().ok()),
-            digits.get(3..5).and_then(|s| s.parse::<u32>().ok()),
-            digits.get(5..9).and_then(|s| s.parse::<u32>().ok()),
-        ),
-        (Some(area), Some(group), Some(serial))
-            if (1..=899).contains(&area)
-                && area != 666
-                && (1..=99).contains(&group)
-                && (1..=9999).contains(&serial)
-    )
+    phonenumber::parse(region, value)
+        .map(|number| phonenumber::is_valid(&number))
+        .unwrap_or(false)
 }
 
 // ============================================================================
 // Public API
 // ============================================================================
 
-/// Check if value is a phone number (cached)
+/// Check if value is a valid phone number (cached)
 ///
-/// Validates phone numbers in E.164 format (7-15 digits):
-/// - With `+` prefix: `+14155552671` (international)
-/// - Without `+`: `14155552671`, `5551234567` (assumes country code or US)
-/// - Various separators: `(415) 555-2671`, `415-555-2671`
+/// Validates phone numbers using libphonenumber. Numbers may be in E.164 form
+/// (`+14155552671`), national form with separators (`(415) 867-5309`,
+/// `415-867-5309`), or bare digits. Numbers without a `+` country code are
+/// interpreted using the US default region.
 ///
-/// Per E.164 standard, phone numbers can be 7-15 digits globally.
-/// Phone numbers without + prefix cannot start with 0.
+/// Validity reflects real numbering plans: invalid carrier prefixes (e.g. the
+/// US `555` exchange) and impossible lengths (e.g. `+44 1`) are rejected.
 pub fn is_phone_number(value: &str) -> bool {
     let trimmed = value.trim();
 
@@ -160,33 +65,7 @@ pub fn is_phone_number(value: &str) -> bool {
         return result;
     }
 
-    // Extract digits for validation
-    let cleaned: String = trimmed
-        .chars()
-        .filter(|c| c.is_ascii_digit() || *c == '+')
-        .collect();
-
-    let digit_count = cleaned.chars().filter(|c| c.is_ascii_digit()).count();
-
-    // E.164: must be 7-15 digits
-    if !(7..=15).contains(&digit_count) {
-        PHONE_CACHE.insert(trimmed.to_string(), false);
-        return false;
-    }
-
-    // E.164: phone numbers without + prefix cannot start with 0
-    if !cleaned.starts_with('+')
-        && let Some(first_digit) = cleaned.chars().next()
-        && first_digit == '0'
-    {
-        PHONE_CACHE.insert(trimmed.to_string(), false);
-        return false;
-    }
-
-    // Check both pattern matching and digit-based validation
-    let result = patterns::phone::E164_EXACT.is_match(trimmed)
-        || patterns::phone::US_EXACT.is_match(trimmed)
-        || digit_count >= 7; // Accept any 7-15 digit number not starting with 0
+    let result = parse_and_validate(trimmed);
 
     // Cache the result
     PHONE_CACHE.insert(trimmed.to_string(), result);
@@ -196,79 +75,38 @@ pub fn is_phone_number(value: &str) -> bool {
 
 /// Find phone number region from the phone string
 ///
-/// Analyzes the phone number to determine the region based on country code.
-/// Requires E.164 format with leading + for accurate detection.
+/// Determines the region from the parsed country calling code. Requires an
+/// explicit `+` country code for an accurate result; numbers without one (or
+/// that fail to parse) return [`PhoneRegion::Unknown`].
 ///
 /// # Examples
 ///
 /// ```ignore
 /// use crate::primitives::identifiers::personal::detection;
+/// use crate::primitives::identifiers::PhoneRegion;
 ///
 /// assert_eq!(detection::find_phone_region("+14155552671"), Some(PhoneRegion::NorthAmerica));
 /// assert_eq!(detection::find_phone_region("+442071234567"), Some(PhoneRegion::Uk));
 /// assert_eq!(detection::find_phone_region("5551234567"), Some(PhoneRegion::Unknown)); // No country code
 /// ```
 pub fn find_phone_region(phone: &str) -> Option<PhoneRegion> {
-    // Clean the phone number
-    let cleaned: String = phone
-        .chars()
-        .filter(|c| c.is_numeric() || *c == '+')
-        .collect();
-
-    if !cleaned.starts_with('+') {
-        // No country code, return Unknown
+    // Parse with no default region so numbers lacking a `+` country code do not
+    // get silently attributed to the US — they should resolve to Unknown.
+    let Ok(number) = phonenumber::parse(None, phone.trim()) else {
         return Some(PhoneRegion::Unknown);
-    }
+    };
 
-    // Extract country code (1-3 digits after +)
-    let digits_after_plus: String = cleaned.chars().skip(1).take(3).collect();
-
-    // Match against known country codes
-    if digits_after_plus.starts_with('1') {
-        // +1 - North America (US, Canada, Caribbean)
-        Some(PhoneRegion::NorthAmerica)
-    } else if digits_after_plus.starts_with("44") {
-        // +44 - United Kingdom
-        Some(PhoneRegion::Uk)
-    } else if digits_after_plus.starts_with("49") {
-        // +49 - Germany
-        Some(PhoneRegion::Germany)
-    } else if digits_after_plus.starts_with("33") {
-        // +33 - France
-        Some(PhoneRegion::France)
-    } else if digits_after_plus.starts_with("34") {
-        // +34 - Spain
-        Some(PhoneRegion::Spain)
-    } else if digits_after_plus.starts_with("39") {
-        // +39 - Italy
-        Some(PhoneRegion::Italy)
-    } else if digits_after_plus.starts_with("61") {
-        // +61 - Australia
-        Some(PhoneRegion::Australia)
-    } else if digits_after_plus.starts_with("81") {
-        // +81 - Japan
-        Some(PhoneRegion::Japan)
-    } else if digits_after_plus.starts_with("86") {
-        // +86 - China
-        Some(PhoneRegion::China)
-    } else if digits_after_plus.starts_with("91") {
-        // +91 - India
-        Some(PhoneRegion::India)
-    } else if digits_after_plus.starts_with("55") {
-        // +55 - Brazil
-        Some(PhoneRegion::Brazil)
-    } else if digits_after_plus.starts_with('7') {
-        // +7 - Russia and Kazakhstan
-        Some(PhoneRegion::Russia)
-    } else {
-        // Valid format but unknown region
-        Some(PhoneRegion::Unknown)
-    }
+    let code = number.code().value();
+    let iso = number.country().id().map(|id| id.as_ref().to_string());
+    Some(PhoneRegion::from_country(code, iso.as_deref()))
 }
 
 /// Check if a phone number is a known test/sample pattern
 ///
-/// Test phone numbers like 555-xxxx are reserved for fictional use.
+/// Test phone numbers like 555-xxxx are reserved for fictional use. This is a
+/// pure digit-pattern heuristic independent of whether the number is a valid
+/// dialable number — libphonenumber rejects most of these as invalid, so this
+/// remains the way to recognise test data.
 ///
 /// # Examples
 ///
@@ -288,20 +126,19 @@ pub fn is_test_phone(phone: &str) -> bool {
     // 555-0100 through 555-0199 are specifically reserved
     if digits.len() >= 10 {
         // Check for 555 in the exchange position (digits 3-5 for 10-digit, or after country code)
-        if digits.len() == 10 && &digits[3..6] == "555" {
+        if digits.len() == 10 && digits.get(3..6) == Some("555") {
             return true;
         }
         // With country code
-        if digits.len() == 11 && digits.starts_with('1') && &digits[4..7] == "555" {
+        if digits.len() == 11 && digits.starts_with('1') && digits.get(4..7) == Some("555") {
             return true;
         }
     }
 
     // All same digit patterns
     if digits.len() >= 7
-        && digits
-            .chars()
-            .all(|c| c == digits.chars().next().unwrap_or('0'))
+        && let Some(first) = digits.chars().next()
+        && digits.chars().all(|c| c == first)
     {
         return true;
     }
@@ -316,19 +153,19 @@ pub fn is_test_phone(phone: &str) -> bool {
 
 /// Detect all phone numbers in text
 ///
-/// Scans text for phone number patterns and returns all matches with positions.
-/// Includes ReDoS protection for large inputs.
+/// Scans text for candidate phone numbers with a loose regex, then validates
+/// each candidate with libphonenumber so only genuinely-valid numbers are
+/// returned. Includes ReDoS protection for large inputs.
 ///
 /// # Examples
 ///
 /// ```ignore
 /// use crate::primitives::identifiers::personal::detection::detect_phones_in_text;
 ///
-/// let text = "Call +1-555-123-4567 or (555) 234-5678";
+/// let text = "Call +1 415 867 5309 or (212) 555-0100";
 /// let matches = detect_phones_in_text(text);
 /// assert_eq!(matches.len(), 2);
 /// ```
-#[allow(clippy::expect_used)]
 #[must_use]
 pub fn detect_phones_in_text(text: &str) -> Vec<IdentifierMatch> {
     // ReDoS protection
@@ -338,27 +175,20 @@ pub fn detect_phones_in_text(text: &str) -> Vec<IdentifierMatch> {
 
     let mut matches = Vec::new();
 
-    for pattern in patterns::phone::all() {
-        for capture in pattern.captures_iter(text) {
-            let full_match = capture.get(0).expect("BUG: capture group 0 always exists");
-            let matched_text = full_match.as_str();
+    for candidate in patterns::phone::CANDIDATE.find_iter(text) {
+        let matched_text = candidate.as_str();
 
-            // Extract digits and filter false positives
-            let digits: String = matched_text
-                .chars()
-                .filter(|c| c.is_ascii_digit())
-                .collect();
-            if digits.len() < 7 || is_likely_false_positive(&digits) {
-                continue;
-            }
-
-            matches.push(IdentifierMatch::high_confidence(
-                full_match.start(),
-                full_match.end(),
-                matched_text.to_string(),
-                IdentifierType::PhoneNumber,
-            ));
+        // Validate the candidate with libphonenumber; only keep real numbers.
+        if !parse_and_validate(matched_text) {
+            continue;
         }
+
+        matches.push(IdentifierMatch::high_confidence(
+            candidate.start(),
+            candidate.end(),
+            matched_text.to_string(),
+            IdentifierType::PhoneNumber,
+        ));
     }
 
     super::common::deduplicate_matches(matches)
@@ -374,19 +204,35 @@ mod tests {
     #[test]
     fn test_is_phone_number() {
         // E.164 format
-        assert!(is_phone_number("+15551234567"));
+        assert!(is_phone_number("+14155552671"));
         assert!(is_phone_number("+442071234567")); // UK
 
-        // US formats
-        assert!(is_phone_number("(555) 123-4567"));
-        assert!(is_phone_number("555-123-4567"));
-        assert!(is_phone_number("5551234567"));
+        // US national formats (genuinely-valid numbers)
+        assert!(is_phone_number("(415) 867-5309"));
+        assert!(is_phone_number("415-867-5309"));
+        assert!(is_phone_number("4158675309"));
 
         // Invalid
         assert!(!is_phone_number(""));
         assert!(!is_phone_number("   "));
         assert!(!is_phone_number("123")); // Too short
         assert!(!is_phone_number("abcdefghij")); // Letters
+
+        // libphonenumber rejects the reserved US 555 exchange and invalid
+        // carrier prefixes that the old regex accepted.
+        assert!(!is_phone_number("+15551234567"));
+        assert!(!is_phone_number("555-123-4567"));
+        assert!(!is_phone_number("+1 555 023 4567")); // invalid US carrier
+        assert!(!is_phone_number("+44 1")); // too short for UK
+    }
+
+    #[test]
+    fn test_is_phone_number_new_regions() {
+        // Regions added by the libphonenumber migration (issue #430).
+        assert!(is_phone_number("+972502111111")); // Israel mobile
+        assert!(is_phone_number("+82 10 1234 5678")); // South Korea mobile
+        assert!(is_phone_number("+52 55 1234 5678")); // Mexico City
+        assert!(is_phone_number("+90 212 345 6789")); // Turkey
     }
 
     #[test]
@@ -396,7 +242,28 @@ mod tests {
             Some(PhoneRegion::NorthAmerica)
         );
         assert_eq!(find_phone_region("+442071234567"), Some(PhoneRegion::Uk));
-        assert_eq!(find_phone_region("5551234567"), Some(PhoneRegion::Unknown));
+        // No country code → Unknown (bare numbers are not attributed to US here)
+        assert_eq!(find_phone_region("4158675309"), Some(PhoneRegion::Unknown));
+    }
+
+    #[test]
+    fn test_find_phone_region_new_regions() {
+        assert_eq!(
+            find_phone_region("+972502111111"),
+            Some(PhoneRegion::Israel)
+        );
+        assert_eq!(
+            find_phone_region("+82 10 1234 5678"),
+            Some(PhoneRegion::SouthKorea)
+        );
+        assert_eq!(
+            find_phone_region("+52 55 1234 5678"),
+            Some(PhoneRegion::Mexico)
+        );
+        assert_eq!(
+            find_phone_region("+90 212 345 6789"),
+            Some(PhoneRegion::Turkey)
+        );
     }
 
     #[test]
@@ -404,12 +271,13 @@ mod tests {
         assert!(is_test_phone("555-123-4567"));
         assert!(is_test_phone("(555) 555-5555"));
         assert!(is_test_phone("1111111111"));
+        assert!(is_test_phone("(212) 555-0100")); // reserved fictional range
         assert!(!is_test_phone("415-867-5309"));
     }
 
     #[test]
     fn test_detect_phones_in_text() {
-        let text = "Call +1-555-123-4567 or (555) 234-5678";
+        let text = "Call +1 415 867 5309 or (212) 234-5678";
         let matches = detect_phones_in_text(text);
         assert_eq!(matches.len(), 2);
     }
@@ -427,7 +295,7 @@ mod tests {
         assert!(is_phone_number("+4917012345678"));
 
         // France
-        assert!(is_phone_number("+33123456789"));
+        assert!(is_phone_number("+33142685300"));
 
         // Australia
         assert!(is_phone_number("+61412345678"));
@@ -447,7 +315,7 @@ mod tests {
 
     #[test]
     fn test_detect_international_phones_in_text() {
-        let text = "UK: +44 7911 123456, DE: +49 30 12345678, FR: +33 1 23 45 67 89";
+        let text = "UK: +44 7911 123456, DE: +49 30 12345678, IN: +91 98765 43210";
         let matches = detect_phones_in_text(text);
         assert!(
             matches.len() >= 3,
@@ -475,6 +343,10 @@ mod tests {
     }
 
     // ── False positive filter tests ────────────────────────────────────
+    //
+    // libphonenumber's possible-length and carrier-prefix tables reject these
+    // non-phone digit strings without the bespoke heuristics the old
+    // implementation needed.
 
     #[test]
     fn test_text_false_positive_sequential() {
@@ -540,7 +412,7 @@ mod tests {
     fn test_phone_cache_hits() {
         clear_personal_caches();
 
-        let phone = "+15551234567";
+        let phone = "+14155552671";
         let _result1 = is_phone_number(phone);
         let stats1 = phone_cache_stats();
 

--- a/crates/octarine/src/primitives/identifiers/personal/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/mod.rs
@@ -127,7 +127,7 @@ pub use detection::find_phone_region;
 pub use detection::is_pii_present;
 
 // Export phone region type from common types module
-pub use super::types::PhoneRegion;
+pub use super::types::{CountryCode, PhoneRegion};
 
 // Export sanitization functions for normalization (in addition to redaction)
 pub use sanitization::{

--- a/crates/octarine/src/primitives/identifiers/personal/sanitization/phone.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/sanitization/phone.rs
@@ -37,10 +37,10 @@ use crate::primitives::Problem;
 /// ```ignore
 /// use octarine::primitives::identifiers::personal::{PhoneRedactionStrategy, redact_phone};
 ///
-/// let phone = "+1-555-123-4567";
+/// let phone = "+1-415-867-5309";
 ///
 /// // Partial - show last four (PCI-DSS)
-/// assert_eq!(redact_phone(phone, PhoneRedactionStrategy::ShowLastFour), "***-***-4567");
+/// assert_eq!(redact_phone(phone, PhoneRedactionStrategy::ShowLastFour), "***-***-5309");
 ///
 /// // Full - type token
 /// assert_eq!(redact_phone(phone, PhoneRedactionStrategy::Token), "[PHONE]");
@@ -111,8 +111,8 @@ pub fn redact_phone_with_strategy(phone: &str, strategy: PhoneRedactionStrategy)
 /// ```ignore
 /// use crate::primitives::identifiers::personal::sanitization;
 ///
-/// assert_eq!(sanitize_phone("(555) 123-4567")?, "+15551234567");
-/// assert_eq!(sanitize_phone("+1-555-123-4567")?, "+15551234567");
+/// assert_eq!(sanitize_phone("(415) 867-5309")?, "+14158675309");
+/// assert_eq!(sanitize_phone("+1-415-867-5309")?, "+14158675309");
 /// assert!(sanitize_phone("123").is_err());
 /// ```
 pub fn sanitize_phone(phone: &str) -> Result<String, Problem> {
@@ -161,16 +161,17 @@ mod tests {
     #[test]
     fn test_redact_phone_with_strategy() {
         assert_eq!(
-            redact_phone_with_strategy("+1-555-123-4567", PhoneRedactionStrategy::ShowLastFour),
-            "***-***-4567"
+            redact_phone_with_strategy("+1-415-867-5309", PhoneRedactionStrategy::ShowLastFour),
+            "***-***-5309"
         );
         assert_eq!(
-            redact_phone_with_strategy("5551234567", PhoneRedactionStrategy::ShowLastFour),
-            "***-***-4567"
+            redact_phone_with_strategy("4158675309", PhoneRedactionStrategy::ShowLastFour),
+            "***-***-5309"
         );
+        // Invalid numbers redact wholesale to avoid leaking partial data.
         assert_eq!(
             redact_phone_with_strategy("1234567", PhoneRedactionStrategy::ShowLastFour),
-            "***-4567"
+            "[PHONE]"
         );
         assert_eq!(
             redact_phone_with_strategy("123", PhoneRedactionStrategy::ShowLastFour),
@@ -181,7 +182,7 @@ mod tests {
     #[test]
     fn test_redact_phone_with_strategy_token() {
         assert_eq!(
-            redact_phone_with_strategy("+1-555-123-4567", PhoneRedactionStrategy::Token),
+            redact_phone_with_strategy("+1-415-867-5309", PhoneRedactionStrategy::Token),
             "[PHONE]"
         );
     }

--- a/crates/octarine/src/primitives/identifiers/personal/sanitization/text.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/sanitization/text.rs
@@ -162,7 +162,7 @@ pub fn redact_birthdates_in_text(text: &str, policy: TextRedactionPolicy) -> Cow
 /// ```ignore
 /// use octarine::primitives::identifiers::personal::{TextRedactionPolicy, redact_all_in_text};
 ///
-/// let text = "Contact John Smith at user@example.com or +1-555-123-4567";
+/// let text = "Contact John Smith at user@example.com or +1-415-867-5309";
 /// let result = redact_all_in_text(text, TextRedactionPolicy::Complete);
 /// // Result: "Contact [NAME] at [EMAIL] or [PHONE]"
 /// ```
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn test_redact_phones_in_text() {
-        let text = "Call +1-555-123-4567";
+        let text = "Call +1-415-867-5309";
         let result = redact_phones_in_text(text, TextRedactionPolicy::Complete);
         assert!(result.contains("[PHONE]"));
     }
@@ -281,7 +281,7 @@ mod tests {
 
     #[test]
     fn test_redact_all_in_text() {
-        let text = "Contact John Smith at user@example.com or +1-555-123-4567. Born: 1990-05-15";
+        let text = "Contact John Smith at user@example.com or +1-415-867-5309. Born: 1990-05-15";
         let result = redact_all_in_text(text, TextRedactionPolicy::Complete);
         assert!(result.contains("[EMAIL]"));
         assert!(result.contains("[PHONE]"));

--- a/crates/octarine/src/primitives/identifiers/personal/validation/phone.rs
+++ b/crates/octarine/src/primitives/identifiers/personal/validation/phone.rs
@@ -95,15 +95,17 @@ mod tests {
         // Starting with 0 (invalid for E.164)
         assert!(validate_phone("0123456789").is_err());
 
-        // Exactly at boundaries
-        assert!(validate_phone("1234567").is_ok()); // 7 digits - minimum
-        assert!(validate_phone("123456789012345").is_ok()); // 15 digits - maximum
+        // libphonenumber enforces real numbering plans, not a bare digit-count
+        // range: impossible numbers are rejected even within 7–15 digits.
+        assert!(validate_phone("1234567").is_err()); // not a real number
+        assert!(validate_phone("123456789012345").is_err()); // not a real number
         assert!(validate_phone("1234567890123456").is_err()); // 16 digits - too long
+        assert!(validate_phone("123-456-7890").is_err()); // area code 123 invalid
 
-        // With various separators
-        assert!(validate_phone("123-456-7890").is_ok());
-        assert!(validate_phone("(123) 456-7890").is_ok());
-        assert!(validate_phone("123.456.7890").is_ok());
+        // Valid US numbers with various separators
+        assert!(validate_phone("415-867-5309").is_ok());
+        assert!(validate_phone("(415) 867-5309").is_ok());
+        assert!(validate_phone("415.867.5309").is_ok());
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/types/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/types/mod.rs
@@ -10,4 +10,4 @@ mod personal;
 
 pub use core::{DetectionConfidence, DetectionResult, IdentifierMatch, IdentifierType};
 pub use financial::{CreditCardType, CryptoAddressType};
-pub use personal::{CredentialMatch, CredentialType, PhoneRegion};
+pub use personal::{CountryCode, CredentialMatch, CredentialType, PhoneRegion};

--- a/crates/octarine/src/primitives/identifiers/types/personal.rs
+++ b/crates/octarine/src/primitives/identifiers/types/personal.rs
@@ -2,9 +2,48 @@
 
 use super::core::{DetectionConfidence, IdentifierMatch, IdentifierType};
 
+/// ISO 3166-1 alpha-2 country code (e.g. `US`, `NG`).
+///
+/// A `Copy` two-byte wrapper used by [`PhoneRegion::Other`] to represent any
+/// ISO country without enumerating all ~250 of them as named variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CountryCode([u8; 2]);
+
+impl CountryCode {
+    /// Build a country code from an ISO alpha-2 string.
+    ///
+    /// Returns `None` unless `iso` is exactly two ASCII alphabetic characters.
+    /// The code is upper-cased for consistency.
+    #[must_use]
+    pub fn new(iso: &str) -> Option<Self> {
+        match iso.as_bytes() {
+            [a, b] if a.is_ascii_alphabetic() && b.is_ascii_alphabetic() => {
+                Some(Self([a.to_ascii_uppercase(), b.to_ascii_uppercase()]))
+            }
+            _ => None,
+        }
+    }
+
+    /// The ISO alpha-2 code as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        // `new` guarantees both bytes are ASCII alphabetic, so the buffer is
+        // always valid UTF-8; the fallback keeps this panic-free regardless.
+        std::str::from_utf8(&self.0).unwrap_or("??")
+    }
+}
+
+impl std::fmt::Display for CountryCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Phone number region enumeration
 ///
-/// Detected based on country code prefix in E.164 format.
+/// Detected from the parsed country calling code (via libphonenumber). Named
+/// variants cover the most common regions; any other recognised ISO country is
+/// carried in [`PhoneRegion::Other`] for full ISO 3166-1 coverage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PhoneRegion {
     /// North America (+1)
@@ -31,8 +70,65 @@ pub enum PhoneRegion {
     Brazil,
     /// Russia (+7)
     Russia,
+    /// Israel (+972)
+    Israel,
+    /// South Korea (+82)
+    SouthKorea,
+    /// Mexico (+52)
+    Mexico,
+    /// Turkey (+90)
+    Turkey,
+    /// Nigeria (+234)
+    Nigeria,
+    /// South Africa (+27)
+    SouthAfrica,
+    /// Egypt (+20)
+    Egypt,
+    /// Kenya (+254)
+    Kenya,
+    /// Any other recognised ISO 3166-1 country, identified by alpha-2 code
+    Other(CountryCode),
     /// Unknown or unrecognized region
     Unknown,
+}
+
+impl PhoneRegion {
+    /// Map a libphonenumber country to a `PhoneRegion`.
+    ///
+    /// `code` is the numeric country calling code and `iso` the optional ISO
+    /// alpha-2 region id. Named variants are matched by calling code first (so
+    /// `+1` is always [`NorthAmerica`](Self::NorthAmerica) regardless of
+    /// US/Canada disambiguation). Any other recognised ISO country becomes
+    /// [`Other`](Self::Other); a missing or invalid id is
+    /// [`Unknown`](Self::Unknown).
+    #[must_use]
+    pub fn from_country(code: u16, iso: Option<&str>) -> Self {
+        match code {
+            1 => Self::NorthAmerica,
+            44 => Self::Uk,
+            49 => Self::Germany,
+            33 => Self::France,
+            34 => Self::Spain,
+            39 => Self::Italy,
+            61 => Self::Australia,
+            81 => Self::Japan,
+            86 => Self::China,
+            91 => Self::India,
+            55 => Self::Brazil,
+            7 => Self::Russia,
+            972 => Self::Israel,
+            82 => Self::SouthKorea,
+            52 => Self::Mexico,
+            90 => Self::Turkey,
+            234 => Self::Nigeria,
+            27 => Self::SouthAfrica,
+            20 => Self::Egypt,
+            254 => Self::Kenya,
+            _ => iso
+                .and_then(CountryCode::new)
+                .map_or(Self::Unknown, Self::Other),
+        }
+    }
 }
 
 impl std::fmt::Display for PhoneRegion {
@@ -50,6 +146,15 @@ impl std::fmt::Display for PhoneRegion {
             Self::India => write!(f, "India (+91)"),
             Self::Brazil => write!(f, "Brazil (+55)"),
             Self::Russia => write!(f, "Russia (+7)"),
+            Self::Israel => write!(f, "Israel (+972)"),
+            Self::SouthKorea => write!(f, "South Korea (+82)"),
+            Self::Mexico => write!(f, "Mexico (+52)"),
+            Self::Turkey => write!(f, "Turkey (+90)"),
+            Self::Nigeria => write!(f, "Nigeria (+234)"),
+            Self::SouthAfrica => write!(f, "South Africa (+27)"),
+            Self::Egypt => write!(f, "Egypt (+20)"),
+            Self::Kenya => write!(f, "Kenya (+254)"),
+            Self::Other(cc) => write!(f, "{cc}"),
             Self::Unknown => write!(f, "Unknown region"),
         }
     }

--- a/crates/octarine/tests/observe/pii_pipeline.rs
+++ b/crates/octarine/tests/observe/pii_pipeline.rs
@@ -53,7 +53,7 @@ fn test_detects_credit_card() {
 
 #[test]
 fn test_detects_phone_number() {
-    let text = "Call: +1-555-123-4567";
+    let text = "Call: +1-415-867-5309";
     assert!(is_pii_present(text));
 
     let types = scan_for_pii(text);

--- a/crates/octarine/tests/observe/writer_dispatch.rs
+++ b/crates/octarine/tests/observe/writer_dispatch.rs
@@ -7,11 +7,12 @@
 //! `let _ = ...`, silently dropping events for every registered writer
 //! except the always-synchronous console.
 //!
-//! Cargo runs these tests in parallel inside a single process, sharing
-//! the global `WRITER_REGISTRY` and `EVENT_DISPATCHER`. Tests use unique
-//! per-test writer names and unique event message markers, and assertions
-//! filter captured events by marker — never by absolute count — so two
-//! tests that fan out through the dispatcher cannot disturb each other.
+//! The dispatcher and `WRITER_REGISTRY` are process-global singletons.
+//! Under nextest each test runs in its own process, but tests still use
+//! unique per-test writer names and unique event message markers, and
+//! assertions filter captured events by marker — never by absolute count
+//! — so the suite stays robust whether run process-per-test (nextest) or
+//! many-per-process (plain `cargo test`).
 
 #![allow(clippy::panic, clippy::expect_used)]
 
@@ -25,6 +26,22 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::time::{Instant, sleep};
+
+/// Deadline for positive-signal polls (waiting for an event to arrive).
+///
+/// The dispatcher runs on a single-threaded background runtime. Under
+/// nextest each test is its own process, and when CI runs many such
+/// processes in parallel that background thread is CPU-starved, so a
+/// flushed event can take well over a second to surface. A 2s deadline
+/// flaked here (observed failures at ~2.02s through all retries); 5s
+/// matches the deadline every other poll in the observe integration
+/// suite already uses and absorbs the scheduling jitter. This bounds the
+/// happy path only — assertions still fail fast once the signal arrives.
+const POLL_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Interval between poll probes. Small enough that a fast machine returns
+/// almost immediately, large enough not to busy-spin.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Poll `probe` up to `deadline`, checking every `interval`. Returns
 /// `true` as soon as the probe succeeds. Avoids fixed-duration sleeps so
@@ -126,7 +143,7 @@ async fn registered_writer_receives_dispatched_event() {
 
     dispatch(Event::new(EventType::Info, marker));
 
-    let received = poll_until(Duration::from_secs(2), Duration::from_millis(10), || {
+    let received = poll_until(POLL_DEADLINE, POLL_INTERVAL, || {
         count_with_marker(&capture, marker) >= 1
     })
     .await;
@@ -165,7 +182,7 @@ async fn multiple_writers_all_receive_event() {
 
     dispatch(Event::new(EventType::Info, marker));
 
-    let both = poll_until(Duration::from_secs(2), Duration::from_millis(10), || {
+    let both = poll_until(POLL_DEADLINE, POLL_INTERVAL, || {
         count_with_marker(&a, marker) >= 1 && count_with_marker(&b, marker) >= 1
     })
     .await;
@@ -199,7 +216,7 @@ async fn failing_writer_does_not_block_others() {
 
     dispatch(Event::new(EventType::Info, marker));
 
-    let good_received = poll_until(Duration::from_secs(5), Duration::from_millis(50), || {
+    let good_received = poll_until(POLL_DEADLINE, POLL_INTERVAL, || {
         count_with_marker(&good, marker) >= 1
     })
     .await;
@@ -246,7 +263,7 @@ async fn disabled_writer_receives_nothing() {
     }));
     dispatch(Event::new(EventType::Info, probe_marker));
 
-    let probe_received = poll_until(Duration::from_secs(2), Duration::from_millis(10), || {
+    let probe_received = poll_until(POLL_DEADLINE, POLL_INTERVAL, || {
         count_with_marker(&probe, probe_marker) >= 1
     })
     .await;

--- a/crates/octarine/tests/pii_redaction_integration.rs
+++ b/crates/octarine/tests/pii_redaction_integration.rs
@@ -42,7 +42,7 @@ fn test_automatic_credit_card_redaction() {
 
 #[test]
 fn test_automatic_phone_redaction() {
-    let text = "Call: +1-555-123-4567";
+    let text = "Call: +1-415-867-5309";
     let redacted = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
 
     assert_eq!(redacted, "Call: [PHONE]");
@@ -166,7 +166,7 @@ fn test_redaction_preserves_message_structure() {
 
 #[test]
 fn test_redaction_preserves_formatting() {
-    let text = "Contact info:\n  Email: user@example.com\n  Phone: +1-555-123-4567";
+    let text = "Contact info:\n  Email: user@example.com\n  Phone: +1-415-867-5309";
     let redacted = redact_pii_with_profile(text, RedactionProfile::ProductionStrict);
 
     // Newlines and spacing preserved

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,12 @@ ignore = [
   # Re-evaluate by 2026-10-01: check if upstream has patched or if we can drop the dep.
   # CRITICAL: if RS256 server-side signing is ever added, this MUST be resolved first.
   { id = "RUSTSEC-2023-0071", reason = "no patch available, transitive dep only — re-evaluate 2026-10-01" },
+  # atomic-polyfill is unmaintained (not a vulnerability). Pulled in transitively
+  # via phonenumber → postcard → heapless 0.7. postcard requires heapless ^0.7,
+  # and heapless only dropped atomic-polyfill (for portable-atomic) in 0.8+, so we
+  # cannot upgrade it away without an upstream postcard bump.
+  # Re-evaluate by 2026-12-01: check if phonenumber/postcard moved to heapless 0.8+.
+  { id = "RUSTSEC-2023-0089", reason = "unmaintained, transitive via phonenumber→postcard→heapless 0.7 — re-evaluate 2026-12-01" },
 ]
 
 # ─── Licenses ────────────────────────────────────────────────────────────────

--- a/justfile
+++ b/justfile
@@ -244,7 +244,7 @@ deps-outdated:
 
 # Check for known security vulnerabilities
 deps-audit:
-    cargo audit --ignore RUSTSEC-2023-0071
+    cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2023-0089
 
 # Run cargo-deny checks (advisories, licenses, sources)
 deps-deny:

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -8,3 +8,9 @@
 id = "RUSTSEC-2023-0071"
 # Marvin attack on the rsa crate. No fix is available upstream yet. The same
 # ignore is applied in `just deps-audit`; revisit when rsa publishes a fix.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0089"
+# atomic-polyfill is unmaintained (not a vulnerability). Pulled in transitively
+# via phonenumber → postcard → heapless 0.7, which cannot be upgraded away until
+# postcard moves to heapless 0.8+. Mirrored in deny.toml; revisit 2026-12-01.


### PR DESCRIPTION
## Summary

Replaces Octarine's hand-rolled phone detection (E.164 regex + digit-count heuristic + 12 country-specific regexes) with the [`phonenumber`](https://crates.io/crates/phonenumber) crate — the Rust port of Google's libphonenumber. Validity, region, and possible-length checks now come from libphonenumber's bundled per-region metadata.

**Why:** For log-scrubbing / LLM-proxy use cases, false positives on arbitrary digit strings (order numbers, customer IDs, hashes) were the single biggest pain point of bare-regex phone detection. libphonenumber's possible-length and carrier-prefix tables drop these to near-zero, and add full international coverage. Ref: `docs/presidio-gap-analysis.md` CRIT-14.

### Changes
- **Core detection** (`primitives/identifiers/personal/detection/phone.rs`): `is_phone_number`, `detect_phones_in_text`, `find_phone_region` run on libphonenumber. Numbers with an explicit `+` parse with **no** default region (passing one wrongly rejects valid international numbers like `+33142685300`); bare numbers fall back to a US default. Deleted the bespoke false-positive heuristics (sequential / repeated / date-like / SSN-like) — the possible-length tables subsume them.
- **Text scanning**: libphonenumber has no text matcher, so a single loose candidate regex extracts substrings and each candidate is validated — only genuinely-valid numbers are reported.
- **`PhoneRegion`**: keeps all legacy variants; adds Israel, SouthKorea, Mexico, Turkey, Nigeria, SouthAfrica, Egypt, Kenya, plus an `Other(CountryCode)` catch-all for full ISO 3166-1 coverage.
- **Kept** `is_test_phone` (RFC 3966 / 555-prefix test-data heuristic) — a strength libphonenumber lacks.
- Deleted 12 format/country regexes from `contact_patterns::phone`; kept `E164_EXACT`/`US_EXACT` for the lenient single-value classifier.

### Behavior changes (intended)
- The reserved US `555` exchange and impossible numbers (`+1 555 023 4567`, `+44 1`, bare `1234567`) are now correctly **rejected**.
- New regions (`+972`, `+82`, `+52`, `+90`, African codes, …) now **validate**.
- Test fixtures that used `555` numbers as *valid* examples were migrated to genuinely-valid numbers; `is_test_phone` fixtures keep `555`.

## Test plan

- `just fmt`, `just clippy` (0 warnings), `just arch-check` (passes — `phonenumber` stays in the primitives layer), `just doc` (strict rustdoc, 0 warnings)
- **7868 nextest tests pass**, **263 doctests pass**
- Added the issue's acceptance matrix: rejects `+1 555 023 4567` & `+44 1`; accepts Israel/Korea/Mexico/Turkey; `is_test_phone` still flags `555`; existing US/UK numbers still valid under libphonenumber semantics

## Pre-review findings

- 3x missing-test-file (type/pattern definition files — `types/personal.rs`, `contact_patterns.rs`; covered by sibling-module tests in `patterns/mod.rs`, `detection/phone.rs`, `validation/phone.rs`)

## Out of scope

- `primitives/identifiers/network/detection/phone.rs::is_phone_international` (separate generic-regex helper, not mentioned by the issue) — left as-is; possible follow-up.

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)