### PR TITLE
chore(deps): bump linkify 0.10 -> 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,9 +2507,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linkify"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+checksum = "92f9ae2f3d31697697311f016320fe984127e636b45cf5eb5c175b7eb103dadb"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Public Suffix List for email + DNS validation (closest Rust analog to Python's tldextract)
 addr = "0.15"
 # Bare-URL extraction from prose with prose-aware boundary handling
-linkify = "0.10"
+linkify = "0.11"
 
 # CLI
 clap = { version = "4.0", features = ["derive", "env"] }


### PR DESCRIPTION
## Why

`linkify 0.11` was the **only** direct dependency in the workspace still behind its latest release after the RUSTSEC-2026-0185 sweep (#625). It was held back because a `0.x` minor bump is semver-breaking, so `cargo update` could not take it — it requires a manifest edit. This supersedes Dependabot PR #612.

## What

- `Cargo.toml`: `linkify = "0.10"` → `"0.11"`
- `Cargo.lock`: `linkify 0.10.0` → `0.11.0`

linkify is **optional**, gated behind the `url-strict` feature, and used in exactly one place: `primitives/identifiers/network/detection/url.rs::find_urls_in_text`.

The 0.11 changelog has **no API changes** (`LinkFinder` / `LinkKind` / `kinds()` unchanged). The sole behavior change: delimiters before slashes are now included in extracted URLs (e.g. `https://test.com/!/` now extracts fully instead of stopping at `/`).

## Breakage / corrections

**None required.** No code changes — the behavior tweak didn't shift any existing assertion.

## Verification

- `just test-filter url` — ✅ 71/71 URL-detection tests pass
- `cargo nextest --all-features --retries 2` — ✅ 7881/7881 pass
- `just test-docs` — ✅ doctests pass
- `just clippy` — ✅ clean

(The two transient timing flakes seen mid-run — `test_cache_cleanup`, `test_constant_time_response_async_fast` — are known timing tests unrelated to this change; both pass in isolation and on retry, which is why CI runs them under the retrying `ci` profile.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)