### PR TITLE
test(runtime): make async timing tests deterministic via paused clock

### DIFF
--- a/crates/octarine/src/primitives/runtime/async/async_utils.rs
+++ b/crates/octarine/src/primitives/runtime/async/async_utils.rs
@@ -345,28 +345,28 @@ mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_sleep_ms() {
-        let start = now();
+        // Paused time advances deterministically when tokio::time::sleep
+        // fires, so elapsed is exactly the requested duration — no wall-clock
+        // jitter and no flakiness under CI coverage instrumentation.
+        let start = tokio::time::Instant::now();
         sleep_ms(10).await;
-        let elapsed = start.elapsed();
-        // Allow 20% margin for OS scheduler jitter
-        assert!(
-            elapsed.as_millis() >= 8,
-            "Expected at least 8ms elapsed, got {}ms",
-            elapsed.as_millis()
-        );
+        assert_eq!(start.elapsed(), Duration::from_millis(10));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_sleep_secs() {
-        let start = now();
-        // Just test it compiles and runs, don't actually wait seconds
-        tokio::time::timeout(Duration::from_millis(1), sleep_secs(1))
-            .await
-            .ok();
-        // Should have been interrupted
-        assert!(start.elapsed().as_millis() < 100);
+        // Paused time advances to the earliest pending timer: the 1ms timeout
+        // fires before the 1s sleep completes, so the sleep is interrupted
+        // deterministically without ever waiting a real second.
+        let start = tokio::time::Instant::now();
+        let result = tokio::time::timeout(Duration::from_millis(1), sleep_secs(1)).await;
+        assert!(
+            result.is_err(),
+            "sleep_secs(1) should be interrupted by the 1ms timeout"
+        );
+        assert_eq!(start.elapsed(), Duration::from_millis(1));
     }
 
     #[tokio::test]
@@ -375,35 +375,27 @@ mod tests {
         yield_now().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_interval() {
         let mut timer = interval_ms(10);
 
         // First tick is immediate
         timer.tick().await;
 
-        let start = now();
+        // Paused time advances exactly one period between ticks, so elapsed
+        // is precisely the configured interval — deterministic, no jitter.
+        let start = tokio::time::Instant::now();
         timer.tick().await;
-        let elapsed = start.elapsed();
-
-        // Allow for some timing variance - at least 5ms should have elapsed
-        assert!(
-            elapsed.as_millis() >= 5,
-            "Expected at least 5ms elapsed, got {}ms",
-            elapsed.as_millis()
-        );
+        assert_eq!(start.elapsed(), Duration::from_millis(10));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_timeout() {
-        let start = now();
+        // Paused time advances exactly when the timeout future fires, so
+        // elapsed is precisely the requested duration.
+        let start = tokio::time::Instant::now();
         timeout(Duration::from_millis(10)).await;
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed.as_millis() >= 10,
-            "Expected at least 10ms elapsed, got {}ms",
-            elapsed.as_millis()
-        );
+        assert_eq!(start.elapsed(), Duration::from_millis(10));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`test_interval` in `primitives/runtime/async/async_utils.rs` intermittently failed the full preflight run — it asserted on wall-clock elapsed time via `std::time::Instant`, and under CPU contention a 10ms interval tick could be measured below the 5ms floor. This is the exact timing anti-pattern the `octarine-test-resilience` skill warns about.

Converts the four wall-clock timing tests (`test_interval`, `test_sleep_ms`, `test_sleep_secs`, `test_timeout`) to `#[tokio::test(start_paused = true)]` with `tokio::time::Instant`.

Under paused time, tokio advances the clock to the earliest pending timer the instant all tasks are idle — sleeps/ticks/timeouts resolve in **zero wall-clock** while the tokio clock advances by **exactly** the requested duration. That lets the assertions tighten from fuzzy lower-bound inequalities (`>= 5ms`) to exact equality (`== 10ms`), removing both the flakiness and the real-time waits.

Follows the established paused-clock idiom already in `auth/timing.rs` and `tests/http/presets.rs`. tokio's `test-util` is already available via `features = ["full"]` — no dependency change.

## Verification
- ✅ All four tests pass, **run 5× consecutively with zero variance** (deterministic)
- ✅ clippy `-D warnings`, fmt-check
- Net −8 lines; test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)