### PR TITLE
feat(http): serve Prometheus /metrics via axum preset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,6 +2331,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2874,6 +2883,7 @@ dependencies = [
  "phonenumber",
  "predicates",
  "pretty_assertions",
+ "prometheus-parse",
  "proptest",
  "proptest-arbitrary-interop",
  "quick-xml 0.40.1",
@@ -3449,6 +3459,18 @@ dependencies = [
  "syn",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools 0.12.1",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -249,6 +249,7 @@ wiremock = "0.6"
 fake = { version = "5.1", features = ["derive"] }
 assert_cmd = "2.0"
 rexpect = "0.7"
+prometheus-parse = "0.2"
 
 [[bench]]
 name = "pii_redaction"

--- a/crates/octarine/src/http/handlers/metrics.rs
+++ b/crates/octarine/src/http/handlers/metrics.rs
@@ -1,0 +1,219 @@
+//! Prometheus `/metrics` scrape handler
+//!
+//! Wires the existing [`PrometheusExporter`] into an Axum handler so operators
+//! can scrape octarine services directly. The matching
+//! [`crate::http::presets::metrics`] preset mounts this handler at `/metrics`.
+//!
+//! # Behavior
+//!
+//! - **200**: renders the active metric registry in Prometheus text exposition
+//!   format with `Content-Type: text/plain; version=0.0.4`.
+//! - **503**: returned (never a panic) when the exporter is *not initialized*,
+//!   using the same structured error envelope as the rest of the HTTP module —
+//!   the operational "not ready" signal a scrape config expects.
+//! - **500**: returned if an initialized exporter *fails to render* (an
+//!   internal error, not a readiness state), via the standard
+//!   [`crate::http::ProblemResponse`] mapping.
+//!
+//! # Example
+//!
+//! ```rust
+//! use axum::Router;
+//! use octarine::http::handlers::{MetricsState, metrics_handler};
+//! use octarine::observe::metrics::PrometheusExporter;
+//!
+//! // `MetricsState::new(...)` serves 200; `MetricsState::uninitialized()`
+//! // (and `MetricsState::default()`) serve 503 until an exporter is wired.
+//! let app: Router = Router::new()
+//!     .route("/metrics", axum::routing::get(metrics_handler))
+//!     .with_state(MetricsState::new(PrometheusExporter::default()));
+//! ```
+
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+
+use crate::http::error::{ErrorBody, ErrorInfo, ProblemResponse};
+use crate::observe::metrics::PrometheusExporter;
+use crate::primitives::runtime as prim_runtime;
+
+/// Prometheus exposition `Content-Type`, per the text format 0.0.4 spec.
+///
+/// Prometheus scrapers key off this exact value, so it is emitted verbatim
+/// rather than the `text/plain; charset=utf-8` Axum would default to.
+const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
+
+/// Shared state for the [`metrics_handler`].
+///
+/// Holds the [`PrometheusExporter`] that renders the active metric registry.
+/// The exporter is optional: a `None` value models an *uninitialized* metrics
+/// pipeline and causes the handler to answer `503` rather than serve an empty
+/// or misleading body. The [`crate::http::presets::metrics`] preset always
+/// injects an initialized exporter.
+#[derive(Debug, Clone, Default)]
+pub struct MetricsState {
+    exporter: Option<PrometheusExporter>,
+}
+
+impl MetricsState {
+    /// Create state with an initialized exporter (handler serves `200`).
+    #[must_use]
+    pub fn new(exporter: PrometheusExporter) -> Self {
+        Self {
+            exporter: Some(exporter),
+        }
+    }
+
+    /// Create state with no exporter (handler answers `503`).
+    ///
+    /// Useful for wiring the route before the metrics pipeline is configured,
+    /// so scrapers receive a clear "not ready" signal instead of a 404.
+    #[must_use]
+    pub fn uninitialized() -> Self {
+        Self { exporter: None }
+    }
+}
+
+/// Axum handler that serves the Prometheus text exposition.
+///
+/// Snapshots the active metric registry through the configured
+/// [`PrometheusExporter`] and returns the rendered body with the Prometheus
+/// `Content-Type`. Never panics: an absent exporter yields `503` (the "not
+/// ready" signal Prometheus retries on its next scrape), and a render failure
+/// yields `500` via the standard [`ProblemResponse`] mapping.
+pub async fn metrics_handler(State(state): State<MetricsState>) -> Response {
+    let Some(exporter) = state.exporter else {
+        return unavailable("metrics exporter not initialized");
+    };
+
+    match exporter.render() {
+        Ok(body) => (
+            StatusCode::OK,
+            [(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(PROMETHEUS_CONTENT_TYPE),
+            )],
+            body,
+        )
+            .into_response(),
+        // A render failure is logged via the standard ProblemResponse path
+        // (500) — distinct from "not initialized", which is the operational
+        // 503 the scrape config expects.
+        Err(problem) => ProblemResponse::from(problem).into_response(),
+    }
+}
+
+/// Build a `503 Service Unavailable` response using the shared HTTP error
+/// envelope, so scrapers and dashboards see the same structured body shape as
+/// every other octarine error.
+fn unavailable(message: &str) -> Response {
+    let body = ErrorBody {
+        error: ErrorInfo {
+            code: "service_unavailable",
+            message: message.to_string(),
+            request_id: prim_runtime::try_correlation_id().map(|id| id.to_string()),
+        },
+    };
+
+    (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use axum::{Router, http::StatusCode, http::header};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    fn router(state: MetricsState) -> Router {
+        Router::new()
+            .route("/metrics", get(metrics_handler))
+            .with_state(state)
+    }
+
+    /// An uninitialized exporter yields 503 (not a panic, not a 404).
+    #[tokio::test]
+    async fn test_uninitialized_returns_503() {
+        let app = router(MetricsState::uninitialized());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        // The 503 must carry the shared structured error envelope, not an
+        // empty body — dashboards key off `error.code`.
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("collect body")
+            .to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("valid JSON envelope");
+        assert_eq!(
+            json.pointer("/error/code").and_then(|v| v.as_str()),
+            Some("service_unavailable"),
+        );
+    }
+
+    /// `MetricsState::default()` is equivalent to `uninitialized()` (serves
+    /// 503), guarding the doc example's stated behavior.
+    #[tokio::test]
+    async fn test_default_state_returns_503() {
+        let app = router(MetricsState::default());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// An initialized exporter serves 200 with the exact Prometheus
+    /// `Content-Type`.
+    #[tokio::test]
+    async fn test_initialized_sets_prometheus_content_type() {
+        let app = router(MetricsState::new(PrometheusExporter::default()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .expect("content-type header"),
+            "text/plain; version=0.0.4"
+        );
+    }
+}

--- a/crates/octarine/src/http/handlers/mod.rs
+++ b/crates/octarine/src/http/handlers/mod.rs
@@ -1,0 +1,14 @@
+//! Built-in Axum request handlers
+//!
+//! This module provides ready-made handlers for standard operational
+//! endpoints, so operators can mount them without hand-rolling glue. Each
+//! handler is paired with a preset in [`crate::http::presets`] that mounts it
+//! at the conventional URL.
+//!
+//! | Handler | Preset | Endpoint |
+//! |---------|--------|----------|
+//! | [`metrics`] | [`crate::http::presets::metrics`] | `GET /metrics` |
+
+pub mod metrics;
+
+pub use metrics::{MetricsState, metrics_handler};

--- a/crates/octarine/src/http/mod.rs
+++ b/crates/octarine/src/http/mod.rs
@@ -75,6 +75,7 @@
 //! `observe::*` logging calls within the request scope.
 
 pub mod extractors;
+pub mod handlers;
 pub mod middleware;
 pub mod presets;
 

--- a/crates/octarine/src/http/presets/metrics.rs
+++ b/crates/octarine/src/http/presets/metrics.rs
@@ -1,0 +1,132 @@
+//! Prometheus `/metrics` scrape preset
+//!
+//! Mounts the [`crate::http::handlers::metrics_handler`] at the conventional
+//! `/metrics` URL so operators can wire a scrapable endpoint in one line,
+//! instead of plumbing the [`PrometheusExporter`] into a hand-rolled handler.
+//!
+//! The preset deliberately applies **no** auth, observe, or rate-limit layers —
+//! scrapers expect an uninstrumented endpoint, and instrumenting `/metrics`
+//! would pollute the very metrics being served.
+//!
+//! # Access control
+//!
+//! This preset does **not** restrict access, and the octarine middleware
+//! layers do not exclude `/metrics` for you: `AuthConfig`, `RateLimitConfig`,
+//! `ObserveConfig`, and `MetricsConfig` all start with an **empty**
+//! exclude-path list. If you apply any of those layers globally, you must
+//! explicitly call `.exclude_paths(["/metrics"])` on their config — otherwise
+//! scrapers receive `401`/`429` and monitoring breaks. Conversely, the
+//! exposition body reveals internal metric names and values, so restrict
+//! access at the network layer (or add an auth layer scoped to this router)
+//! before exposing it beyond a trusted scrape network.
+//!
+//! # Example
+//!
+//! ```rust
+//! use axum::Router;
+//! use octarine::http::presets::metrics;
+//!
+//! let app: Router = Router::new().merge(metrics::metrics());
+//! ```
+//!
+//! [`PrometheusExporter`]: crate::observe::metrics::PrometheusExporter
+
+use axum::{Router, routing::get};
+
+use crate::http::handlers::{MetricsState, metrics_handler};
+use crate::observe::metrics::{PrometheusConfig, PrometheusExporter};
+
+/// Mount a Prometheus scrape endpoint at `GET /metrics`.
+///
+/// Uses a default [`PrometheusExporter`], which renders the active global
+/// metric registry. Merge the returned router into your application:
+///
+/// ```rust
+/// use axum::Router;
+/// use octarine::http::presets::metrics;
+///
+/// let app: Router = Router::new().merge(metrics::metrics());
+/// ```
+pub fn metrics() -> Router {
+    with_config(PrometheusConfig::default())
+}
+
+/// Mount a Prometheus scrape endpoint at `GET /metrics` with a custom
+/// [`PrometheusConfig`] (namespace, subsystem, default labels).
+///
+/// ```rust
+/// use axum::Router;
+/// use octarine::http::presets::metrics;
+/// use octarine::observe::metrics::PrometheusConfig;
+///
+/// let app: Router = Router::new()
+///     .merge(metrics::with_config(PrometheusConfig::new().namespace("myapp")));
+/// ```
+pub fn with_config(config: PrometheusConfig) -> Router {
+    let state = MetricsState::new(PrometheusExporter::new(config));
+    Router::new()
+        .route("/metrics", get(metrics_handler))
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode, header};
+    use tower::ServiceExt;
+
+    use super::*;
+
+    /// The preset serves 200 at `/metrics` with the Prometheus content type.
+    #[tokio::test]
+    async fn test_metrics_preset_serves_200() {
+        let app = Router::new().merge(metrics());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .expect("content-type header"),
+            "text/plain; version=0.0.4"
+        );
+    }
+
+    /// `with_config()` (custom namespace) also serves 200 with the Prometheus
+    /// content type — it is the only entry point for namespaced exposition.
+    #[tokio::test]
+    async fn test_with_config_serves_200() {
+        let app = Router::new().merge(with_config(PrometheusConfig::new().namespace("myapp")));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .expect("content-type header"),
+            "text/plain; version=0.0.4"
+        );
+    }
+}

--- a/crates/octarine/src/http/presets/mod.rs
+++ b/crates/octarine/src/http/presets/mod.rs
@@ -13,6 +13,7 @@
 //! | [`limits`] | Request body size limits |
 //! | [`timeout`] | Request timeout configurations |
 //! | [`compression`] | Response compression |
+//! | [`metrics`] | Prometheus `/metrics` scrape endpoint |
 //!
 //! # Recommended Middleware Stack
 //!
@@ -74,6 +75,7 @@
 pub mod compression;
 pub mod cors;
 pub mod limits;
+pub mod metrics;
 pub mod rate_limit;
 pub mod timeout;
 

--- a/crates/octarine/tests/http/metrics.rs
+++ b/crates/octarine/tests/http/metrics.rs
@@ -1,0 +1,170 @@
+//! Integration tests for the served `/metrics` Prometheus endpoint.
+//!
+//! These exercise the `octarine::http::presets::metrics()` preset end-to-end
+//! through `Router::oneshot()`, confirming the wiring an operator relies on:
+//! the route serves, the `Content-Type` matches the Prometheus exposition
+//! spec exactly, the body parses as valid Prometheus text, and an
+//! uninitialized exporter degrades to a structured `503` rather than panicking.
+
+#![allow(clippy::panic, clippy::expect_used)]
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode, header},
+    routing::get,
+};
+use http_body_util::BodyExt;
+use octarine::http::handlers::{MetricsState, metrics_handler};
+use octarine::http::presets::metrics;
+use tower::ServiceExt;
+
+/// `Router::new().merge(metrics())` serves `/metrics` with status 200 and the
+/// exact Prometheus content type.
+#[tokio::test]
+async fn test_preset_serves_metrics_with_prometheus_content_type() {
+    let app = Router::new().merge(metrics::metrics());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content-type header"),
+        "text/plain; version=0.0.4",
+    );
+}
+
+/// An uninitialized exporter answers `503` with the shared structured error
+/// envelope instead of panicking.
+#[tokio::test]
+async fn test_uninitialized_exporter_returns_503_envelope() {
+    let app = Router::new()
+        .route("/metrics", get(metrics_handler))
+        .with_state(MetricsState::uninitialized());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("valid JSON envelope");
+
+    assert_eq!(
+        json.pointer("/error/code").and_then(|v| v.as_str()),
+        Some("service_unavailable"),
+    );
+    assert!(
+        json.pointer("/error/message")
+            .and_then(|v| v.as_str())
+            .is_some_and(|m| m.contains("not initialized")),
+        "expected a descriptive message, got: {json}",
+    );
+}
+
+/// Recording a known counter, gauge, and histogram produces a body that the
+/// `prometheus-parse` crate accepts as valid Prometheus text exposition.
+///
+/// Requires the `testing` feature for `flush_for_testing()`, which drains the
+/// async metric queue so the snapshot is deterministic.
+#[cfg(feature = "testing")]
+#[tokio::test]
+async fn test_recorded_metrics_parse_as_prometheus_text() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use octarine::observe::metrics::{MetricName, flush_for_testing, gauge, increment_by, record};
+    use prometheus_parse::Scrape;
+
+    // Unique suffix keeps this test isolated from the shared global registry.
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let suffix = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let counter = format!("scrape.requests.{suffix}");
+    let gauge_name = format!("scrape.queue.{suffix}");
+    let histo = format!("scrape.latency.{suffix}");
+
+    // Record and flush on a dedicated OS thread: `flush_for_testing()` blocks
+    // on a oneshot channel, which panics if called inside this `#[tokio::test]`
+    // runtime. The metric registry is process-global, so the flushed state is
+    // visible to the request issued below.
+    {
+        let (counter, gauge_name, histo) = (counter.clone(), gauge_name.clone(), histo.clone());
+        std::thread::spawn(move || {
+            increment_by(MetricName::new(&counter).expect("valid name"), 7);
+            gauge(MetricName::new(&gauge_name).expect("valid name"), 42);
+            record(MetricName::new(&histo).expect("valid name"), 0.25);
+            flush_for_testing();
+        })
+        .join()
+        .expect("record thread");
+    }
+
+    let app = Router::new().merge(metrics::metrics());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let body = String::from_utf8(bytes.to_vec()).expect("utf-8 body");
+
+    // The endpoint must produce parseable Prometheus text exposition.
+    let lines = body.lines().map(|l| Ok(l.to_string()));
+    let scrape = Scrape::parse(lines).expect("body parses as Prometheus text");
+
+    // Dots are normalized to underscores in the rendered names.
+    let counter_metric = counter.replace('.', "_");
+    let gauge_metric = gauge_name.replace('.', "_");
+    let histo_metric = histo.replace('.', "_");
+
+    assert!(
+        scrape.samples.iter().any(|s| s.metric == counter_metric),
+        "counter {counter_metric} missing from scrape: {body}",
+    );
+    assert!(
+        scrape.samples.iter().any(|s| s.metric == gauge_metric),
+        "gauge {gauge_metric} missing from scrape: {body}",
+    );
+    // Histograms render as `<name>_bucket` / `_sum` / `_count` series.
+    assert!(
+        scrape
+            .samples
+            .iter()
+            .any(|s| s.metric.starts_with(&histo_metric)),
+        "histogram {histo_metric} missing from scrape: {body}",
+    );
+}

