### PR TITLE
feat(http): add CorrelationLayer middleware for correlation-id propagation

### DIFF
--- a/crates/octarine/src/http/extractors.rs
+++ b/crates/octarine/src/http/extractors.rs
@@ -70,7 +70,7 @@ where
             .map(CorrelationId)
             .ok_or((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "Missing correlation ID - ensure RequestIdLayer is configured",
+                "Missing correlation ID - ensure CorrelationLayer or RequestIdLayer is configured",
             ))
     }
 }

--- a/crates/octarine/src/http/middleware/correlation.rs
+++ b/crates/octarine/src/http/middleware/correlation.rs
@@ -1,0 +1,299 @@
+//! Correlation ID propagation middleware
+//!
+//! Wires the existing `traceparent` + `x-correlation-id` extraction helpers in
+//! [`crate::observe::tracing`] into the HTTP layer so that:
+//!
+//! 1. Every inbound request is tagged with a correlation ID, taken from the
+//!    `X-Correlation-ID`, `X-Request-ID`, or W3C `traceparent` header (in that
+//!    priority order), or freshly generated when none is present.
+//! 2. The id is established in a **task-local** scope for the duration of the
+//!    request, so every `observe::Event` emitted inside the handler — across
+//!    `await` points and worker-thread hops — automatically carries it.
+//! 3. The response echoes the active correlation ID back to the caller via the
+//!    `X-Correlation-ID` header and a chained W3C `traceparent`, letting
+//!    downstream services and clients stitch the request chain across hops.
+//!
+//! # Security
+//!
+//! Inbound header values are accepted **only** when they parse as a UUID. The
+//! underlying [`extract_from_headers`](crate::observe::tracing::extract_from_headers)
+//! helper validates every candidate, so arbitrary header content can never reach
+//! the correlation ID — closing log-injection and downstream header-smuggling
+//! vectors. A present-but-invalid `X-Correlation-ID` is rejected (a fresh id is
+//! generated) and a warning is logged **without** echoing the rejected value.
+//!
+//! # Relationship to [`RequestIdLayer`](super::RequestIdLayer)
+//!
+//! `RequestIdLayer` sets the correlation ID in **thread-local** storage and only
+//! understands `X-Request-ID`. `CorrelationLayer` is the richer option: it also
+//! accepts `X-Correlation-ID` and W3C `traceparent`, scopes the id as
+//! **task-local** (correct for async handlers on a multi-threaded runtime), and
+//! emits a chained `traceparent` on the response. Use one or the other, not both.
+//!
+//! # Preferred Layer Order
+//!
+//! Mount `CorrelationLayer` outermost so every subsequent layer's events carry
+//! the id (outermost listed first):
+//!
+//! 1. `CorrelationLayer` — correlation ID + traceparent (first, so all logs have it)
+//! 2. `ObserveLayer` — request/response logging (inherits the id)
+//! 3. `ContextLayer` — tenant / user / source IP
+//! 4. `AuthLayer` — authentication (its failures are logged with the id)
+//! 5. `RateLimitLayer` — typically per-route
+//!
+//! # Example
+//!
+//! ```rust
+//! use axum::{Router, routing::get};
+//! use octarine::http::middleware::CorrelationLayer;
+//!
+//! let app: Router = Router::new()
+//!     .route("/", get(|| async { "ok" }))
+//!     .layer(CorrelationLayer::new());
+//! ```
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use axum::{
+    body::Body,
+    http::{HeaderMap, HeaderValue, Request, Response, header::HeaderName},
+};
+use tower::{Layer, Service};
+use uuid::Uuid;
+
+use crate::observe::tracing::{extract_correlation_id, inject_to_headers};
+use crate::observe::warn;
+use crate::primitives::runtime as prim_runtime;
+
+/// Header name for the correlation ID (canonical, echoed on responses).
+pub static X_CORRELATION_ID: HeaderName = HeaderName::from_static("x-correlation-id");
+
+/// Header name for the W3C trace context.
+pub static TRACEPARENT: HeaderName = HeaderName::from_static("traceparent");
+
+/// Layer that propagates a correlation ID across the request lifecycle.
+///
+/// See the module-level documentation for behavior, security notes, and the
+/// preferred ordering relative to the other middleware layers.
+///
+/// # Example
+///
+/// ```rust
+/// use axum::{Router, routing::get};
+/// use octarine::http::middleware::CorrelationLayer;
+///
+/// let app: Router = Router::new()
+///     .route("/", get(|| async { "ok" }))
+///     .layer(CorrelationLayer::new());
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct CorrelationLayer {
+    /// When `true`, also write the resolved id into the **request** headers as
+    /// `X-Correlation-ID` (if absent) so downstream services receive it.
+    propagate_to_request: bool,
+}
+
+impl CorrelationLayer {
+    /// Create a new `CorrelationLayer` with default settings.
+    ///
+    /// By default the resolved id is propagated into the inbound request headers
+    /// so that downstream services (reached from within the handler) inherit it.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            propagate_to_request: true,
+        }
+    }
+
+    /// Control whether the resolved id is written into the inbound request
+    /// headers (`X-Correlation-ID`) for downstream propagation.
+    ///
+    /// Disable this if a downstream client constructs its own outbound headers
+    /// and you do not want the inbound request mutated.
+    #[must_use]
+    pub fn propagate_to_request(mut self, enable: bool) -> Self {
+        self.propagate_to_request = enable;
+        self
+    }
+}
+
+impl<S> Layer<S> for CorrelationLayer {
+    type Service = CorrelationService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CorrelationService {
+            inner,
+            propagate_to_request: self.propagate_to_request,
+        }
+    }
+}
+
+/// Service that resolves, scopes, and echoes the correlation ID.
+#[derive(Debug, Clone)]
+pub struct CorrelationService<S> {
+    inner: S,
+    propagate_to_request: bool,
+}
+
+/// Build a case-preserving string view of the header map for the `HeaderLike`
+/// extraction helpers. Header names are already lowercase in axum, and the
+/// helpers query case-insensitively, so this is a faithful adapter.
+fn headers_to_map(headers: &HeaderMap) -> HashMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|v| (name.as_str().to_string(), v.to_string()))
+        })
+        .collect()
+}
+
+impl<S> Service<Request<Body>> for CorrelationService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: Request<Body>) -> Self::Future {
+        // Reject a present-but-invalid X-Correlation-ID. We log WITHOUT echoing
+        // the rejected value to avoid log injection from attacker-controlled
+        // header content.
+        let raw_correlation = request
+            .headers()
+            .get(&X_CORRELATION_ID)
+            .and_then(|v| v.to_str().ok());
+        if let Some(raw) = raw_correlation
+            && Uuid::parse_str(raw.trim()).is_err()
+        {
+            warn(
+                "correlation",
+                "Rejected invalid X-Correlation-ID header (not a UUID); generating a fresh id",
+            );
+        }
+
+        // Extract the trace context. `extract_correlation_id` tries
+        // X-Correlation-ID -> X-Request-ID -> traceparent (all UUID-validated)
+        // and falls back to a fresh UUID when none is present/valid.
+        let header_map = headers_to_map(request.headers());
+        let correlation_id = extract_correlation_id(&header_map).correlation_id;
+
+        // Optionally propagate the resolved id into the request headers so
+        // downstream services reached from the handler inherit it.
+        if self.propagate_to_request
+            && let Ok(value) = HeaderValue::from_str(&correlation_id.to_string())
+        {
+            request
+                .headers_mut()
+                .insert(X_CORRELATION_ID.clone(), value);
+        }
+
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            // Scope the id as task-local so every observe::Event emitted during
+            // request handling carries it, across await points and threads.
+            let mut response =
+                prim_runtime::with_correlation_id(correlation_id, inner.call(request)).await?;
+
+            inject_correlation_response(response.headers_mut(), correlation_id);
+
+            Ok(response)
+        })
+    }
+}
+
+/// Echo the correlation id into response headers: `X-Correlation-ID` plus a
+/// chained W3C `traceparent`.
+///
+/// The canonical formatting (including the trace-id derived from the correlation
+/// id, which keeps the trace chained across hops) is reused from
+/// [`inject_to_headers`]; we copy only the correlation + traceparent headers so
+/// we never clobber an `X-Request-ID` set by another layer.
+fn inject_correlation_response(headers: &mut HeaderMap, correlation_id: Uuid) {
+    let mut formatted: HashMap<String, String> = HashMap::new();
+    inject_to_headers(&mut formatted, correlation_id);
+
+    // `inject_to_headers` keys the map with the propagation module's own header
+    // casing (e.g. `X-Correlation-ID`), so match case-insensitively against the
+    // lowercase canonical names we want to copy. We copy only correlation +
+    // traceparent so we never clobber an `X-Request-ID` set by another layer.
+    for canonical in [&X_CORRELATION_ID, &TRACEPARENT] {
+        if let Some(value) = formatted
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case(canonical.as_str()))
+            .map(|(_, value)| value)
+            && let Ok(header_value) = HeaderValue::from_str(value)
+        {
+            headers.insert(canonical.clone(), header_value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_layer_creation_defaults() {
+        let layer = CorrelationLayer::new();
+        assert!(layer.propagate_to_request);
+    }
+
+    #[test]
+    fn test_propagate_to_request_toggle() {
+        let layer = CorrelationLayer::new().propagate_to_request(false);
+        assert!(!layer.propagate_to_request);
+    }
+
+    #[test]
+    fn test_headers_to_map_skips_non_utf8() {
+        let mut headers = HeaderMap::new();
+        headers.insert(&X_CORRELATION_ID, HeaderValue::from_static("abc"));
+        headers.insert(
+            HeaderName::from_static("x-binary"),
+            HeaderValue::from_bytes(&[0xff, 0xfe]).expect("bytes"),
+        );
+
+        let map = headers_to_map(&headers);
+        assert_eq!(map.get("x-correlation-id"), Some(&"abc".to_string()));
+        assert!(!map.contains_key("x-binary"));
+    }
+
+    #[test]
+    fn test_inject_correlation_response_sets_headers() {
+        let id = Uuid::new_v4();
+        let mut headers = HeaderMap::new();
+        inject_correlation_response(&mut headers, id);
+
+        let echoed = headers
+            .get(&X_CORRELATION_ID)
+            .and_then(|v| v.to_str().ok())
+            .expect("x-correlation-id set");
+        assert_eq!(echoed, id.to_string());
+
+        let traceparent = headers
+            .get(&TRACEPARENT)
+            .and_then(|v| v.to_str().ok())
+            .expect("traceparent set");
+        assert!(traceparent.starts_with("00-"));
+
+        // We intentionally do not set X-Request-ID here (avoid clobbering
+        // RequestIdLayer).
+        assert!(headers.get("x-request-id").is_none());
+    }
+}

--- a/crates/octarine/src/http/middleware/correlation.rs
+++ b/crates/octarine/src/http/middleware/correlation.rs
@@ -66,7 +66,9 @@ use axum::{
 use tower::{Layer, Service};
 use uuid::Uuid;
 
-use crate::observe::tracing::{HeaderLike, extract_correlation_id, inject_to_headers};
+use crate::observe::tracing::{
+    HeaderLike, extract_correlation_id, inject_to_headers, is_valid_traceparent,
+};
 use crate::observe::warn;
 use crate::primitives::runtime as prim_runtime;
 
@@ -207,6 +209,16 @@ where
                     ),
                 );
             }
