### PR TITLE
chore(memory): record anonymize sans-IO split and CodeQL crypto FP notes

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -12,3 +12,5 @@
 - [Conform scope allowlist](project_conform_scope_allowlist.md) — new top-level octarine modules must be added to `.conform.yaml` scopes or the commit-msg hook rejects `feat(<module>):`
 - [CI Doc job is strict](project_ci_doc_job_strict.md) — CI `Doc` runs `just doc` (rustdoc -D warnings, catches broken intra-doc links); `just preflight`/`test-docs` don't. Run `just doc` after editing doc comments.
 - [Redactor/engine convergence](project_redactor_engine_convergence.md) — epic #604: converge observe/pii redactor onto anonymize engine; operators (Mask #483, Hash #484) must delegate to primitive strategies, not reimplement. Detection already single-sourced.
+- [Anonymize sans-IO split](project-anonymize-sans-io-split.md) — anonymize engine: sync splice core shared by sync + async shells; AsyncOperator coexists with Operator; vault access is async-only by invariant (#609)
+- [CodeQL hard-coded crypto FP](project-codeql-hardcoded-crypto-fp.md) — CodeQL flags `[0u8; N]`/`[9u8; N]` array literals reaching AEAD key/nonce sinks even when overwritten; build arrays from a Vec via `try_into`, promote test-key literals to named consts. Token can't dismiss alerts (403).

--- a/.claude/memory/project-anonymize-sans-io-split.md
+++ b/.claude/memory/project-anonymize-sans-io-split.md
@@ -1,0 +1,16 @@
+---
+name: project-anonymize-sans-io-split
+description: anonymize engine has a sans-IO split — sync splice core shared by sync + async shells; vault access is async-only by invariant
+metadata:
+  node_type: memory
+  type: project
+  originSessionId: 7a1a4a43-92f6-4436-83b4-587c07a70043
+---
+
+The `crates/octarine/src/anonymize/` engine uses a **sans-IO split** (landed #609): a private sync `splice()` core (gap-copy, length-based offsets, audit) plus a pure `dedupe_overlaps()` span selector, shared by both the sync `anonymize()` shell and the async `anonymize_async()`/`deanonymize_async()` shells. Two operator traits coexist: sync `Operator` (4 built-ins, fixed transforms) and `#[async_trait] AsyncOperator` (session+store aware, for store-backed token minting). Store injected via `with_store(Arc<dyn StateStore>)`, async ops via `with_async_operator(..)`.
+
+**Load-bearing invariant:** the sync path applies *fixed transforms only*; vault (`StateStore`) access is *async-only*. Rationale: keeps the [[project-redactor-engine-convergence]] #604 redactor sync, avoids the `block_on` footgun in tokio. Documented in operator/engine module docs + `docs/anonymize/token-vault.md`. Revisit trigger: if a sync caller ever needs the vault, `StateStore` needs a sync face — change deliberately.
+
+**Why:** #543 (InstanceCounter operators) needs this async path; it was un-implementable against the merged sync engine + async StateStore. #609 delivers path+trait only (in-test mock); concrete operators = #543, backend = #540.
+
+**How to apply:** when adding store-backed operators, implement `AsyncOperator`, register on the async path; never add `block_on` to the sync path. When resolving replacements on the async path, only iterate `dedupe_overlaps` output so tokens mint once per applied span.

--- a/.claude/memory/project-codeql-hardcoded-crypto-fp.md
+++ b/.claude/memory/project-codeql-hardcoded-crypto-fp.md
@@ -1,0 +1,33 @@
+---
+name: project-codeql-hardcoded-crypto-fp
+description: "CodeQL flags [0u8; N] buffers filled by fill_random as \"hard-coded cryptographic value\" on crypto PRs; build the array from a Vec via try_into instead"
+metadata:
+  node_type: memory
+  type: project
+  originSessionId: c3904a6c-3b22-41e2-bca5-55349a933cfd
+---
+
+CodeQL's "Hard-coded cryptographic value" (critical) rule fires on octarine
+crypto code whenever a fixed-size array literal flows into an AEAD key/nonce
+sink — even when the bytes are immediately overwritten by a CSPRNG or KDF. It
+is a **false positive** but blocks the `CodeQL` CI check (a separate status from
+the three `Analyze (rust|python|actions)` jobs, which pass).
+
+**Why:** CodeQL tracks the `[0u8; N]` / `[9u8; N]` literal as the tainted value
+reaching the cipher. `let mut x = [0u8; N]; fill_random(&mut x)?;` (the pattern
+`ephemeral.rs` uses) and an inline wrong-key `[9u8; N]` in tests both trip it.
+PR checks only report *new* alerts, so unchanged code using the same pattern
+stays green — you can't rely on existing precedent passing.
+
+**How to apply:** make the array originate from a `Vec`-returning source, then
+convert with `try_into`, so no literal reaches the sink:
+
+- random nonce/key: `let v = random_bytes_vec(N)?; v.get(..N).and_then(|s| s.try_into().ok())...`
+- KDF-derived: same shape over the `hkdf_sha3_256` output `Vec`
+- decoded-from-wire: `slice.try_into()` instead of `[0u8; N]` + `copy_from_slice`
+- test fixtures: promote inline `[9u8; N]` keys to a named `const` (named consts
+  in tests are not flagged).
+
+The token in this environment lacks `code-scanning` read/dismiss scope (403), so
+you cannot dismiss alerts via API — you must write code that doesn't trip the
+heuristic. See [[project-redactor-engine-convergence]] for the anonymize epic.


### PR DESCRIPTION
## Summary

Adds two committed-tier project memories (and their `MEMORY.md` index entries) capturing non-obvious architectural and CI knowledge for future sessions.

## Changes

- **`project-anonymize-sans-io-split.md`** — documents the anonymize engine's sans-IO split (landed #609): a private sync `splice()` core shared by the sync `anonymize()` and async `anonymize_async()`/`deanonymize_async()` shells, the coexistence of the sync `Operator` and async `AsyncOperator` traits, and the load-bearing invariant that **vault (`StateStore`) access is async-only** to keep the redactor sync and avoid the `block_on` footgun.
- **`project-codeql-hardcoded-crypto-fp.md`** — documents CodeQL's "hard-coded cryptographic value" false positive: `[0u8; N]`/`[9u8; N]` array literals reaching AEAD key/nonce sinks trip the rule even when immediately overwritten by a CSPRNG/KDF. Records the build-from-`Vec`-via-`try_into` workaround and that the environment token can't dismiss alerts (403).
- **`MEMORY.md`** — two index pointers.

## Notes

Documentation-only — no source or build changes. `.claude/memory/*.md` is committed-tier (only `tmp/` is gitignored), with prior `chore(memory):` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)