### PR TITLE
deps: bump quick-xml to 0.41 and migrate AEAD crates to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
@@ -348,9 +348,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -358,14 +358,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -815,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1477,7 +1478,7 @@ dependencies = [
  "deunicode",
  "dummy",
  "either",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -2277,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2303,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2898,8 +2899,8 @@ dependencies = [
  "prometheus-parse",
  "proptest",
  "proptest-arbitrary-interop",
- "quick-xml 0.40.1",
- "rand 0.10.1",
+ "quick-xml",
+ "rand 0.10.2",
  "rand_core 0.10.1",
  "rayon",
  "regex",
@@ -3223,16 +3224,16 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phonenumber"
-version = "0.3.9+9.0.21"
+version = "0.3.10+9.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9114f9c1683dd09c5f4fa024c89fdad783eaae21d3d52dd23ddaaffa29ffb168"
+checksum = "66d85d3cc5477bfe2f357939e7f02a5a566632508633af1a2c37577d0bef87d9"
 dependencies = [
  "either",
  "fnv",
  "nom",
  "once_cell",
  "postcard",
- "quick-xml 0.38.4",
+ "quick-xml",
  "regex",
  "regex-cache",
  "serde",
@@ -3553,9 +3554,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.215"
+version = "2.1.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff7403e06671f170c65dc7bf475ed31d6e108c7e0d2440fb4df8ba56cfded6"
+checksum = "9826c2fe4dade07e9da1af2e18427257877bc8bc27aa810f6fbb52d907a480cc"
 dependencies = [
  "psl-types",
 ]
@@ -3589,18 +3590,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3705,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20 0.10.1",
  "getrandom 0.4.3",
@@ -3986,9 +3978,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4049,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4657,7 +4649,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -4936,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4956,9 +4948,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,34 +20,34 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.5.2",
  "ctr",
  "ghash",
  "subtle",
@@ -614,37 +614,26 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead",
- "chacha20 0.9.1",
- "cipher",
+ "chacha20",
+ "cipher 0.5.2",
  "poly1305",
- "zeroize",
 ]
 
 [[package]]
@@ -695,8 +684,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
- "zeroize",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -879,6 +878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,7 +1025,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1030,17 +1034,18 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1782,11 +1787,10 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -2328,6 +2332,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2996,12 +3009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3335,24 +3342,22 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "a00baa632505d05512f48a963e16051c54fda9a95cc9acea1a4e3c90991c4a2e"
 dependencies = [
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -3701,7 +3706,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -4694,7 +4699,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "ssh-encoding",
 ]
 
@@ -5479,12 +5484,12 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -57,8 +57,8 @@ sha3 = "0.12"
 blake3 = "1"
 hex = "0.4"
 zeroize = { version = "1.8", features = ["derive"] }
-chacha20poly1305 = "0.10.1"
-aes-gcm = "0.10.3"
+chacha20poly1305 = "0.11.0"
+aes-gcm = "0.11.0"
 argon2 = "0.5"
 
 # Cryptocurrency address validation (BTC base58check, Bech32/Bech32m, ETH EIP-55)

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -165,7 +165,7 @@ sha1 = { version = "0.11", optional = true }
 graphql-parser = { version = "0.4", optional = true }
 
 # Structured data formats (optional, for formats module)
-quick-xml = { version = "0.40", optional = true }
+quick-xml = { version = "0.41", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 # Crypto input validation (optional)

--- a/crates/octarine/src/primitives/crypto/encryption/ephemeral.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/ephemeral.rs
@@ -157,9 +157,9 @@ impl EphemeralEncryption {
         let cipher = ChaCha20Poly1305::new_from_slice(&key)
             .map_err(|e| CryptoError::invalid_key(format!("Failed to create cipher: {e}")))?;
 
-        let nonce_ref = Nonce::from_slice(&nonce);
+        let nonce_ref = Nonce::from(nonce);
         let ciphertext = cipher
-            .encrypt(nonce_ref, data)
+            .encrypt(&nonce_ref, data)
             .map_err(|e| CryptoError::encryption(format!("Encryption failed: {e}")))?;
 
         Ok(Self {
@@ -272,10 +272,10 @@ impl EphemeralEncryption {
         let cipher = ChaCha20Poly1305::new_from_slice(&self.key)
             .map_err(|e| CryptoError::invalid_key(format!("Failed to create cipher: {e}")))?;
 
-        let nonce = Nonce::from_slice(&self.nonce);
+        let nonce = Nonce::from(self.nonce);
 
         cipher
-            .decrypt(nonce, self.ciphertext.as_slice())
+            .decrypt(&nonce, self.ciphertext.as_slice())
             .map_err(|e| CryptoError::decryption(format!("Decryption failed: {e}")))
     }
 

--- a/crates/octarine/src/primitives/crypto/encryption/hybrid/encryption.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/hybrid/encryption.rs
@@ -98,9 +98,9 @@ impl HybridEncryption {
         let cipher = ChaCha20Poly1305::new_from_slice(&encryption_key)
             .map_err(|e| CryptoError::encryption(format!("Failed to create cipher: {e}")))?;
 
-        let nonce_ref = Nonce::from_slice(&nonce);
+        let nonce_ref = Nonce::from(nonce);
         let ciphertext = cipher
-            .encrypt(nonce_ref, data)
+            .encrypt(&nonce_ref, data)
             .map_err(|e| CryptoError::encryption(format!("Encryption failed: {e}")))?;
 
         // Zeroize sensitive material (encryption_key is already mut)
@@ -170,9 +170,9 @@ impl HybridEncryption {
         let cipher = ChaCha20Poly1305::new_from_slice(&decryption_key)
             .map_err(|e| CryptoError::decryption(format!("Failed to create cipher: {e}")))?;
 
-        let nonce = Nonce::from_slice(&self.nonce);
+        let nonce = Nonce::from(self.nonce);
         let plaintext = cipher
-            .decrypt(nonce, self.ciphertext.as_slice())
+            .decrypt(&nonce, self.ciphertext.as_slice())
             .map_err(|e| CryptoError::decryption(format!("Decryption failed: {e}")))?;
 
         // Zeroize sensitive material (decryption_key is already mut)

--- a/crates/octarine/src/primitives/crypto/encryption/keyed.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/keyed.rs
@@ -159,14 +159,14 @@ fn aead_encrypt(
             let cipher = ChaCha20Poly1305::new_from_slice(key)
                 .map_err(|e| CryptoError::invalid_key(format!("cipher init failed: {e}")))?;
             cipher
-                .encrypt(ChachaNonce::from_slice(nonce), payload)
+                .encrypt(&ChachaNonce::from(*nonce), payload)
                 .map_err(|e| CryptoError::encryption(format!("encryption failed: {e}")))
         }
         AeadAlgo::Aes256Gcm => {
             let cipher = Aes256Gcm::new_from_slice(key)
                 .map_err(|e| CryptoError::invalid_key(format!("cipher init failed: {e}")))?;
             cipher
-                .encrypt(AesNonce::from_slice(nonce), payload)
+                .encrypt(&AesNonce::from(*nonce), payload)
                 .map_err(|e| CryptoError::encryption(format!("encryption failed: {e}")))
         }
     }
@@ -190,14 +190,14 @@ fn aead_decrypt(
             let cipher = ChaCha20Poly1305::new_from_slice(key)
                 .map_err(|e| CryptoError::invalid_key(format!("cipher init failed: {e}")))?;
             cipher
-                .decrypt(ChachaNonce::from_slice(nonce), payload)
+                .decrypt(&ChachaNonce::from(*nonce), payload)
                 .map_err(|e| CryptoError::decryption(format!("decryption failed: {e}")))
         }
         AeadAlgo::Aes256Gcm => {
             let cipher = Aes256Gcm::new_from_slice(key)
                 .map_err(|e| CryptoError::invalid_key(format!("cipher init failed: {e}")))?;
             cipher
-                .decrypt(AesNonce::from_slice(nonce), payload)
+                .decrypt(&AesNonce::from(*nonce), payload)
                 .map_err(|e| CryptoError::decryption(format!("decryption failed: {e}")))
         }
     }
@@ -452,6 +452,48 @@ mod tests {
     #[test]
     fn empty_wire_decodes_to_error() {
         assert!(open(&KEY, "", b"EMAIL").is_err());
+    }
+
+    /// Known-answer test pinning the exact on-wire bytes for deterministic-mode
+    /// sealing. In deterministic mode the nonce is `HKDF(key, AAD ‖ plaintext)`,
+    /// so a fixed `(algo, key, plaintext, aad)` produces a byte-stable wire
+    /// string — unlike random mode. These vectors were captured under aes-gcm /
+    /// chacha20poly1305 0.10 (aead 0.5) and verified byte-for-byte identical
+    /// under 0.11 (aead 0.6), proving the trait/`hybrid-array` migration did not
+    /// alter the AEAD output. They guard against silent wire-format drift on
+    /// future AEAD upgrades: a change here means previously stored ciphertext
+    /// would no longer decrypt, and must be treated as a breaking data-format
+    /// change — never blindly re-baselined.
+    #[test]
+    fn deterministic_wire_format_known_answers() {
+        const KAT_PLAINTEXT: &[u8] = b"known-answer-plaintext";
+        const KAT_AAD: &[u8] = b"EMAIL";
+        // Captured vectors: (algo, expected base64 URL_SAFE_NO_PAD wire string).
+        let vectors = [
+            (
+                AeadAlgo::ChaCha20Poly1305,
+                "AQH-jQCP_cTwrF4Ju8a7bQZmH-Bw4UNb4Jy_qkM7E5c_DziHbFyynYgBZiXy-uFxAcm2Eg",
+            ),
+            (
+                AeadAlgo::Aes256Gcm,
+                "AQL-jQCP_cTwrF4Ju8b_PBgMFvtvQEkjMAtBmXHtgnsgIQp7XbGc08v3gP5MZ7HYXjSCZA",
+            ),
+        ];
+        for (algo, expected) in vectors {
+            let wire =
+                seal(algo, &KEY, KAT_PLAINTEXT, KAT_AAD, NonceMode::Deterministic).expect("seal");
+            assert_eq!(
+                wire,
+                expected,
+                "wire format drifted for algo_id={} — stored ciphertext would no longer decrypt",
+                algo.algo_id()
+            );
+            // The pinned bytes must also still open to the original plaintext.
+            assert_eq!(
+                open(&KEY, expected, KAT_AAD).expect("open").as_slice(),
+                KAT_PLAINTEXT
+            );
+        }
     }
 
     #[test]

--- a/crates/octarine/src/primitives/crypto/encryption/persistent/storage/operations.rs
+++ b/crates/octarine/src/primitives/crypto/encryption/persistent/storage/operations.rs
@@ -52,7 +52,7 @@ impl SecureStorage {
             .map_err(|e| CryptoError::encryption(format!("ChaCha cipher init failed: {e}")))?;
 
         let chacha_ciphertext = chacha_cipher
-            .encrypt(ChachaNonce::from_slice(&chacha_nonce), data)
+            .encrypt(&ChachaNonce::from(chacha_nonce), data)
             .map_err(|e| CryptoError::encryption(format!("ChaCha encryption failed: {e}")))?;
 
         // Step 5: Second layer - AES-256-GCM
@@ -60,10 +60,7 @@ impl SecureStorage {
             .map_err(|e| CryptoError::encryption(format!("AES cipher init failed: {e}")))?;
 
         let aes_ciphertext = aes_cipher
-            .encrypt(
-                AesNonce::from_slice(&aes_nonce),
-                chacha_ciphertext.as_slice(),
-            )
+            .encrypt(&AesNonce::from(aes_nonce), chacha_ciphertext.as_slice())
             .map_err(|e| CryptoError::encryption(format!("AES encryption failed: {e}")))?;
 
         // Step 6: Encrypt shared secret with platform key for storage
@@ -74,10 +71,7 @@ impl SecureStorage {
             .map_err(|e| CryptoError::encryption(format!("Platform cipher init failed: {e}")))?;
 
         let encrypted_shared_secret = platform_cipher
-            .encrypt(
-                ChachaNonce::from_slice(&platform_nonce),
-                shared_secret.as_ref(),
-            )
+            .encrypt(&ChachaNonce::from(platform_nonce), shared_secret.as_ref())
             .map_err(|e| CryptoError::encryption(format!("Platform key encryption failed: {e}")))?;
 
         // Zeroize sensitive material
@@ -133,7 +127,7 @@ impl SecureStorage {
 
         let shared_secret_bytes = platform_cipher
             .decrypt(
-                ChachaNonce::from_slice(&encrypted.platform_nonce),
+                &ChachaNonce::from(encrypted.platform_nonce),
                 encrypted.encrypted_shared_secret.as_slice(),
             )
             .map_err(|e| CryptoError::decryption(format!("Platform key decryption failed: {e}")))?;
@@ -147,7 +141,7 @@ impl SecureStorage {
 
         let chacha_ciphertext = aes_cipher
             .decrypt(
-                AesNonce::from_slice(&encrypted.aes_nonce),
+                &AesNonce::from(encrypted.aes_nonce),
                 encrypted.aes_ciphertext.as_slice(),
             )
             .map_err(|e| CryptoError::decryption(format!("AES decryption failed: {e}")))?;
@@ -158,7 +152,7 @@ impl SecureStorage {
 
         let plaintext = chacha_cipher
             .decrypt(
-                ChachaNonce::from_slice(&encrypted.chacha_nonce),
+                &ChachaNonce::from(encrypted.chacha_nonce),
                 chacha_ciphertext.as_slice(),
             )
             .map_err(|e| CryptoError::decryption(format!("ChaCha decryption failed: {e}")))?;

--- a/crates/octarine/src/primitives/crypto/secrets/buffer.rs
+++ b/crates/octarine/src/primitives/crypto/secrets/buffer.rs
@@ -166,9 +166,9 @@ impl PrimitiveSecureBuffer {
         let cipher = ChaCha20Poly1305::new_from_slice(&key)
             .map_err(|e| CryptoError::invalid_key(format!("Failed to create cipher: {e}")))?;
 
-        let nonce_ref = Nonce::from_slice(&nonce);
+        let nonce_ref = Nonce::from(nonce);
         let ciphertext = cipher
-            .encrypt(nonce_ref, data.as_slice())
+            .encrypt(&nonce_ref, data.as_slice())
             .map_err(|e| CryptoError::encryption(format!("Encryption failed: {e}")))?;
 
         // Zeroize the original plaintext
@@ -339,10 +339,10 @@ impl PrimitiveSecureBuffer {
         let cipher = ChaCha20Poly1305::new_from_slice(&self.key)
             .map_err(|e| CryptoError::invalid_key(format!("Failed to create cipher: {e}")))?;
 
-        let nonce = Nonce::from_slice(&self.nonce);
+        let nonce = Nonce::from(self.nonce);
 
         cipher
-            .decrypt(nonce, self.ciphertext.as_slice())
+            .decrypt(&nonce, self.ciphertext.as_slice())
             .map_err(|e| CryptoError::decryption(format!("Decryption failed: {e}")))
     }
 
@@ -357,10 +357,10 @@ impl PrimitiveSecureBuffer {
         let cipher = ChaCha20Poly1305::new_from_slice(&self.key)
             .map_err(|e| CryptoError::invalid_key(format!("Failed to create cipher: {e}")))?;
 
-        let nonce = Nonce::from_slice(&self.nonce);
+        let nonce = Nonce::from(self.nonce);
 
         self.ciphertext = cipher
-            .encrypt(nonce, plaintext.as_slice())
+            .encrypt(&nonce, plaintext.as_slice())
             .map_err(|e| CryptoError::encryption(format!("Encryption failed: {e}")))?;
 
         self.plaintext_len = plaintext.len();


### PR DESCRIPTION
## Summary

Unblocks CI across all open PRs by resolving newly-published dependency advisories. These two commits already existed locally but had never been pushed or PR'd; extracting them here so `main` gets the fix through review.

- **`quick-xml` → 0.41** — bumps the direct pin `0.40 → 0.41` so it unifies with the transitive copy pulled in via `phonenumber 0.3.10`. Eliminates the vulnerable `quick-xml 0.38.4`/`0.40.1` from the tree, closing **RUSTSEC-2026-0194** (quadratic duplicate-attribute check) and **RUSTSEC-2026-0195** (unbounded namespace-declaration allocation / memory-exhaustion DoS). Also folds in compatible `cargo update` bumps (console, indicatif, …).
- **AEAD crates → 0.11 (aead 0.6)** — migrates `aes-gcm 0.10 → 0.11` and `chacha20poly1305 0.10 → 0.11` and adapts the crypto primitives (`ephemeral`, `hybrid`, `keyed`, `persistent`, `secrets/buffer`) to the `aead 0.6` API. Supersedes Dependabot PRs #650 (aes-gcm) and #651 (chacha20poly1305), which bump the same crates individually.

## Why now

`origin/main`'s last green audit predates the `quick-xml` advisory publication; the RustSec DB is fetched fresh each CI run, so every open PR (including #653) now fails **Cargo Audit / Cargo Deny / OSV Scanner** on `quick-xml`. This PR is the coordinated fix.

## Test plan

- `cargo audit` — no `quick-xml` advisories remain; only the two pre-existing, `deny.toml`-ignored advisories (RUSTSEC-2023-0071 rsa, RUSTSEC-2023-0089 atomic-polyfill) show.
- `just clippy` (all features) clean — confirms the AEAD 0.6 source migration compiles.
- Full CI (Test, cross-platform Check, Coverage, SemVer, security scanners) via this PR.

## Follow-up

- Close Dependabot #650 and #651 as superseded once this merges.
- Rebase #653 (InstanceCounter operators) onto this so its CI goes green.