+        }
+        // traceparent is also an accepted source — audit a malformed one too,
+        // so the rejection-warning guarantee covers every header we read.
+        if let Some(raw) = header_map.get_header(TRACEPARENT.as_str())
+            && !is_valid_traceparent(&raw)
+        {
+            warn(
+                "correlation",
+                "Rejected invalid traceparent header (malformed); generating a fresh id",
+            );
         }
 
         // Extract the trace context. `extract_correlation_id` tries

--- a/crates/octarine/src/http/middleware/correlation.rs
+++ b/crates/octarine/src/http/middleware/correlation.rs
@@ -45,7 +45,7 @@
 //!
 //! ```rust
 //! use axum::{Router, routing::get};
-//! use octarine::http::middleware::CorrelationLayer;
+//! use octarine::http::CorrelationLayer;
 //!
 //! let app: Router = Router::new()
 //!     .route("/", get(|| async { "ok" }))
@@ -66,12 +66,15 @@ use axum::{
 use tower::{Layer, Service};
 use uuid::Uuid;
 
-use crate::observe::tracing::{extract_correlation_id, inject_to_headers};
+use crate::observe::tracing::{HeaderLike, extract_correlation_id, inject_to_headers};
 use crate::observe::warn;
 use crate::primitives::runtime as prim_runtime;
 
 /// Header name for the correlation ID (canonical, echoed on responses).
 pub static X_CORRELATION_ID: HeaderName = HeaderName::from_static("x-correlation-id");
+
+/// Header name for the common request ID (accepted as a correlation source).
+pub static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
 
 /// Header name for the W3C trace context.
 pub static TRACEPARENT: HeaderName = HeaderName::from_static("traceparent");
@@ -85,17 +88,29 @@ pub static TRACEPARENT: HeaderName = HeaderName::from_static("traceparent");
 ///
 /// ```rust
 /// use axum::{Router, routing::get};
-/// use octarine::http::middleware::CorrelationLayer;
+/// use octarine::http::CorrelationLayer;
 ///
 /// let app: Router = Router::new()
 ///     .route("/", get(|| async { "ok" }))
 ///     .layer(CorrelationLayer::new());
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct CorrelationLayer {
-    /// When `true`, also write the resolved id into the **request** headers as
-    /// `X-Correlation-ID` (if absent) so downstream services receive it.
+    /// When `true`, write the resolved id into the **request** headers as
+    /// `X-Correlation-ID` (overwriting any inbound value with the resolved,
+    /// validated id) so downstream services receive it.
     propagate_to_request: bool,
+}
+
+impl Default for CorrelationLayer {
+    /// Identical to [`CorrelationLayer::new`] — request-header propagation on.
+    ///
+    /// Implemented manually (rather than derived) so `Default::default()` and
+    /// `new()` never diverge: a derived `Default` would zero `propagate_to_request`
+    /// to `false`, silently disabling the documented default behavior.
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CorrelationLayer {
@@ -169,30 +184,39 @@ where
     }
 
     fn call(&mut self, mut request: Request<Body>) -> Self::Future {
-        // Reject a present-but-invalid X-Correlation-ID. We log WITHOUT echoing
-        // the rejected value to avoid log injection from attacker-controlled
-        // header content.
-        let raw_correlation = request
-            .headers()
-            .get(&X_CORRELATION_ID)
-            .and_then(|v| v.to_str().ok());
-        if let Some(raw) = raw_correlation
-            && Uuid::parse_str(raw.trim()).is_err()
-        {
-            warn(
-                "correlation",
-                "Rejected invalid X-Correlation-ID header (not a UUID); generating a fresh id",
-            );
+        // Build the header view ONCE and drive both the audit warning and the
+        // extraction from it, so the value we warn about is exactly the value
+        // extraction considers — avoiding a first-vs-last mismatch when a client
+        // smuggles duplicate id headers.
+        let header_map = headers_to_map(request.headers());
+
+        // Reject present-but-invalid id headers. We log WITHOUT echoing the
+        // rejected value to avoid log injection from attacker-controlled header
+        // content. Both accepted id sources (`X-Correlation-ID`, `X-Request-ID`)
+        // are checked so the audit trail is complete regardless of which header
+        // the probe used.
+        for header in [&X_CORRELATION_ID, &X_REQUEST_ID] {
+            if let Some(raw) = header_map.get_header(header.as_str())
+                && Uuid::parse_str(raw.trim()).is_err()
+            {
+                warn(
+                    "correlation",
+                    format!(
+                        "Rejected invalid {} header (not a UUID); generating a fresh id",
+                        header.as_str()
+                    ),
+                );
+            }
         }
 
         // Extract the trace context. `extract_correlation_id` tries
         // X-Correlation-ID -> X-Request-ID -> traceparent (all UUID-validated)
         // and falls back to a fresh UUID when none is present/valid.
-        let header_map = headers_to_map(request.headers());
         let correlation_id = extract_correlation_id(&header_map).correlation_id;
 
         // Optionally propagate the resolved id into the request headers so
-        // downstream services reached from the handler inherit it.
+        // downstream services reached from the handler inherit it. We overwrite
+        // any inbound value with the resolved, validated id.
         if self.propagate_to_request
             && let Ok(value) = HeaderValue::from_str(&correlation_id.to_string())
         {
@@ -201,7 +225,11 @@ where
                 .insert(X_CORRELATION_ID.clone(), value);
         }
 
-        let mut inner = self.inner.clone();
+        // Tower contract: `call` must run on the same instance that `poll_ready`
+        // readied. Swap the readied `self.inner` out and leave a clone behind for
+        // the next poll, rather than cloning the (unpolled) service for the call.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move {
             // Scope the id as task-local so every observe::Event emitted during
@@ -258,6 +286,16 @@ mod tests {
     fn test_propagate_to_request_toggle() {
         let layer = CorrelationLayer::new().propagate_to_request(false);
         assert!(!layer.propagate_to_request);
+    }
+
+    #[test]
+    fn test_default_matches_new() {
+        // Default must not diverge from new() — both enable request propagation.
+        assert_eq!(
+            CorrelationLayer::default().propagate_to_request,
+            CorrelationLayer::new().propagate_to_request
+        );
+        assert!(CorrelationLayer::default().propagate_to_request);
     }
 
     #[test]

--- a/crates/octarine/src/http/middleware/correlation.rs
+++ b/crates/octarine/src/http/middleware/correlation.rs
@@ -161,15 +161,17 @@ pub struct CorrelationService<S> {
 /// extraction helpers. Header names are already lowercase in axum, and the
 /// helpers query case-insensitively, so this is a faithful adapter.
 fn headers_to_map(headers: &HeaderMap) -> HashMap<String, String> {
-    headers
-        .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|v| (name.as_str().to_string(), v.to_string()))
-        })
-        .collect()
+    let mut map = HashMap::new();
+    for (name, value) in headers.iter() {
+        // First-value-wins, matching `HeaderMap::get()` and HTTP precedence:
+        // a client cannot displace a valid leading id by appending a duplicate
+        // header (which a plain `.collect()` would let win, last-writer-wins).
+        if let Ok(v) = value.to_str() {
+            map.entry(name.as_str().to_string())
+                .or_insert_with(|| v.to_string());
+        }
+    }
+    map
 }
 
 impl<S> Service<Request<Body>> for CorrelationService<S>

--- a/crates/octarine/src/http/middleware/mod.rs
+++ b/crates/octarine/src/http/middleware/mod.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "auth")]
 mod auth;
 mod context;
+mod correlation;
 mod metrics;
 mod observe;
 mod rate_limit;
@@ -15,6 +16,7 @@ mod security;
 #[cfg(feature = "auth")]
 pub use auth::{ApiKeyValidator, AuthConfig, AuthLayer, AuthService, Claims};
 pub use context::{ContextLayer, ContextService};
+pub use correlation::{CorrelationLayer, CorrelationService};
 pub use metrics::{MetricsConfig, MetricsLayer, MetricsService};
 // Re-export PathPattern from data layer for public API
 pub use crate::data::network::PathPattern;

--- a/crates/octarine/src/http/mod.rs
+++ b/crates/octarine/src/http/mod.rs
@@ -52,7 +52,12 @@
 //!
 //! Recommended order (outermost first):
 //!
-//! 1. `RequestIdLayer` - correlation ID (first, so all logs have it)
+//! 1. `CorrelationLayer` - correlation ID + W3C `traceparent` (first, so all
+//!    logs carry the id and the response echoes it). Prefer this over
+//!    `RequestIdLayer` for async services: it also accepts `X-Correlation-ID`
+//!    and `traceparent`, scopes the id as task-local, and chains the outbound
+//!    trace. Use `RequestIdLayer` only when a thread-local, `X-Request-ID`-only
+//!    id is sufficient; do not mount both.
 //! 2. `TimeoutLayer` - reject slow requests early
 //! 3. `RequestBodyLimitLayer` - reject oversized requests
 //! 4. `ContextLayer` - extract tenant/user
@@ -89,9 +94,9 @@ pub use extractors::{
 #[cfg(feature = "auth")]
 pub use middleware::{AuthConfig, AuthLayer, Claims};
 pub use middleware::{
-    ContextLayer, FrameOptions, KeyStrategy, MetricsConfig, MetricsLayer, ObserveConfig,
-    ObserveLayer, PathPattern, RateLimitConfig, RateLimitLayer, RequestIdLayer, SecurityConfig,
-    SecurityLayer,
+    ContextLayer, CorrelationLayer, FrameOptions, KeyStrategy, MetricsConfig, MetricsLayer,
+    ObserveConfig, ObserveLayer, PathPattern, RateLimitConfig, RateLimitLayer, RequestIdLayer,
+    SecurityConfig, SecurityLayer,
 };
 
 // Re-export tower-http types for convenience (so users don't need to add tower-http dependency)

--- a/crates/octarine/src/http/mod.rs
+++ b/crates/octarine/src/http/mod.rs
@@ -15,7 +15,7 @@
 //!
 //! ```rust
 //! use axum::{Router, routing::get};
-//! use octarine::http::{RequestIdLayer, ContextLayer};
+//! use octarine::http::{CorrelationLayer, ContextLayer};
 //!
 //! async fn list_patterns() -> &'static str {
 //!     "patterns"
@@ -23,7 +23,7 @@
 //!
 //! let app: Router = Router::new()
 //!     .route("/api/patterns", get(list_patterns))
-//!     .layer(RequestIdLayer::new())
+//!     .layer(CorrelationLayer::new())
 //!     .layer(ContextLayer::new());
 //! ```
 //!

--- a/crates/octarine/src/observe/tracing/mod.rs
+++ b/crates/octarine/src/observe/tracing/mod.rs
@@ -75,7 +75,7 @@ pub use config::TracingConfig;
 pub use layer::ObserveLayer;
 pub use propagation::{
     HeaderLike, HeaderLikeMut, TraceContext, extract_correlation_id, extract_from_headers,
-    inject_correlation_id, inject_to_headers,
+    inject_correlation_id, inject_to_headers, is_valid_traceparent,
 };
 
 // Re-export otel types at tracing level (three-layer API)

--- a/crates/octarine/src/observe/tracing/propagation.rs
+++ b/crates/octarine/src/observe/tracing/propagation.rs
@@ -199,6 +199,16 @@ where
     }
 }
 