--- a/crates/octarine/tests/http/mod.rs
+++ b/crates/octarine/tests/http/mod.rs
@@ -3,5 +3,6 @@
 mod context;
 mod error_response;
 mod extractors;
+mod metrics;
 mod presets;
 mod request_id;


### PR DESCRIPTION
## Summary

Wires the existing `PrometheusExporter` into a served axum `GET /metrics`
route so operators can scrape octarine services with one line —
`Router::new().merge(octarine::http::presets::metrics())` — instead of
hand-rolling a handler.

- **`http/handlers/metrics.rs`** (new): `metrics_handler` renders the
  exporter's text exposition with `Content-Type: text/plain; version=0.0.4`.
  `MetricsState` holds an `Option<PrometheusExporter>`; an absent exporter
  models the uninitialized pipeline and returns a structured **503** (never a
  panic). A render failure maps to **500** via the standard `ProblemResponse`.
- **`http/presets/metrics.rs`** (new): `metrics()` and `with_config()` mount
  the handler at `/metrics` with no auth/observe/rate-limit layers.
- Re-exports the new `handlers` module from `octarine::http`; lists the preset
  in the presets docs.

## Test plan

- Unit + integration tests (`Router::oneshot`):
  - `metrics()` **and** `with_config()` serve 200 with the exact
    `text/plain; version=0.0.4` content type.
  - Uninitialized / default state returns 503 with the shared structured error
    envelope (`error.code = service_unavailable`), asserted at both unit and
    integration level.
  - A recorded counter + gauge + histogram is scraped and parsed with the
    `prometheus-parse` crate, confirming valid Prometheus text exposition.
