### PR TITLE
chore(tooling): bump Rust toolchain 1.94 -> 1.95.0, fix LSP and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
           components: rustfmt
       - uses: taiki-e/install-action@just
       - run: just fmt-check
@@ -224,7 +224,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold clang
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@just
@@ -240,7 +240,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold clang
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-nextest
       - uses: taiki-e/install-action@just
@@ -267,7 +267,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold clang
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
         with:
@@ -302,7 +302,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold clang
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@just
       - run: just doc
@@ -314,7 +314,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - uses: taiki-e/install-action@cargo-audit
       - uses: taiki-e/install-action@just
       - run: just deps-audit
@@ -326,7 +326,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - uses: taiki-e/install-action@cargo-deny
       - uses: taiki-e/install-action@just
       - run: just deps-deny
@@ -353,7 +353,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold clang
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: semver
@@ -384,7 +384,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: windows
@@ -408,7 +408,7 @@ jobs:
         run: echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - name: Verify cargo resolves to toolchain
         # Fail fast (and visibly) if cargo/rustc still aren't reachable,
         # instead of letting later steps emit a confusing error.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           ref: ${{ needs.validate.outputs.tag }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: release
@@ -131,7 +131,7 @@ jobs:
           ref: ${{ needs.validate.outputs.tag }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: release
@@ -156,7 +156,7 @@ jobs:
           ref: ${{ needs.validate.outputs.tag }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/octarine", "crates/octarine-derive", "crates/octarine-problem
 [workspace.package]
 version = "0.3.0-beta.3"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshjhall/octarine"
 authors = ["Third Thought"]

--- a/crates/octarine/src/observe/pii/redactor/location.rs
+++ b/crates/octarine/src/observe/pii/redactor/location.rs
@@ -74,7 +74,7 @@ pub(super) fn redact_named_locations(text: &str, profile: RedactionProfile) -> S
                 return text.to_string();
             }
             // Replace from the end so earlier byte spans stay valid.
-            matches.sort_by(|a, b| b.start.cmp(&a.start));
+            matches.sort_by_key(|m| std::cmp::Reverse(m.start));
             let mut out = text.to_string();
             for m in matches {
                 if m.confidence == DetectionConfidence::Low {

--- a/crates/octarine/src/observe/writers/database/traits.rs
+++ b/crates/octarine/src/observe/writers/database/traits.rs
@@ -303,9 +303,9 @@ impl DatabaseBackend for InMemoryBackend {
 
         // Sort
         if query.ascending {
-            filtered.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+            filtered.sort_by_key(|a| a.timestamp);
         } else {
-            filtered.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+            filtered.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
         }
 
         let total_count = filtered.len();

--- a/crates/octarine/src/observe/writers/query.rs
+++ b/crates/octarine/src/observe/writers/query.rs
@@ -337,9 +337,9 @@ pub fn paginate_events_with_errors(
 ) -> QueryResult {
     // Sort
     if query.ascending {
-        events.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        events.sort_by_key(|a| a.timestamp);
     } else {
-        events.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        events.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     }
 
     let total_count = events.len();

--- a/crates/octarine/src/primitives/data/paths/boundary/validation.rs
+++ b/crates/octarine/src/primitives/data/paths/boundary/validation.rs
@@ -309,10 +309,8 @@ pub fn calculate_boundary_depth_strict(path: &str, boundary: &str) -> Result<usi
             Component::Normal(_) => {
                 depth = depth.saturating_add(1);
             }
-            Component::ParentDir => {
-                if depth > 0 {
-                    depth = depth.saturating_sub(1);
-                }
+            Component::ParentDir if depth > 0 => {
+                depth = depth.saturating_sub(1);
             }
             _ => {}
         }

--- a/crates/octarine/src/primitives/data/text/log.rs
+++ b/crates/octarine/src/primitives/data/text/log.rs
@@ -272,15 +272,14 @@ pub fn sanitize_for_log_with_config<'a>(input: &'a str, options: &TextConfig) ->
             '\t' if options.escape_tabs => {
                 result.push_str("\\t");
             }
-            _ if c.is_ascii() && is_dangerous_control_byte(c as u8) => {
-                if options.remove_control_chars {
-                    if options.use_replacement_char {
-                        result.push('\u{FFFD}');
-                    }
-                    // else: skip (remove)
-                } else {
-                    result.push(c);
+            _ if c.is_ascii()
+                && is_dangerous_control_byte(c as u8)
+                && options.remove_control_chars =>
+            {
+                if options.use_replacement_char {
+                    result.push('\u{FFFD}');
                 }
+                // else: skip (remove)
             }
             _ if !c.is_ascii() && !options.allow_unicode => {
                 if options.escape_unicode {

--- a/crates/octarine/src/primitives/security/network/detection/url.rs
+++ b/crates/octarine/src/primitives/security/network/detection/url.rs
@@ -58,10 +58,8 @@ pub fn extract_host(url: &str) -> Option<&str> {
     // Find the scheme separator
     let after_scheme = if let Some(idx) = trimmed.find("://") {
         &trimmed[idx + 3..]
-    } else if let Some(rest) = trimmed.strip_prefix("//") {
-        rest
     } else {
-        return None;
+        trimmed.strip_prefix("//")?
     };
 
     // Remove userinfo if present (user:pass@)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94"
-components = ["rustfmt", "clippy"]
+channel = "1.95.0"
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
## Summary

Bumps the Rust toolchain from 1.94 to **1.95.0** in lockstep across the pin, MSRV, and CI/release workflows — matching the devcontainer's default toolchain — and repairs the Rust LSP, which was failing in this repo.

## Why the LSP was broken

`rust-analyzer` on the container is a rustup **shim** (symlink → `rustup`) that resolves against the *active* toolchain. The repo pinned `1.94` via `rust-toolchain.toml`, but the container only provisions the `rust-analyzer` component onto its **default** `1.95.0` toolchain. Inside the project dir the shim routed to 1.94, which lacked the component:

```
$ rust-analyzer --version
error: Unknown binary 'rust-analyzer' in official toolchain '1.94-aarch64-unknown-linux-gnu'.
```

So the LSP never started for any file in the repo.

## Changes

- **`rust-toolchain.toml`** — channel `1.94 → 1.95.0`; add `rust-analyzer` to `components` so rustup installs it under the pinned toolchain regardless of the container default. Verified: `rust-analyzer --version` → `1.95.0`.
- **`Cargo.toml`** — workspace MSRV `rust-version` `1.94 → 1.95`.
- **`.github/workflows/ci.yml`** (×10) and **`release.yml`** (×3) — pinned `toolchain` `1.94 → 1.95.0`.
- **8 clippy fixes** for lints newly enforced by clippy 1.95.0 (`sort_by_key`, `collapsible_match`, `question_mark`) across `observe/` and `primitives/`. Behavior-preserving.

## Verification

- `just check` — clean
- `just clippy` — clean (`-D warnings`)
- `just fmt-check` — clean
- `just test` (nextest) — **7881 passed, 29 skipped**

## Related

- Durable container-side fix tracked in **joshjhall/containers#511** (luggage should apply `component_add rust-analyzer` to pinned toolchains, not just the default).
- Follow-up: a cohesive 1.96 bump is planned next week. The containers catalog has no 1.96 entry yet, so containers#511 (or a catalog 1.96 entry) should land first to avoid re-triggering this LSP gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)