+/// Returns `true` if `value` is a `traceparent` header this parser would
+/// accept (valid version byte and a 32-hex-digit trace-id yielding a UUID).
+///
+/// Useful for auditing: an HTTP middleware can warn when a present
+/// `traceparent` header is rejected, instead of silently dropping it.
+#[must_use]
+pub fn is_valid_traceparent(value: &str) -> bool {
+    parse_traceparent(value).is_some()
+}
+
 /// Parse W3C traceparent header format
 ///
 /// Format: {version}-{trace-id}-{parent-id}-{flags}
@@ -206,6 +216,14 @@ where
 fn parse_traceparent(value: &str) -> Option<Uuid> {
     let parts: Vec<&str> = value.split('-').collect();
     if parts.len() >= 2 {
+        // version is the first part: a two-hex-digit byte. Per W3C Trace
+        // Context §2.2.3 the reserved value `ff` is invalid and MUST be
+        // rejected; we also reject any malformed (non-two-char) version so an
+        // attacker cannot smuggle a chosen trace-id via a bogus version.
+        let version = parts.first()?;
+        if version.len() != 2 || version.eq_ignore_ascii_case("ff") {
+            return None;
+        }
         // trace-id is the second part (32 hex chars)
         let trace_id = parts.get(1)?;
         if trace_id.len() == 32 {

--- a/crates/octarine/src/observe/tracing/propagation.rs
+++ b/crates/octarine/src/observe/tracing/propagation.rs
@@ -218,23 +218,28 @@ fn parse_traceparent(value: &str) -> Option<Uuid> {
     if parts.len() >= 2 {
         // version is the first part: a two-hex-digit byte. Per W3C Trace
         // Context §2.2.3 the reserved value `ff` is invalid and MUST be
-        // rejected; we also reject any malformed (non-two-char) version so an
-        // attacker cannot smuggle a chosen trace-id via a bogus version.
+        // rejected; we also reject any malformed (non-two-hex-digit) version so
+        // an attacker cannot smuggle a chosen trace-id via a bogus version.
         let version = parts.first()?;
-        if version.len() != 2 || version.eq_ignore_ascii_case("ff") {
+        if version.len() != 2
+            || !version.bytes().all(|b| b.is_ascii_hexdigit())
+            || version.eq_ignore_ascii_case("ff")
+        {
             return None;
         }
-        // trace-id is the second part (32 hex chars)
+        // trace-id is the second part (32 hex chars). Require ASCII hex so the
+        // byte-range slices below always fall on char boundaries (no panic) and
+        // out-of-spec trace-ids are rejected.
         let trace_id = parts.get(1)?;
-        if trace_id.len() == 32 {
+        if trace_id.len() == 32 && trace_id.bytes().all(|b| b.is_ascii_hexdigit()) {
             // Convert to UUID format
             let uuid_str = format!(
                 "{}-{}-{}-{}-{}",
-                &trace_id[0..8],
-                &trace_id[8..12],
-                &trace_id[12..16],
-                &trace_id[16..20],
-                &trace_id[20..32]
+                trace_id.get(0..8)?,
+                trace_id.get(8..12)?,
+                trace_id.get(12..16)?,
+                trace_id.get(16..20)?,
+                trace_id.get(20..32)?
             );
             return Uuid::parse_str(&uuid_str).ok();
         }
@@ -475,6 +480,45 @@ mod tests {
         // Invalid format
         assert!(parse_traceparent("invalid").is_none());
         assert!(parse_traceparent("00-short-00f067aa0ba902b7-01").is_none());
+    }
+
+    #[test]
+    fn test_parse_traceparent_rejects_invalid_version() {
+        // W3C §2.2.3: reserved `ff` version must be rejected.
+        assert!(
+            parse_traceparent("ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01").is_none()
+        );
+        // Malformed version length.
+        assert!(
+            parse_traceparent("0-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01").is_none()
+        );
+        assert!(
+            parse_traceparent("000-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01").is_none()
+        );
+        // Non-hex version byte.
+        assert!(
+            parse_traceparent("zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01").is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_traceparent_rejects_non_hex_trace_id() {
+        // 32-char trace-id with non-hex chars must be rejected (and must not
+        // panic on slicing).
+        assert!(
+            parse_traceparent("00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-00f067aa0ba902b7-01").is_none()
+        );
+    }
+
+    #[test]
+    fn test_is_valid_traceparent() {
+        assert!(is_valid_traceparent(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ));
+        assert!(!is_valid_traceparent(
+            "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        ));
+        assert!(!is_valid_traceparent("malformed"));
     }
 
     #[test]

--- a/crates/octarine/tests/http/correlation.rs
+++ b/crates/octarine/tests/http/correlation.rs
@@ -317,6 +317,133 @@ async fn test_compatible_with_observe_and_context_layers() {
 }
 
 #[tokio::test]
+async fn test_propagate_to_request_enabled_sets_request_header() {
+    // The positive arm: with propagation on (the default), a request arriving
+    // without any correlation header gets the resolved id injected before the
+    // handler sees it.
+    let app = Router::new()
+        .route(
+            "/",
+            get(|request: Request<Body>| async move {
+                request
+                    .headers()
+                    .get("x-correlation-id")
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "missing".to_string())
+            }),
+        )
+        .layer(CorrelationLayer::new());
+
+    let request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("valid utf8");
+
+    assert_ne!(body_str, "missing", "handler should see an injected header");
+    Uuid::parse_str(&body_str).expect("injected request header is a valid UUID");
+}
+
+#[tokio::test]
+async fn test_invalid_traceparent_falls_back_to_fresh_id() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(CorrelationLayer::new());
+
+    let request = Request::builder()
+        .uri("/")
+        .header(&TRACEPARENT, "invalid-garbage")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+
+    // A malformed traceparent is rejected; a fresh valid id is echoed.
+    let echoed = response
+        .headers()
+        .get(&X_CORRELATION_ID)
+        .and_then(|v| v.to_str().ok())
+        .expect("x-correlation-id echoed");
+    Uuid::parse_str(echoed).expect("fresh id is a valid UUID");
+}
+
+#[tokio::test]
+async fn test_correlation_id_visible_to_runtime_context_in_handler() {
+    // The core observability claim: the id is task-local for the request scope,
+    // so anything emitting an event (which reads the runtime correlation id)
+    // sees the inbound id. We read the runtime context directly in the handler.
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async { octarine::runtime::r#async::correlation_id().to_string() }),
+        )
+        .layer(CorrelationLayer::new());
+
+    let inbound = Uuid::new_v4();
+    let request = Request::builder()
+        .uri("/")
+        .header(&X_CORRELATION_ID, inbound.to_string())
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("valid utf8");
+
+    // The runtime correlation id observed inside the handler equals the inbound.
+    assert_eq!(body_str, inbound.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent_requests_have_isolated_correlation_ids() {
+    // task-local (not thread-local) isolation: two concurrent requests with a
+    // yield point must each observe only their own id, even across thread hops.
+    let app = Router::new()
+        .route(
+            "/",
+            get(|| async {
+                tokio::task::yield_now().await;
+                octarine::runtime::r#async::correlation_id().to_string()
+            }),
+        )
+        .layer(CorrelationLayer::new());
+
+    let id_a = Uuid::new_v4();
+    let id_b = Uuid::new_v4();
+
+    let req = |id: Uuid| {
+        Request::builder()
+            .uri("/")
+            .header(&X_CORRELATION_ID, id.to_string())
+            .body(Body::empty())
+            .expect("valid request")
+    };
+
+    let (resp_a, resp_b) = tokio::join!(
+        call_app(app.clone(), req(id_a)),
+        call_app(app.clone(), req(id_b))
+    );
+
+    let read = |resp: axum::response::Response| async {
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024)
+            .await
+            .expect("read body");
+        String::from_utf8(bytes.to_vec()).expect("valid utf8")
+    };
+
+    assert_eq!(read(resp_a).await, id_a.to_string());
+    assert_eq!(read(resp_b).await, id_b.to_string());
+}
+
+#[tokio::test]
 async fn test_propagate_to_request_disabled_does_not_set_request_header() {
     let app = Router::new()
         .route(

--- a/crates/octarine/tests/http/correlation.rs
+++ b/crates/octarine/tests/http/correlation.rs
@@ -1,0 +1,345 @@
+//! Integration tests for `CorrelationLayer`
+//!
+//! Covers the acceptance criteria from issue #531:
+//! - inbound `x-correlation-id` reaches the handler context (and thus events)
+//! - invalid `x-correlation-id` is rejected; a fresh id is generated
+//! - outbound `traceparent` chains with inbound when present; fresh otherwise
+//! - response carries `x-correlation-id`
+//! - error responses include the correlation id in the error envelope body
+//! - compatible with the other middleware layers (ordering)
+
+#![allow(clippy::panic, clippy::expect_used)]
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode, header::HeaderName},
+    routing::get,
+};
+use octarine::Problem;
+use octarine::http::{
+    ContextLayer, CorrelationId, CorrelationLayer, ObserveLayer, ProblemResponse,
+};
+use serde_json::Value;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+static X_CORRELATION_ID: HeaderName = HeaderName::from_static("x-correlation-id");
+static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+static TRACEPARENT: HeaderName = HeaderName::from_static("traceparent");
+
+/// Helper to make a request and get the response.
+async fn call_app(app: Router, request: Request<Body>) -> axum::response::Response {
+    app.oneshot(request).await.expect("request should succeed")
+}
+
+/// Build the W3C traceparent string the way the propagation helpers do, so a
+/// test can assert chaining (the trace-id is derived from the correlation id).
+fn expected_trace_id(id: Uuid) -> String {
+    format!("{:032x}", id.as_u128())
+}
+
+// ============================================================================
+// AC1: inbound correlation id reaches the handler context
+// ============================================================================
+
+#[tokio::test]
+async fn test_inbound_correlation_id_reaches_handler() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|CorrelationId(id): CorrelationId| async move { id.to_string() }),
+        )
+        .layer(CorrelationLayer::new());
+
+    let inbound = Uuid::new_v4();
+    let request = Request::builder()
+        .uri("/")
+        .header(&X_CORRELATION_ID, inbound.to_string())
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("valid utf8");
+
+    // The handler observed the SAME id as the inbound header — proving the
+    // task-local scope is active for everything emitted during the request.
+    assert_eq!(body_str, inbound.to_string());
+}
+
+#[tokio::test]
+async fn test_inbound_request_id_header_is_accepted() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|CorrelationId(id): CorrelationId| async move { id.to_string() }),
+        )
+        .layer(CorrelationLayer::new());
+
+    let inbound = Uuid::new_v4();
+    let request = Request::builder()
+        .uri("/")
+        .header(&X_REQUEST_ID, inbound.to_string())
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("valid utf8");
+
+    assert_eq!(body_str, inbound.to_string());
+}
+
+// ============================================================================
+// AC2: invalid correlation id is rejected; fresh id generated
+// ============================================================================
+
+#[tokio::test]
+async fn test_invalid_correlation_id_is_rejected() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|CorrelationId(id): CorrelationId| async move { id.to_string() }),
+        )
+        .layer(CorrelationLayer::new());
+
+    let request = Request::builder()
+        .uri("/")
+        .header(&X_CORRELATION_ID, "not-a-uuid; rm -rf /")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Response must carry a fresh, valid UUID — never the rejected raw value.
+    let echoed = response
+        .headers()
+        .get(&X_CORRELATION_ID)
+        .and_then(|v| v.to_str().ok())
+        .expect("x-correlation-id echoed")
+        .to_string();
+    assert_ne!(echoed, "not-a-uuid; rm -rf /");
+    Uuid::parse_str(&echoed).expect("fresh id is a valid UUID");
+
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("valid utf8");
+    Uuid::parse_str(&body_str).expect("handler saw a valid UUID");
+}
+
+// ============================================================================
+// AC3: traceparent chaining
+// ============================================================================
+
+#[tokio::test]
+async fn test_outbound_traceparent_chains_with_inbound() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(CorrelationLayer::new());
+
+    // W3C traceparent whose trace-id maps to a known UUID.
+    let inbound = Uuid::parse_str("4bf92f35-77b3-4da6-a3ce-929d0e0e4736").expect("valid uuid");
+    let traceparent_in = format!("00-{}-00f067aa0ba902b7-01", expected_trace_id(inbound));
+
+    let request = Request::builder()
+        .uri("/")
+        .header(&TRACEPARENT, &traceparent_in)
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+
+    // Outbound traceparent must carry the SAME trace-id (chained).
+    let traceparent_out = response
+        .headers()
+        .get(&TRACEPARENT)
+        .and_then(|v| v.to_str().ok())
+        .expect("traceparent echoed");
+    assert!(
+        traceparent_out.contains(&expected_trace_id(inbound)),
+        "outbound traceparent {traceparent_out} should chain inbound trace-id"
+    );
+
+    // And the echoed correlation id equals the inbound trace's UUID.
+    let echoed = response
+        .headers()
+        .get(&X_CORRELATION_ID)
+        .and_then(|v| v.to_str().ok())
+        .expect("x-correlation-id echoed");
+    assert_eq!(echoed, inbound.to_string());
+}
+
+#[tokio::test]
+async fn test_fresh_traceparent_when_absent() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(CorrelationLayer::new());
+
+    let request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+
+    let traceparent_out = response
+        .headers()
+        .get(&TRACEPARENT)
+        .and_then(|v| v.to_str().ok())
+        .expect("traceparent generated");
+    assert!(traceparent_out.starts_with("00-"));
+    assert!(traceparent_out.ends_with("-01"));
+
+    // Echoed correlation id is a fresh valid UUID.
+    let echoed = response
+        .headers()
+        .get(&X_CORRELATION_ID)
+        .and_then(|v| v.to_str().ok())
+        .expect("x-correlation-id echoed");
+    Uuid::parse_str(echoed).expect("fresh id is a valid UUID");
+}
+
+// ============================================================================
+// AC4: response carries x-correlation-id
+// ============================================================================
+
+#[tokio::test]
+async fn test_response_echoes_correlation_id() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(CorrelationLayer::new());
+
+    let inbound = Uuid::new_v4();
+    let request = Request::builder()
+        .uri("/")
+        .header(&X_CORRELATION_ID, inbound.to_string())
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+
+    let echoed = response
+        .headers()
+        .get(&X_CORRELATION_ID)
+        .and_then(|v| v.to_str().ok())
+        .expect("x-correlation-id echoed");
+    assert_eq!(echoed, inbound.to_string());
+}
+
+// ============================================================================
+// AC5: error responses include the correlation id in the envelope body
+// ============================================================================
+
+#[tokio::test]
+async fn test_error_envelope_includes_correlation_id() {
+    async fn failing() -> Result<&'static str, ProblemResponse> {
+        Err(Problem::Validation("bad input".into()).into())
+    }
+
+    let app = Router::new()
+        .route("/", get(failing))
+        .layer(CorrelationLayer::new());
+
+    let inbound = Uuid::new_v4();
+    let request = Request::builder()
+        .uri("/")
+        .header(&X_CORRELATION_ID, inbound.to_string())
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = axum::body::to_bytes(response.into_body(), 4096)
+        .await
+        .expect("read body");
+    let json: Value = serde_json::from_slice(&body).expect("valid json");
+
+    // The error envelope's request_id field carries the active correlation id.
+    let request_id = json
+        .get("error")
+        .and_then(|e| e.get("request_id"))
+        .and_then(|r| r.as_str())
+        .expect("error.request_id present");
+    assert_eq!(request_id, inbound.to_string());
+}
+
+// ============================================================================
+// AC6: compatible with the other middleware layers (ordering)
+// ============================================================================
+
+#[tokio::test]
+async fn test_compatible_with_observe_and_context_layers() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|CorrelationId(id): CorrelationId| async move { id.to_string() }),
+        )
+        // Inner-to-outer: ContextLayer, then ObserveLayer, then CorrelationLayer
+        // outermost so the id is set before observe logs the request.
+        .layer(ContextLayer::new())
+        .layer(ObserveLayer::new())
+        .layer(CorrelationLayer::new());
+
+    let inbound = Uuid::new_v4();
+    let request = Request::builder()
+        .uri("/")
+        .header(&X_CORRELATION_ID, inbound.to_string())
+        .header("x-tenant-id", "acme")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Correlation id survives the full stack and is echoed.
+    let echoed = response
+        .headers()
+        .get(&X_CORRELATION_ID)
+        .and_then(|v| v.to_str().ok())
+        .expect("x-correlation-id echoed");
+    assert_eq!(echoed, inbound.to_string());
+
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("valid utf8");
+    assert_eq!(body_str, inbound.to_string());
+}
+
+#[tokio::test]
+async fn test_propagate_to_request_disabled_does_not_set_request_header() {
+    let app = Router::new()
+        .route(
+            "/",
+            get(|request: Request<Body>| async move {
+                if request.headers().contains_key("x-correlation-id") {
+                    "has-header"
+                } else {
+                    "no-header"
+                }
+            }),
+        )
+        .layer(CorrelationLayer::new().propagate_to_request(false));
+
+    let request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("valid utf8");
+    assert_eq!(body_str, "no-header");
+}