- `just clippy`, `just doc` (strict), full `just test` — all green. Pre-push
  hook ran `cargo test --workspace` (205 doctests + workspace suite) clean.

## Acceptance criteria

- [x] `Router::new().merge(octarine::http::presets::metrics())` compiles and
      serves on `/metrics`
- [x] Snapshot test parseable by `prometheus-parse`
- [x] `Content-Type` exactly `text/plain; version=0.0.4`
- [x] Uninitialized exporter returns 503 with structured envelope, never panics
- [ ] **Deferred**: end-to-end integration test wiring the preset into
      `octarine-server`. That crate does not exist yet — this issue is blocked
      by #469 and pairs with #465 (`octarine-server` REST scaffold). The
      in-process `Router::oneshot` tests cover the serving contract; the real
      TCP-bind scrape test belongs with #465 when the server lands.

## Adversarial review

A pre-PR adversarial review pass (security / correctness / tests / conventions
/ scope-drift) ran before this PR. Resolved on this PR:

- **Corrected a misleading security doc claim** — the preset docstring
  previously said `/metrics` was a "default-exclude path" across the
  middleware stack. It is **not**: `AuthConfig`, `RateLimitConfig`,
  `ObserveConfig`, and `MetricsConfig` all default to an empty `exclude_paths`.
  The docs now state operators must add `/metrics` to `exclude_paths`
  explicitly if they layer auth/rate-limit globally, plus an access-control
  callout.
- **Fixed a 503-vs-500 doc/behavior mismatch** and added a default-state test
  and a `with_config()` test.

Deferred (non-blocking, suitable for follow-up): an optional
`with_bearer_token` / `with_ip_allowlist` safe-by-default auth variant for the
endpoint.

Closes #528