--- a/crates/octarine/tests/http/correlation.rs
+++ b/crates/octarine/tests/http/correlation.rs
@@ -97,6 +97,35 @@ async fn test_inbound_request_id_header_is_accepted() {
     assert_eq!(body_str, inbound.to_string());
 }
 
+#[tokio::test]
+async fn test_correlation_id_takes_priority_over_request_id() {
+    // When both X-Correlation-ID and X-Request-ID are present, the former wins.
+    let app = Router::new()
+        .route(
+            "/",
+            get(|CorrelationId(id): CorrelationId| async move { id.to_string() }),
+        )
+        .layer(CorrelationLayer::new());
+
+    let correlation = Uuid::new_v4();
+    let request_id = Uuid::new_v4();
+    let request = Request::builder()
+        .uri("/")
+        .header(&X_CORRELATION_ID, correlation.to_string())
+        .header(&X_REQUEST_ID, request_id.to_string())
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .expect("read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("valid utf8");
+
+    assert_eq!(body_str, correlation.to_string());
+    assert_ne!(body_str, request_id.to_string());
+}
+
 // ============================================================================
 // AC2: invalid correlation id is rejected; fresh id generated
 // ============================================================================
@@ -134,6 +163,30 @@ async fn test_invalid_correlation_id_is_rejected() {
         .expect("read body");
     let body_str = String::from_utf8(body.to_vec()).expect("valid utf8");
     Uuid::parse_str(&body_str).expect("handler saw a valid UUID");
+}
+
+#[tokio::test]
+async fn test_invalid_request_id_header_is_rejected() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(CorrelationLayer::new());
+
+    let request = Request::builder()
+        .uri("/")
+        .header(&X_REQUEST_ID, "definitely-not-a-uuid")
+        .body(Body::empty())
+        .expect("valid request");
+
+    let response = call_app(app, request).await;
+
+    // Invalid X-Request-ID is rejected; a fresh valid id is echoed.
+    let echoed = response
+        .headers()
+        .get(&X_CORRELATION_ID)
+        .and_then(|v| v.to_str().ok())
+        .expect("x-correlation-id echoed");
+    assert_ne!(echoed, "definitely-not-a-uuid");
+    Uuid::parse_str(echoed).expect("fresh id is a valid UUID");
 }
 
 // ============================================================================

--- a/crates/octarine/tests/http/mod.rs
+++ b/crates/octarine/tests/http/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP integration test modules
 
 mod context;
+mod correlation;
 mod error_response;
 mod extractors;
 mod metrics;


### PR DESCRIPTION
## Summary

Adds `CorrelationLayer` — a tower `Layer`/`Service` middleware that wires the
existing `observe/tracing/propagation` helpers into the HTTP boundary so every
`observe::Event` emitted during a request handler carries the inbound
correlation id, and responses echo it back to callers.

- **Extract** inbound id from `X-Correlation-ID` → `X-Request-ID` → W3C
  `traceparent` (priority order) via `extract_correlation_id`, which
  UUID-validates every candidate — arbitrary header content can never reach the
  id, closing log-injection / header-smuggling vectors.
- **Reject** a present-but-invalid `X-Correlation-ID` / `X-Request-ID` /
  `traceparent` (warn without echoing the raw value) and fall back to a fresh
  UUID. Audit coverage spans all three accepted sources.
- **Scope** the id as task-local (`with_correlation_id`) so it flows across
  await points / worker threads to every event during request handling.
- **Echo** `X-Correlation-ID` plus a chained W3C `traceparent` on the response;
  the trace-id derives from the id, so the outbound trace chains with the
  inbound parent when present and is fresh otherwise.
- **Error-envelope** correlation id works automatically via the existing
  `http/error.rs` path (`try_correlation_id` reads task-local).
- Documents the preferred layer order relative to the other middleware.

Hardening also added to the shared `parse_traceparent` helper (W3C version-byte
validation incl. reserved `ff`, hex-digit enforcement, panic-safe slicing) and
a new `is_valid_traceparent` predicate.

## Acceptance criteria

- [x] Inbound `x-correlation-id` (valid UUID) ends up on every event emitted
      during request handling (verified via runtime-context read in handler).
- [x] Invalid `x-correlation-id` (non-UUID) is rejected — fresh id generated +
      warning logged.
- [x] Outbound `traceparent` chains with inbound when present; fresh when absent.
- [x] Response carries `x-correlation-id` echoing the active id.
- [x] Error responses include the correlation id in the error envelope body.
- [x] Compatible with `observe` / `context` middleware ordering — documented
      preferred order.

## Test plan

- `just test` (full workspace, nextest + doctests) — green.
- New integration tests in `tests/http/correlation.rs` cover all six ACs plus:
  header priority, invalid `X-Request-ID`, invalid/`ff` `traceparent` fallback,
  task-local visibility inside the handler, multi-thread concurrent-request
  isolation, and both `propagate_to_request` arms.
- New unit tests for `is_valid_traceparent` and the version / non-hex
  rejection branches.
- `just clippy`, `just doc` (strict), `just fmt-check`, `just arch-check` — all
  clean.

## Review

Three adversarial pre-PR review cycles (cap reached). All blocking findings
fixed on this branch; remaining out-of-scope `observe/tracing/propagation`
hardening (baggage CRLF sanitization in `inject_correlation_id`,
`extract_parent_span` validation consistency) filed as linked follow-ups —
those paths are not reachable through `CorrelationLayer`, which consumes only
the correlation id.

Closes #531
