### PR TITLE
test(primitives): cover x509, crypto detection, paths, random, compliance (#659)

### DIFF
--- a/crates/octarine/src/data/paths/builder/filename.rs
+++ b/crates/octarine/src/data/paths/builder/filename.rs
@@ -619,4 +619,234 @@ mod tests {
         assert_eq!(fb.from_parts("doc", "pdf"), "doc.pdf");
         assert_eq!(fb.with_number("file.txt", 1), "file_1.txt");
     }
+
+    // ========================================================================
+    // Detection: accessor + classification wrappers.
+    // ========================================================================
+
+    #[test]
+    fn test_detection_accessors() {
+        let fb = FilenameBuilder::silent();
+
+        // Extension accessors.
+        assert_eq!(fb.find_extension("archive.tar.gz"), Some("gz"));
+        assert_eq!(fb.find_extension("noext"), None);
+        assert_eq!(fb.stem("report.pdf"), "report");
+        assert!(fb.is_extension_present("a.txt"));
+        assert!(!fb.is_extension_present("a"));
+
+        // Extension matching.
+        assert!(fb.is_extension_found("photo.JPG", "jpg")); // case-insensitive
+        assert!(fb.is_extension_in_list("main.rs", &["rs", "toml"]));
+        assert!(!fb.is_extension_in_list("main.py", &["rs", "toml"]));
+
+        // Classification.
+        assert!(fb.is_dot_file(".bashrc"));
+        assert!(!fb.is_dot_file("file.txt"));
+        assert!(fb.is_directory_ref(".."));
+        assert!(fb.is_directory_ref("."));
+        assert!(!fb.is_directory_ref("dir"));
+    }
+
+    #[test]
+    fn test_detection_threat_predicates() {
+        let fb = FilenameBuilder::silent();
+
+        assert!(fb.is_null_bytes_present("a\0b"));
+        assert!(!fb.is_null_bytes_present("ab"));
+        assert!(fb.is_control_characters_present("a\nb"));
+        assert!(fb.is_shell_chars_present("a;b"));
+        assert!(fb.is_command_substitution_present("$(id)"));
+        // is_variable_expansion_present matches the $VAR form ($ followed by a
+        // letter/underscore); the ${VAR} brace form is not this function's job.
+        assert!(fb.is_variable_expansion_present("back$HOME.txt"));
+        assert!(!fb.is_variable_expansion_present("plain.txt"));
+        assert!(fb.is_injection_present("file`whoami`.txt"));
+        assert!(fb.is_dangerous_extension_present("evil.exe"));
+        assert!(!fb.is_dangerous_extension_present("doc.pdf"));
+        assert!(fb.is_non_ascii_present("café.txt"));
+        assert!(!fb.is_non_ascii_present("cafe.txt"));
+    }
+
+    // ========================================================================
+    // Validation wrappers (strict-by-default per Issue #182).
+    // ========================================================================
+
+    #[test]
+    fn test_validation_wrappers() {
+        let fb = FilenameBuilder::new();
+
+        // Cross-platform: reserved names / trailing dots are rejected.
+        assert!(fb.is_cross_platform_safe("document.txt"));
+        assert!(fb.validate_cross_platform("document.txt").is_ok());
+        assert!(!fb.is_cross_platform_safe("CON"));
+        assert!(fb.validate_cross_platform("CON").is_err());
+
+        // Shell safety.
+        assert!(fb.is_shell_safe("plain.txt"));
+        assert!(!fb.is_shell_safe("a;rm -rf b"));
+        assert!(fb.validate_shell_safe("plain.txt").is_ok());
+        assert!(fb.validate_shell_safe("a;b").is_err());
+
+        // Upload safety + validation.
+        assert!(fb.validate_upload_safe("photo.png").is_ok());
+        assert!(fb.validate_upload_safe("shell.exe").is_err());
+
+        // Extension allow-list.
+        assert!(fb.is_extension_allowed("image.png", &["png", "jpg"]));
+        assert!(!fb.is_extension_allowed("image.gif", &["png", "jpg"]));
+        assert!(
+            fb.validate_allowed_extension("image.png", &["png", "jpg"])
+                .is_ok()
+        );
+        assert!(
+            fb.validate_allowed_extension("image.gif", &["png", "jpg"])
+                .is_err()
+        );
+
+        // Extension safety.
+        assert!(fb.is_extension_safe("notes.txt"));
+        assert!(!fb.is_extension_safe("payload.bat"));
+    }
+
+    #[test]
+    fn test_length_validation() {
+        let fb = FilenameBuilder::new();
+        assert!(fb.is_within_length("short.txt", 255));
+        assert!(!fb.is_within_length("aaaa.txt", 4));
+        assert!(fb.validate_within_length("short.txt", 255).is_ok());
+        assert!(fb.validate_within_length("toolong.txt", 3).is_err());
+    }
+
+    #[test]
+    fn test_validate_safe_and_generic_validate() {
+        let fb = FilenameBuilder::new();
+        assert!(fb.validate_safe("file.txt").is_ok());
+        assert!(fb.validate_safe("CON").is_err());
+    }
+
+    // ========================================================================
+    // Sanitization: strip / replace / normalize / to_safe wrappers.
+    // ========================================================================
+
+    #[test]
+    fn test_strip_wrappers() {
+        let fb = FilenameBuilder::silent();
+
+        assert_eq!(fb.strip_null_bytes("a\0b.txt"), "ab.txt");
+        assert_eq!(fb.strip_control_chars("a\nb.txt"), "ab.txt");
+        // Path separators removed (Cow may borrow or own).
+        assert!(!fb.strip_path_separators("a/b\\c.txt").contains('/'));
+        assert!(!fb.strip_path_separators("a/b\\c.txt").contains('\\'));
+        // Shell metacharacters removed.
+        let cleaned = fb.strip_shell_chars("a;b|c.txt");
+        assert!(!cleaned.contains(';'));
+        assert!(!cleaned.contains('|'));
+    }
+
+    #[test]
+    fn test_replace_and_normalize_wrappers() {
+        let fb = FilenameBuilder::silent();
+
+        assert_eq!(fb.replace_spaces("my file.txt"), "my_file.txt");
+        assert_eq!(fb.replace_spaces_with_hyphens("my file.txt"), "my-file.txt");
+        assert_eq!(fb.normalize_case("MyFile.TXT"), "myfile.txt");
+        // Only the extension is lowercased.
+        assert_eq!(fb.normalize_extension("Report.PDF"), "Report.pdf");
+    }
+
+    #[test]
+    fn test_sanitize_context_and_strict() {
+        let fb = FilenameBuilder::new();
+
+        // Strict sanitization REJECTS (errors) when threats are present, and
+        // passes a clean name through unchanged.
+        assert_eq!(fb.sanitize_strict("clean.txt").expect("clean"), "clean.txt");
+        assert!(
+            fb.sanitize_strict("../a;b.txt").is_err(),
+            "strict sanitize must reject threats, not strip them"
+        );
+
+        // Lenient sanitize DOES strip threats.
+        let lenient = fb.sanitize("../a;b.txt").expect("lenient");
+        assert!(!lenient.contains(".."));
+        assert!(!lenient.contains(';'));
+
+        // Context-driven sanitization for a secure file.
+        let secure = fb
+            .sanitize_with_context("weird name!.txt", SanitizationContext::SecureFile)
+            .expect("context");
+        assert!(!secure.is_empty());
+
+        // to_safe_filename fallback for empty/garbage input.
+        assert_eq!(fb.to_safe_filename(""), "unnamed");
+        assert_eq!(fb.to_safe_filename_or("", "fallback"), "fallback");
+    }
+
+    #[test]
+    fn test_shell_escape_wrappers() {
+        let fb = FilenameBuilder::new();
+        assert_eq!(fb.shell_escape("file.txt"), "'file.txt'");
+        // Strict shell escape errors on control chars / null bytes.
+        assert!(fb.shell_escape_strict("clean.txt").is_ok());
+        assert!(fb.shell_escape_strict("bad\0.txt").is_err());
+    }
+
+    // ========================================================================
+    // Construction: strict variants + stem / part manipulation.
+    // ========================================================================
+
+    #[test]
+    fn test_construction_strict_and_stem() {
+        let fb = FilenameBuilder::new();
+
+        assert_eq!(
+            fb.set_extension_strict("file.txt", "pdf").expect("strict"),
+            "file.pdf"
+        );
+        assert!(fb.set_extension_strict("file.txt", "e/x").is_err());
+
+        assert_eq!(fb.strip_all_extensions("a.tar.gz"), "a");
+        assert_eq!(fb.append_to_stem("file.txt", "_v2"), "file_v2.txt");
+        assert_eq!(fb.with_padded_number("f.txt", 7, 3), "f_007.txt");
+
+        assert_eq!(
+            fb.from_parts_strict("doc", "pdf").expect("parts"),
+            "doc.pdf"
+        );
+        assert_eq!(
+            fb.with_stem_strict("old.txt", "new").expect("stem"),
+            "new.txt"
+        );
+    }
+
+    #[test]
+    fn test_timestamp_and_uuid_construction() {
+        let fb = FilenameBuilder::new();
+
+        // Timestamp-based filename carries the prefix and extension.
+        let ts = fb.with_timestamp("backup", "tar");
+        assert!(ts.starts_with("backup"));
+        assert!(ts.ends_with(".tar"));
+
+        // UUID-based filenames are unique across calls and well-formed.
+        let a = fb.with_uuid("upload", "bin");
+        let b = fb.with_uuid("upload", "bin");
+        assert!(a.starts_with("upload"));
+        assert!(a.ends_with(".bin"));
+        assert_ne!(a, b, "UUID filenames must be unique");
+    }
+
+    #[test]
+    fn test_pattern_matching_and_detect_issues() {
+        let fb = FilenameBuilder::silent();
+        assert!(fb.is_pattern_found("report.txt", "*.txt"));
+        assert!(!fb.is_pattern_found("report.md", "*.txt"));
+
+        // detect_issues surfaces problems for a hostile filename.
+        let issues = fb.detect_issues("../$(id).txt");
+        assert!(!issues.is_empty());
+        // A clean filename yields no issues.
+        assert!(fb.detect_issues("clean.txt").is_empty());
+    }
 }

--- a/crates/octarine/src/data/paths/types.rs
+++ b/crates/octarine/src/data/paths/types.rs
@@ -787,4 +787,436 @@ mod tests {
         assert!(!invalid.is_valid);
         assert_eq!(invalid.errors.len(), 1);
     }
+
+    // ========================================================================
+    // Platform: Display + round-trip conversions to/from the primitive type.
+    // ========================================================================
+
+    #[test]
+    fn test_platform_display_all_variants() {
+        assert_eq!(Platform::Unix.to_string(), "Unix");
+        assert_eq!(Platform::Windows.to_string(), "Windows");
+        assert_eq!(Platform::Auto.to_string(), "Auto");
+    }
+
+    #[test]
+    fn test_platform_roundtrip_conversion() {
+        use crate::primitives::data::paths::Platform as P;
+        for (public, prim) in [
+            (Platform::Unix, P::Unix),
+            (Platform::Windows, P::Windows),
+            (Platform::Auto, P::Auto),
+        ] {
+            // public -> primitive -> public is the identity.
+            let back: Platform = P::from(public).into();
+            assert_eq!(back, public);
+            // primitive -> public matches the paired variant.
+            assert_eq!(Platform::from(prim), public);
+        }
+    }
+
+    // ========================================================================
+    // PathType: classification predicates + platform mapping (spec-derived).
+    // ========================================================================
+
+    #[test]
+    fn test_path_type_classification_table() {
+        // (variant, is_absolute, is_relative, is_unix, is_windows, platform)
+        let cases = [
+            (
+                PathType::UnixAbsolute,
+                true,
+                false,
+                true,
+                false,
+                Platform::Unix,
+            ),
+            (
+                PathType::UnixRelative,
+                false,
+                true,
+                true,
+                false,
+                Platform::Unix,
+            ),
+            (
+                PathType::WindowsAbsolute,
+                true,
+                false,
+                false,
+                true,
+                Platform::Windows,
+            ),
+            (
+                PathType::WindowsUnc,
+                true,
+                false,
+                false,
+                true,
+                Platform::Windows,
+            ),
+            (
+                PathType::WindowsRelative,
+                false,
+                true,
+                false,
+                true,
+                Platform::Windows,
+            ),
+            (
+                PathType::Unknown,
+                false,
+                false,
+                false,
+                false,
+                Platform::Auto,
+            ),
+        ];
+        for (pt, abs, rel, unix, win, plat) in cases {
+            assert_eq!(pt.is_absolute(), abs, "{pt} is_absolute");
+            assert_eq!(pt.is_relative(), rel, "{pt} is_relative");
+            assert_eq!(pt.is_unix(), unix, "{pt} is_unix");
+            assert_eq!(pt.is_windows(), win, "{pt} is_windows");
+            assert_eq!(pt.platform(), plat, "{pt} platform");
+        }
+    }
+
+    #[test]
+    fn test_path_type_display_and_default() {
+        assert_eq!(PathType::default(), PathType::Unknown);
+        assert_eq!(PathType::UnixAbsolute.to_string(), "Unix Absolute");
+        assert_eq!(PathType::WindowsUnc.to_string(), "Windows UNC");
+        assert_eq!(PathType::Unknown.to_string(), "Unknown");
+    }
+
+    #[test]
+    fn test_path_type_from_primitive_all_variants() {
+        use crate::primitives::data::paths::PathType as P;
+        let cases = [
+            (P::UnixAbsolute, PathType::UnixAbsolute),
+            (P::UnixRelative, PathType::UnixRelative),
+            (P::WindowsAbsolute, PathType::WindowsAbsolute),
+            (P::WindowsUnc, PathType::WindowsUnc),
+            (P::WindowsRelative, PathType::WindowsRelative),
+            (P::Unknown, PathType::Unknown),
+        ];
+        for (prim, expected) in cases {
+            assert_eq!(PathType::from(prim), expected);
+        }
+    }
+
+    // ========================================================================
+    // FileCategory: predicate groupings + Display + conversion.
+    // ========================================================================
+
+    #[test]
+    fn test_file_category_predicate_groups() {
+        // Sensitive == credential/certificate/key only.
+        for c in [
+            FileCategory::Credential,
+            FileCategory::Certificate,
+            FileCategory::Key,
+        ] {
+            assert!(c.is_sensitive(), "{c} should be sensitive");
+        }
+        assert!(!FileCategory::Text.is_sensitive());
+
+        // Executable grouping.
+        for c in [
+            FileCategory::Executable,
+            FileCategory::Script,
+            FileCategory::Library,
+        ] {
+            assert!(c.is_executable(), "{c} should be executable");
+        }
+        assert!(!FileCategory::Image.is_executable());
+
+        // Text-based grouping (note: Script is both executable and text-based).
+        for c in [
+            FileCategory::Text,
+            FileCategory::SourceCode,
+            FileCategory::Script,
+            FileCategory::Config,
+            FileCategory::Data,
+        ] {
+            assert!(c.is_text_based(), "{c} should be text-based");
+        }
+        assert!(!FileCategory::Executable.is_text_based());
+
+        // Media grouping.
+        for c in [
+            FileCategory::Image,
+            FileCategory::Audio,
+            FileCategory::Video,
+        ] {
+            assert!(c.is_media(), "{c} should be media");
+        }
+        assert!(!FileCategory::Document.is_media());
+    }
+
+    #[test]
+    fn test_file_category_display_and_default() {
+        assert_eq!(FileCategory::default(), FileCategory::Unknown);
+        assert_eq!(FileCategory::SourceCode.to_string(), "Source Code");
+        assert_eq!(FileCategory::Credential.to_string(), "Credential");
+    }
+
+    #[test]
+    fn test_file_category_from_primitive_roundtrips_all() {
+        use crate::primitives::data::paths::FileCategory as P;
+        // Every primitive variant maps to the matching public variant. We
+        // check a representative spread across all groups.
+        let cases = [
+            (P::Text, FileCategory::Text),
+            (P::Document, FileCategory::Document),
+            (P::Spreadsheet, FileCategory::Spreadsheet),
+            (P::Presentation, FileCategory::Presentation),
+            (P::SourceCode, FileCategory::SourceCode),
+            (P::Script, FileCategory::Script),
+            (P::Config, FileCategory::Config),
+            (P::Data, FileCategory::Data),
+            (P::Image, FileCategory::Image),
+            (P::Audio, FileCategory::Audio),
+            (P::Video, FileCategory::Video),
+            (P::Archive, FileCategory::Archive),
+            (P::Compressed, FileCategory::Compressed),
+            (P::Executable, FileCategory::Executable),
+            (P::Library, FileCategory::Library),
+            (P::System, FileCategory::System),
+            (P::Hidden, FileCategory::Hidden),
+            (P::Temporary, FileCategory::Temporary),
+            (P::Credential, FileCategory::Credential),
+            (P::Certificate, FileCategory::Certificate),
+            (P::Key, FileCategory::Key),
+            (P::Unknown, FileCategory::Unknown),
+        ];
+        for (prim, expected) in cases {
+            assert_eq!(FileCategory::from(prim), expected);
+        }
+    }
+
+    // ========================================================================
+    // PathDetectionResult: severity aggregation + primitive conversion.
+    // ========================================================================
+
+    #[test]
+    fn test_detection_result_threat_aggregation() {
+        let result = PathDetectionResult {
+            threats: vec![
+                ThreatAnnotation {
+                    cwe: "CWE-22",
+                    severity: 4,
+                    description: "traversal",
+                },
+                ThreatAnnotation {
+                    cwe: "CWE-78",
+                    severity: 5,
+                    description: "cmd injection",
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(!result.is_safe());
+        assert!(result.is_threat_detected());
+        assert_eq!(result.threat_count(), 2);
+        assert_eq!(result.max_severity(), Some(5));
+    }
+
+    #[test]
+    fn test_detection_result_from_primitive() {
+        use crate::primitives::data::paths as prim;
+        let prim_result = prim::PathDetectionResult {
+            path_type: prim::PathType::UnixAbsolute,
+            platform: prim::Platform::Unix,
+            file_category: Some(prim::FileCategory::SourceCode),
+            is_absolute: true,
+            is_hidden: false,
+            has_extension: true,
+            extension: Some("rs".to_string()),
+            threats: Vec::new(),
+        };
+        let public: PathDetectionResult = prim_result.into();
+        assert_eq!(public.path_type, PathType::UnixAbsolute);
+        assert_eq!(public.platform, Platform::Unix);
+        assert_eq!(public.file_category, Some(FileCategory::SourceCode));
+        assert!(public.is_absolute);
+        assert_eq!(public.extension.as_deref(), Some("rs"));
+        assert!(public.is_safe());
+    }
+
+    // ========================================================================
+    // ThreatAnnotation: Display + From<SecurityThreat>.
+    // ========================================================================
+
+    #[test]
+    fn test_threat_annotation_from_security_threat() {
+        // Use a real primitive SecurityThreat so cwe/severity/description come
+        // from the security concern, not hand-copied constants.
+        use crate::primitives::data::paths::SecurityThreat;
+        let ann: ThreatAnnotation = SecurityThreat::Traversal.into();
+        assert_eq!(ann.cwe, SecurityThreat::Traversal.cwe());
+        assert_eq!(ann.severity, SecurityThreat::Traversal.severity());
+        assert_eq!(ann.description, SecurityThreat::Traversal.description());
+        // Display renders "<description> (<cwe>)".
+        let shown = ann.to_string();
+        assert!(shown.contains(ann.cwe));
+        assert!(shown.contains(ann.description));
+    }
+
+    // ========================================================================
+    // PathValidationResult: warnings + primitive conversion.
+    // ========================================================================
+
+    #[test]
+    fn test_validation_result_warnings_and_conversion() {
+        let mut r = PathValidationResult::valid();
+        assert!(!r.is_warning_present());
+        r.warnings.push("suspicious but allowed".to_string());
+        assert!(r.is_warning_present());
+
+        use crate::primitives::data::paths::PathValidationResult as P;
+        let prim = P {
+            is_valid: false,
+            errors: vec!["bad".to_string()],
+            warnings: vec!["warn".to_string()],
+        };
+        let public: PathValidationResult = prim.into();
+        assert!(!public.is_valid);
+        assert_eq!(public.errors, vec!["bad".to_string()]);
+        assert_eq!(public.warnings, vec!["warn".to_string()]);
+    }
+
+    // ========================================================================
+    // BoundaryStrategy / FilenameSanitizationStrategy.
+    // ========================================================================
+
+    #[test]
+    fn test_boundary_strategy_conversion_and_default() {
+        use crate::primitives::data::paths::BoundaryStrategy as P;
+        assert_eq!(BoundaryStrategy::default(), BoundaryStrategy::Reject);
+        for (public, prim) in [
+            (BoundaryStrategy::Reject, P::Reject),
+            (BoundaryStrategy::Constrain, P::Constrain),
+            (BoundaryStrategy::Resolve, P::Resolve),
+        ] {
+            assert_eq!(P::from(public), prim);
+        }
+    }
+
+    #[test]
+    fn test_filename_sanitization_strategy_replacement_char() {
+        assert_eq!(
+            FilenameSanitizationStrategy::default(),
+            FilenameSanitizationStrategy::ReplaceWithUnderscore
+        );
+        assert_eq!(
+            FilenameSanitizationStrategy::ReplaceWithUnderscore.replacement(),
+            Some('_')
+        );
+        assert_eq!(
+            FilenameSanitizationStrategy::ReplaceWithDash.replacement(),
+            Some('-')
+        );
+        // Remove and Reject have no replacement character.
+        assert_eq!(FilenameSanitizationStrategy::Remove.replacement(), None);
+        assert_eq!(FilenameSanitizationStrategy::Reject.replacement(), None);
+    }
+
+    // ========================================================================
+    // PathFormat + SeparatorStyle: predicates, Display, conversions.
+    // ========================================================================
+
+    #[test]
+    fn test_path_format_predicates_and_default() {
+        assert_eq!(PathFormat::default(), PathFormat::Portable);
+        // Unix-like set.
+        for f in [PathFormat::Unix, PathFormat::Wsl, PathFormat::Portable] {
+            assert!(f.is_unix_like(), "{f} unix-like");
+            assert!(!f.is_windows_like(), "{f} not windows-like");
+        }
+        // Windows-like set.
+        for f in [PathFormat::Windows, PathFormat::PowerShell] {
+            assert!(f.is_windows_like(), "{f} windows-like");
+            assert!(!f.is_unix_like(), "{f} not unix-like");
+        }
+    }
+
+    #[test]
+    fn test_path_format_display_and_roundtrip() {
+        use crate::primitives::data::paths::PathFormat as P;
+        let cases = [
+            (PathFormat::Unix, P::Unix, "Unix"),
+            (PathFormat::Windows, P::Windows, "Windows"),
+            (PathFormat::PowerShell, P::PowerShell, "PowerShell"),
+            (PathFormat::Wsl, P::Wsl, "WSL"),
+            (PathFormat::Portable, P::Portable, "Portable"),
+        ];
+        for (public, prim, disp) in cases {
+            assert_eq!(public.to_string(), disp);
+            assert_eq!(PathFormat::from(prim), public);
+            assert_eq!(P::from(public), prim);
+        }
+    }
+
+    #[test]
+    fn test_separator_style_predicates_display_conversion() {
+        use crate::primitives::data::paths::SeparatorStyle as P;
+        assert_eq!(SeparatorStyle::default(), SeparatorStyle::None);
+
+        // (variant, separators_present, consistent, display)
+        let cases = [
+            (SeparatorStyle::Forward, true, true, "Forward", P::Forward),
+            (SeparatorStyle::Back, true, true, "Back", P::Back),
+            (SeparatorStyle::Mixed, true, false, "Mixed", P::Mixed),
+            (SeparatorStyle::None, false, true, "None", P::None),
+        ];
+        for (style, present, consistent, disp, prim) in cases {
+            assert_eq!(style.is_separators_present(), present, "{style} present");
+            assert_eq!(style.is_consistent(), consistent, "{style} consistent");
+            assert_eq!(style.to_string(), disp);
+            assert_eq!(SeparatorStyle::from(prim), style);
+        }
+    }
+
+    // ========================================================================
+    // SanitizationContext: Display + bidirectional conversion.
+    // ========================================================================
+
+    #[test]
+    fn test_sanitization_context_display_and_roundtrip() {
+        use crate::primitives::data::paths::SanitizationContext as P;
+        assert_eq!(
+            SanitizationContext::default(),
+            SanitizationContext::UserFile
+        );
+        let cases = [
+            (SanitizationContext::UserFile, P::UserFile, "User File"),
+            (
+                SanitizationContext::SystemFile,
+                P::SystemFile,
+                "System File",
+            ),
+            (
+                SanitizationContext::SecureFile,
+                P::SecureFile,
+                "Secure File",
+            ),
+            (
+                SanitizationContext::ConfigFile,
+                P::ConfigFile,
+                "Config File",
+            ),
+            (
+                SanitizationContext::UploadFile,
+                P::UploadFile,
+                "Upload File",
+            ),
+        ];
+        for (public, prim, disp) in cases {
+            assert_eq!(public.to_string(), disp);
+            // Round-trip both directions.
+            assert_eq!(P::from(public), prim);
+            assert_eq!(SanitizationContext::from(prim), public);
+        }
+    }
 }

--- a/crates/octarine/src/io/formats/builder.rs
+++ b/crates/octarine/src/io/formats/builder.rs
@@ -194,4 +194,174 @@ mod tests {
             Some(FormatType::Xml)
         ));
     }
+
+    #[test]
+    fn test_builder_read_write_xml_roundtrip() {
+        let builder = FormatIoBuilder::new();
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join("doc.xml");
+        let content = "<root><child/></root>";
+
+        builder.write_xml_file(&path, content).expect("write xml");
+        let result = builder.read_xml_file(&path).expect("read xml");
+        assert!(matches!(result.format, FormatType::Xml));
+        // Content round-trips byte-for-byte.
+        assert_eq!(result.content, content);
+    }
+
+    #[test]
+    fn test_builder_read_write_yaml_roundtrip() {
+        let builder = FormatIoBuilder::new();
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join("cfg.yaml");
+        let content = "key: value";
+
+        builder.write_yaml_file(&path, content).expect("write yaml");
+        let result = builder.read_yaml_file(&path).expect("read yaml");
+        assert!(matches!(result.format, FormatType::Yaml));
+        assert_eq!(result.content, content);
+    }
+
+    #[test]
+    fn test_write_file_dispatches_on_format() {
+        let builder = FormatIoBuilder::new();
+        let dir = tempdir().expect("temp dir");
+
+        // write_file with an explicit format, then auto-detected read back.
+        let path = dir.path().join("auto.yaml");
+        builder
+            .write_file(&path, "a: 1", FormatType::Yaml)
+            .expect("write");
+        let result = builder.read_file(&path).expect("read");
+        assert!(matches!(result.format, FormatType::Yaml));
+    }
+
+    #[test]
+    fn test_read_file_auto_detects_by_extension() {
+        let builder = FormatIoBuilder::new();
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join("data.json");
+        builder.write_json_file(&path, r#"{"a":1}"#).expect("write");
+        let result = builder.read_file(&path).expect("read");
+        assert!(matches!(result.format, FormatType::Json));
+    }
+
+    #[test]
+    fn test_read_missing_file_is_err() {
+        // The Layer 3 wrapper must surface the primitive read error (and it
+        // logs a warning on the failure path).
+        let builder = FormatIoBuilder::new();
+        let result = builder.read_file(Path::new("/nonexistent/definitely/missing.json"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_json_file_missing_is_err() {
+        let builder = FormatIoBuilder::new();
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join("nope.json");
+        assert!(builder.read_json_file(&path).is_err());
+    }
+
+    #[test]
+    fn test_write_to_unwritable_path_is_err() {
+        // Writing into a directory that does not exist must error and trip the
+        // warn() branch in write_file.
+        let builder = FormatIoBuilder::new();
+        let path = Path::new("/nonexistent/dir/out.json");
+        let result = builder.write_file(path, r#"{"k":1}"#, FormatType::Json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_file_with_options() {
+        use crate::primitives::io::formats::FormatReadOptions;
+        let builder = FormatIoBuilder::new();
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join("data.json");
+        builder
+            .write_json_file(&path, r#"{"ok":true}"#)
+            .expect("write");
+
+        let opts = FormatReadOptions::json();
+        let result = builder
+            .read_file_with_options(&path, &opts)
+            .expect("read w/ options");
+        assert!(matches!(result.format, FormatType::Json));
+    }
+
+    #[test]
+    fn test_write_file_with_options() {
+        use crate::primitives::io::formats::FormatWriteOptions;
+        let builder = FormatIoBuilder::new();
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join("out.json");
+
+        let opts = FormatWriteOptions::json();
+        builder
+            .write_file_with_options(&path, r#"{"k":1}"#, &opts)
+            .expect("write w/ options");
+        assert!(path.exists());
+        let result = builder.read_json_file(&path).expect("read");
+        assert!(matches!(result.format, FormatType::Json));
+    }
+
+    #[test]
+    fn test_detect_format_from_path_variants() {
+        let builder = FormatIoBuilder::new();
+        assert!(matches!(
+            builder.detect_format_from_path(Path::new("a.yaml")),
+            Some(FormatType::Yaml)
+        ));
+        assert!(matches!(
+            builder.detect_format_from_path(Path::new("a.yml")),
+            Some(FormatType::Yaml)
+        ));
+        assert!(matches!(
+            builder.detect_format_from_path(Path::new("a.xml")),
+            Some(FormatType::Xml)
+        ));
+        // Unknown extension yields None.
+        assert!(
+            builder
+                .detect_format_from_path(Path::new("a.bin"))
+                .is_none()
+        );
+        // No extension yields None.
+        assert!(
+            builder
+                .detect_format_from_path(Path::new("noext"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_detect_format_from_content_variants() {
+        let builder = FormatIoBuilder::new();
+        // JSON object and array.
+        assert!(matches!(
+            builder.detect_format_from_content(r#"{"a":1}"#),
+            Some(FormatType::Json)
+        ));
+        assert!(matches!(
+            builder.detect_format_from_content("[1,2,3]"),
+            Some(FormatType::Json)
+        ));
+        // XML.
+        assert!(matches!(
+            builder.detect_format_from_content("<a/>"),
+            Some(FormatType::Xml)
+        ));
+        // YAML document marker and key: value form.
+        assert!(matches!(
+            builder.detect_format_from_content("---\nk: v"),
+            Some(FormatType::Yaml)
+        ));
+        assert!(matches!(
+            builder.detect_format_from_content("- item"),
+            Some(FormatType::Yaml)
+        ));
+        // Unrecognized content yields None.
+        assert!(builder.detect_format_from_content("plain text").is_none());
+    }
 }

--- a/crates/octarine/src/observe/builder/compliance.rs
+++ b/crates/octarine/src/observe/builder/compliance.rs
@@ -141,3 +141,124 @@ impl ObserveBuilder {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+    use crate::observe::compliance::{
+        GdprBasis, HipaaSafeguard, Iso27001Control, PciDssRequirement, Soc2Control,
+    };
+
+    fn base() -> ObserveBuilder {
+        ObserveBuilder::for_operation("test.op")
+    }
+
+    #[test]
+    fn test_soc2_single_and_multiple() {
+        // Single control is recorded.
+        let b = base().soc2_control(Soc2Control::CC6_1);
+        assert!(b.compliance_tags.soc2.contains(&Soc2Control::CC6_1));
+
+        // Multiple controls accumulate; duplicates are deduplicated by
+        // ComplianceTags::with_soc2.
+        let b = base().soc2_controls([Soc2Control::CC6_1, Soc2Control::CC8_1, Soc2Control::CC6_1]);
+        assert_eq!(b.compliance_tags.soc2.len(), 2);
+        assert!(b.compliance_tags.soc2.contains(&Soc2Control::CC8_1));
+    }
+
+    #[test]
+    fn test_hipaa_single_and_multiple() {
+        let b = base().hipaa_safeguard(HipaaSafeguard::Technical);
+        assert!(b.compliance_tags.hipaa.contains(&HipaaSafeguard::Technical));
+
+        let b = base().hipaa_safeguards([
+            HipaaSafeguard::Technical,
+            HipaaSafeguard::Administrative,
+            HipaaSafeguard::Technical,
+        ]);
+        assert_eq!(b.compliance_tags.hipaa.len(), 2);
+    }
+
+    #[test]
+    fn test_gdpr_basis_sets_option() {
+        let b = base().gdpr_basis(GdprBasis::Consent);
+        assert_eq!(b.compliance_tags.gdpr_basis, Some(GdprBasis::Consent));
+        // Setting again replaces the basis.
+        let b = b.gdpr_basis(GdprBasis::LegalObligation);
+        assert_eq!(
+            b.compliance_tags.gdpr_basis,
+            Some(GdprBasis::LegalObligation)
+        );
+    }
+
+    #[test]
+    fn test_pci_dss_single_and_multiple() {
+        let b = base().pci_dss_requirement(PciDssRequirement::Req3);
+        assert!(b.compliance_tags.pci_dss.contains(&PciDssRequirement::Req3));
+
+        let b = base().pci_dss_requirements([
+            PciDssRequirement::Req3,
+            PciDssRequirement::Req8,
+            PciDssRequirement::Req3,
+        ]);
+        assert_eq!(b.compliance_tags.pci_dss.len(), 2);
+    }
+
+    #[test]
+    fn test_iso27001_single_and_multiple() {
+        let b = base().iso27001_control(Iso27001Control::A8_5);
+        assert!(b.compliance_tags.iso27001.contains(&Iso27001Control::A8_5));
+
+        let b = base().iso27001_controls([
+            Iso27001Control::A8_5,
+            Iso27001Control::A8_15,
+            Iso27001Control::A8_5,
+        ]);
+        assert_eq!(b.compliance_tags.iso27001.len(), 2);
+    }
+
+    #[test]
+    fn test_compliance_evidence_flag() {
+        let b = base();
+        assert!(!b.compliance_tags.is_evidence);
+        let b = b.compliance_evidence();
+        assert!(b.compliance_tags.is_evidence);
+    }
+
+    #[test]
+    fn test_compliance_replaces_all_tags() {
+        // Start with some tags, then replace wholesale.
+        let b = base()
+            .soc2_control(Soc2Control::CC6_1)
+            .iso27001_control(Iso27001Control::A8_5);
+        assert!(!b.compliance_tags.is_empty());
+
+        let replacement = ComplianceTags::new().with_gdpr(GdprBasis::Consent);
+        let b = b.compliance(replacement);
+        // Prior SOC2/ISO tags are gone; only the GDPR basis remains.
+        assert!(b.compliance_tags.soc2.is_empty());
+        assert!(b.compliance_tags.iso27001.is_empty());
+        assert_eq!(b.compliance_tags.gdpr_basis, Some(GdprBasis::Consent));
+    }
+
+    #[test]
+    fn test_chained_builders_compose() {
+        // The fluent chain merges tags from every framework into one set.
+        let b = base()
+            .soc2_control(Soc2Control::CC6_1)
+            .hipaa_safeguard(HipaaSafeguard::Technical)
+            .gdpr_basis(GdprBasis::Consent)
+            .pci_dss_requirement(PciDssRequirement::Req8)
+            .iso27001_control(Iso27001Control::A8_15)
+            .compliance_evidence();
+        let tags = &b.compliance_tags;
+        assert_eq!(tags.soc2.len(), 1);
+        assert_eq!(tags.hipaa.len(), 1);
+        assert!(tags.gdpr_basis.is_some());
+        assert_eq!(tags.pci_dss.len(), 1);
+        assert_eq!(tags.iso27001.len(), 1);
+        assert!(tags.is_evidence);
+        assert!(!tags.is_empty());
+    }
+}

--- a/crates/octarine/src/observe/compliance/iso27001.rs
+++ b/crates/octarine/src/observe/compliance/iso27001.rs
@@ -326,4 +326,114 @@ mod tests {
         assert_eq!(Iso27001Control::A8_5.theme(), "Technological");
         assert_eq!(Iso27001Control::A8_26.theme(), "Technological");
     }
+
+    /// All Annex A controls represented in the enum. Used to drive exhaustive
+    /// table checks. If a variant is added, this list must be extended too
+    /// (the `theme()`/`as_str()` matches are already exhaustive at compile time).
+    const ALL: &[Iso27001Control] = &[
+        Iso27001Control::A5_1,
+        Iso27001Control::A5_2,
+        Iso27001Control::A5_3,
+        Iso27001Control::A5_7,
+        Iso27001Control::A5_15,
+        Iso27001Control::A5_16,
+        Iso27001Control::A5_17,
+        Iso27001Control::A5_18,
+        Iso27001Control::A5_22,
+        Iso27001Control::A5_24,
+        Iso27001Control::A5_25,
+        Iso27001Control::A5_26,
+        Iso27001Control::A5_28,
+        Iso27001Control::A5_33,
+        Iso27001Control::A5_34,
+        Iso27001Control::A6_1,
+        Iso27001Control::A6_3,
+        Iso27001Control::A7_4,
+        Iso27001Control::A8_2,
+        Iso27001Control::A8_3,
+        Iso27001Control::A8_4,
+        Iso27001Control::A8_5,
+        Iso27001Control::A8_7,
+        Iso27001Control::A8_8,
+        Iso27001Control::A8_9,
+        Iso27001Control::A8_10,
+        Iso27001Control::A8_11,
+        Iso27001Control::A8_12,
+        Iso27001Control::A8_15,
+        Iso27001Control::A8_16,
+        Iso27001Control::A8_17,
+        Iso27001Control::A8_20,
+        Iso27001Control::A8_24,
+        Iso27001Control::A8_25,
+        Iso27001Control::A8_28,
+    ];
+
+    #[test]
+    fn test_as_str_matches_dotted_control_id() {
+        // The ISO control identifier for `Ax_y` is the dotted form `A.x.y`.
+        // Derive the expectation mechanically from the variant name via its
+        // Debug representation rather than hand-copying every string.
+        for ctrl in ALL {
+            let debug = format!("{ctrl:?}"); // e.g. "A8_15"
+            let (theme_num, sub) = debug
+                .trim_start_matches('A')
+                .split_once('_')
+                .expect("variant name has form Ax_y");
+            let expected = format!("A.{theme_num}.{sub}");
+            assert_eq!(ctrl.as_str(), expected, "as_str for {debug}");
+            // Display delegates to as_str.
+            assert_eq!(ctrl.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn test_theme_matches_control_number_prefix() {
+        // 2022 reorganization: A.5 => Organizational, A.6 => People,
+        // A.7 => Physical, A.8 => Technological. Derive the family from the
+        // variant name so every variant is checked against the spec rule.
+        for ctrl in ALL {
+            let debug = format!("{ctrl:?}");
+            let family = debug
+                .trim_start_matches('A')
+                .split('_')
+                .next()
+                .expect("variant name has form Ax_y");
+            let expected = match family {
+                "5" => "Organizational",
+                "6" => "People",
+                "7" => "Physical",
+                "8" => "Technological",
+                other => panic!("unexpected control family A{other}"),
+            };
+            assert_eq!(ctrl.theme(), expected, "theme for {debug}");
+        }
+    }
+
+    #[test]
+    fn test_description_non_empty_and_unique() {
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        for ctrl in ALL {
+            let desc = ctrl.description();
+            assert!(!desc.is_empty(), "empty description for {ctrl:?}");
+            // Each control should have a distinct description.
+            assert!(
+                seen.insert(desc),
+                "duplicate description {desc:?} for {ctrl:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_serde_roundtrip_and_rename() {
+        // Serialized form uses the SCREAMING variant name (e.g. "A8_15"),
+        // NOT the dotted display form, and round-trips losslessly.
+        for ctrl in ALL {
+            let json = serde_json::to_string(ctrl).expect("serialize");
+            let debug = format!("{ctrl:?}");
+            assert_eq!(json, format!("\"{debug}\""), "serialized form for {debug}");
+            let back: Iso27001Control = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(&back, ctrl);
+        }
+    }
 }

--- a/crates/octarine/src/primitives/crypto/builder/random.rs
+++ b/crates/octarine/src/primitives/crypto/builder/random.rs
@@ -153,5 +153,250 @@ impl RandomBuilder {
     }
 }
 
-// Note: RandomBuilder tests are included in the main mod.rs integration tests
-// since they don't require specific builder test coverage beyond API verification.
+// ============================================================================
+// Tests
+// ============================================================================
+//
+// SECURITY-SENSITIVE: RandomBuilder is the public gateway to the OS CSPRNG.
+// These tests exercise the *contracts* callers rely on — correct output
+// length, correct alphabet, honoured bounds, and non-repetition across
+// successive calls — rather than pinning any specific random value.
+//
+// Uniqueness note: for k independent draws from a space of size N, the
+// probability that ALL are distinct is ~ 1 - C(k,2)/N. For the sizes used
+// here (>= 96 bits of entropy, k <= 64) the collision probability is far
+// below 1e-20, so a duplicate would signal a real entropy defect, not
+// flakiness.
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+    use std::collections::HashSet;
+
+    fn rb() -> RandomBuilder {
+        RandomBuilder::new()
+    }
+
+    // ------------------------------------------------------------------
+    // Fixed-size byte / key / nonce / IV / salt generators
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_fixed_length_contracts() {
+        let b = rb();
+        assert_eq!(b.bytes::<32>().expect("bytes").len(), 32);
+        assert_eq!(b.key_256().expect("key256").len(), 32);
+        assert_eq!(b.key_128().expect("key128").len(), 16);
+        assert_eq!(b.nonce_12().expect("nonce12").len(), 12);
+        assert_eq!(b.nonce_24().expect("nonce24").len(), 24);
+        assert_eq!(b.iv_16().expect("iv16").len(), 16);
+        assert_eq!(b.salt().expect("salt").len(), 16);
+    }
+
+    #[test]
+    fn test_bytes_vec_and_salt_sized_length() {
+        let b = rb();
+        assert_eq!(b.bytes_vec(48).expect("vec").len(), 48);
+        assert_eq!(b.salt_sized(24).expect("salt").len(), 24);
+        // Zero-length salt is rejected by the entropy contract.
+        assert!(b.salt_sized(0).is_err());
+    }
+
+    #[test]
+    fn test_fill_overwrites_buffer() {
+        let b = rb();
+        let mut buffer = [0u8; 32];
+        b.fill(&mut buffer).expect("fill");
+        // An all-zero 32-byte fill has probability 2^-256; treat non-zero as
+        // the entropy contract. (Not a value assertion — a liveness check.)
+        assert!(buffer.iter().any(|&x| x != 0), "fill produced all zeros");
+    }
+
+    // ------------------------------------------------------------------
+    // Uniqueness / entropy contract: successive calls must differ.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_key_256_successive_calls_differ() {
+        let b = rb();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        for _ in 0..64 {
+            let key = b.key_256().expect("key");
+            assert!(seen.insert(key), "duplicate 256-bit key => entropy defect");
+        }
+    }
+
+    #[test]
+    fn test_nonce_12_successive_calls_differ() {
+        let b = rb();
+        let mut seen: HashSet<[u8; 12]> = HashSet::new();
+        for _ in 0..64 {
+            let n = b.nonce_12().expect("nonce");
+            assert!(seen.insert(n), "duplicate 96-bit nonce => entropy defect");
+        }
+    }
+
+    #[test]
+    fn test_uuid_v4_unique_and_wellformed() {
+        let b = rb();
+        let mut seen = HashSet::new();
+        for _ in 0..64 {
+            let id = b.uuid_v4().expect("uuid");
+            // RFC 4122 shape: 8-4-4-4-12, version nibble '4', variant in 8/9/a/b.
+            assert_eq!(id.len(), 36);
+            assert_eq!(
+                id.as_bytes().get(14).copied(),
+                Some(b'4'),
+                "version nibble must be 4"
+            );
+            let variant = id.as_bytes().get(19).copied().map(char::from);
+            assert!(
+                matches!(variant, Some('8' | '9' | 'a' | 'b')),
+                "variant nibble {variant:?} out of range"
+            );
+            assert!(seen.insert(id), "duplicate UUID => entropy defect");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Encoded string generators: length + alphabet contracts.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_hex_length_and_alphabet() {
+        let b = rb();
+        let hex = b.hex(16).expect("hex");
+        // 16 bytes -> 32 hex chars, lowercase hex alphabet only.
+        assert_eq!(hex.len(), 32);
+        assert!(
+            hex.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+        // Distinct successive outputs.
+        assert_ne!(hex, b.hex(16).expect("hex2"));
+    }
+
+    #[test]
+    fn test_base64_standard_length() {
+        let b = rb();
+        // 24 bytes -> 32 standard-base64 chars (no padding needed, 24 % 3 == 0).
+        let s = b.base64(24).expect("b64");
+        assert_eq!(s.len(), 32);
+    }
+
+    #[test]
+    fn test_base64_url_is_url_safe() {
+        let b = rb();
+        let s = b.base64_url(32).expect("b64url");
+        // URL-safe, no-pad alphabet: no '+', '/', or '=' characters.
+        assert!(!s.contains('+'));
+        assert!(!s.contains('/'));
+        assert!(!s.contains('='));
+        assert!(!s.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // Integer generators: bounds and rejection-sampling contracts.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_u32_u64_produce_variation() {
+        let b = rb();
+        // Over many draws we expect more than one distinct value (a constant
+        // generator would be a severe defect).
+        let a: HashSet<u32> = (0..32).map(|_| b.u32().expect("u32")).collect();
+        assert!(a.len() > 1, "u32 generator appears constant");
+        let c: HashSet<u64> = (0..32).map(|_| b.u64().expect("u64")).collect();
+        assert!(c.len() > 1, "u64 generator appears constant");
+    }
+
+    #[test]
+    fn test_u32_bounded_respects_exclusive_upper() {
+        let b = rb();
+        for _ in 0..500 {
+            let v = b.u32_bounded(10).expect("bounded");
+            assert!(v < 10, "value {v} not in [0,10)");
+        }
+        // bound of 1 always yields 0; bound of 0 is an error.
+        assert_eq!(b.u32_bounded(1).expect("one"), 0);
+        assert!(b.u32_bounded(0).is_err());
+    }
+
+    #[test]
+    fn test_u64_bounded_respects_exclusive_upper() {
+        let b = rb();
+        for _ in 0..500 {
+            let v = b.u64_bounded(1000).expect("bounded");
+            assert!(v < 1000, "value {v} not in [0,1000)");
+        }
+        assert!(b.u64_bounded(0).is_err());
+    }
+
+    #[test]
+    fn test_u32_range_inclusive_bounds() {
+        let b = rb();
+        for _ in 0..500 {
+            let v = b.u32_range(10, 20).expect("range");
+            assert!((10..=20).contains(&v), "value {v} not in [10,20]");
+        }
+        // Degenerate single-value range.
+        assert_eq!(b.u32_range(7, 7).expect("single"), 7);
+        // Inverted range is rejected.
+        assert!(b.u32_range(20, 10).is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // Selection helpers: shuffle / choice / sample.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_shuffle_is_permutation() {
+        let b = rb();
+        let mut data: Vec<i32> = (0..64).collect();
+        let original = data.clone();
+        b.shuffle(&mut data).expect("shuffle");
+        // Same multiset of elements...
+        let mut sorted = data.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, original);
+        // ...and (with overwhelming probability) a different order.
+        assert_ne!(data, original, "shuffle left order unchanged");
+    }
+
+    #[test]
+    fn test_choice_returns_member() {
+        let b = rb();
+        let items = [10, 20, 30, 40, 50];
+        for _ in 0..100 {
+            let pick = b.choice(&items).expect("choice");
+            assert!(items.contains(pick));
+        }
+        // Empty slice is an error.
+        let empty: [i32; 0] = [];
+        assert!(b.choice(&empty).is_err());
+    }
+
+    #[test]
+    fn test_sample_without_replacement() {
+        let b = rb();
+        let items: Vec<i32> = (1..=20).collect();
+        let picked = b.sample(&items, 5).expect("sample");
+        assert_eq!(picked.len(), 5);
+        // No repeats, all drawn from the source.
+        let unique: HashSet<_> = picked.iter().collect();
+        assert_eq!(unique.len(), 5, "sample drew a duplicate");
+        assert!(picked.iter().all(|x| items.contains(x)));
+        // Oversized sample is rejected; zero sample is empty.
+        assert!(b.sample(&items, 21).is_err());
+        assert!(b.sample(&items, 0).expect("zero").is_empty());
+    }
+
+    #[test]
+    fn test_default_and_clone_construct() {
+        // Default + Clone impls are part of the public surface.
+        let b = RandomBuilder::default();
+        let _c = b.clone();
+        assert_eq!(b.key_128().expect("k").len(), 16);
+    }
+}

--- a/crates/octarine/src/primitives/data/crypto/x509.rs
+++ b/crates/octarine/src/primitives/data/crypto/x509.rs
@@ -211,16 +211,27 @@ fn detect_public_key_type(cert: &x509_parser::certificate::X509Certificate<'_>) 
             }
         }
         Ok(PublicKey::EC(_)) => {
-            // Try to determine curve from OID
-            let oid = cert.public_key().algorithm.algorithm.to_string();
-            if oid.contains("prime256v1") || oid.contains("secp256r1") {
-                KeyType::P256
-            } else if oid.contains("secp384r1") {
-                KeyType::P384
-            } else if oid.contains("secp521r1") {
-                KeyType::P521
-            } else {
-                KeyType::Unknown
+            // For EC keys the algorithm OID is always `id-ecPublicKey`
+            // (1.2.840.10045.2.1); the *named curve* is carried in the
+            // AlgorithmIdentifier parameters as its own OID. Match on the
+            // curve OID id-string (RFC 5480 / SEC 2):
+            //   - prime256v1/secp256r1 => 1.2.840.10045.3.1.7 (P-256)
+            //   - secp384r1            => 1.3.132.0.34         (P-384)
+            //   - secp521r1            => 1.3.132.0.35         (P-521)
+            let curve_oid = cert
+                .public_key()
+                .algorithm
+                .parameters
+                .as_ref()
+                .and_then(|params| params.as_oid().ok())
+                .map(|oid| oid.to_id_string())
+                .unwrap_or_default();
+
+            match curve_oid.as_str() {
+                "1.2.840.10045.3.1.7" => KeyType::P256,
+                "1.3.132.0.34" => KeyType::P384,
+                "1.3.132.0.35" => KeyType::P521,
+                _ => KeyType::Unknown,
             }
         }
         _ => KeyType::Unknown,
@@ -316,5 +327,177 @@ mod tests {
         let huge = "x".repeat(super::MAX_CERT_SIZE + 1);
         let result = super::validate_certificate_format_pem(&huge);
         assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // Feature-gated parsing tests (require `crypto-validation`)
+    //
+    // Test fixtures are real certificates generated with OpenSSL 3.x with
+    // KNOWN structure, so expected values are derived from the certificate
+    // spec / generation parameters, NOT from current parser output.
+    // ========================================================================
+
+    // Self-signed RSA-2048 / SHA-256 CA certificate.
+    //   Subject/Issuer: C=US, O=Octarine, CN=octarine.test
+    //   Validity: 2026-07-03 .. 2036-06-30 (10 years, CA:TRUE)
+    //   SAN: DNS:octarine.test, DNS:www.octarine.test, email:test@octarine.test
+    //   keyUsage: digitalSignature, keyCertSign
+    #[cfg(feature = "crypto-validation")]
+    const RSA_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----
+MIIDoTCCAomgAwIBAgIUIBqYDTwPs0w1FbKM9mMOE7PJUoYwDQYJKoZIhvcNAQEL
+BQAwODEWMBQGA1UEAwwNb2N0YXJpbmUudGVzdDERMA8GA1UECgwIT2N0YXJpbmUx
+CzAJBgNVBAYTAlVTMB4XDTI2MDcwMzE3MDQ1NFoXDTM2MDYzMDE3MDQ1NFowODEW
+MBQGA1UEAwwNb2N0YXJpbmUudGVzdDERMA8GA1UECgwIT2N0YXJpbmUxCzAJBgNV
+BAYTAlVTMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmrg8ir1LmYXF
+TjrgU3U7xXa8U25MWcVM17Af0IG3jPPpriGs/IClbYHOi/gHCfJFnU23q1+FVDUW
+whaDnymCBWvrcCu0eYMMleF/P/dwOYbjII+9JuTTermGFCT2k3ccwYRFJvXjsfcP
+U/Tfq9Rq3yu5mOW014FGf5CCYhG1W9bosJPSfh0GWBDGi9Ohdaw+tlRdvU+pNWSk
+IXLGe1rXCU1u3u7cK4/mHSOksW2k1Iz483B5xGX5ifKX6x2XqRtzooP45et6TLWr
+qkaUIwPkX4dXpJ4JKM3G4ZeMDPXPm8lhUKUXL4TfNALMNs7nPM+0Aqfd2roRUWg3
+TI2uwB1seQIDAQABo4GiMIGfMB0GA1UdDgQWBBRxWIHTY+24T212hsxG8kRS0A4a
+wjAfBgNVHSMEGDAWgBRxWIHTY+24T212hsxG8kRS0A4awjA/BgNVHREEODA2gg1v
+Y3RhcmluZS50ZXN0ghF3d3cub2N0YXJpbmUudGVzdIESdGVzdEBvY3RhcmluZS50
+ZXN0MAsGA1UdDwQEAwIChDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUA
+A4IBAQAxCxOT/4l3/e9LspAEXohIWzGd03m/7eHCtqKwRBbTxtLQR6uXxJcTw+ou
+FhjoJXM0NpuoEX67kYPhK/xlGdSA38erqPIvfRCvWSz0PkvVnGU3wICQYijr61gX
+NqkABZp7la/v+Ri4Z0mA6e8Jjn+3y9/kSHAlPVtB2M6LpD+9TRXbY017fzMob95r
+TgJHncR9NUia7FyIlgFQD2mAviwTKXo62jwClR/4UbMDyW7WDB7RYsJtlD1ljV5Y
+s65IEVG6SQCLEcR2Or1dlnSJEs1Yd2lh/Mm8okWlW+ku4i3Y1VFzlXPchg0qQZ1+
+LMkl8mNtd2MbHD07VEPVzgaZQaEg
+-----END CERTIFICATE-----";
+
+    // Self-signed EC P-256 (prime256v1) / ecdsa-with-SHA256 certificate.
+    //   Subject/Issuer: CN=ec.octarine.test
+    //   Validity: 2026-07-03 .. 2027-07-03 (1 year, CA:TRUE)
+    #[cfg(feature = "crypto-validation")]
+    const EC_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----
+MIIBizCCATGgAwIBAgIUFs+d9rRzFKfmSyUhQNMPC7KQX8AwCgYIKoZIzj0EAwIw
+GzEZMBcGA1UEAwwQZWMub2N0YXJpbmUudGVzdDAeFw0yNjA3MDMxNzA1MTJaFw0y
+NzA3MDMxNzA1MTJaMBsxGTAXBgNVBAMMEGVjLm9jdGFyaW5lLnRlc3QwWTATBgcq
+hkjOPQIBBggqhkjOPQMBBwNCAAS3UM4g/lq/Y+P2fpf0uVMaJ9G6VKdb0RCE856P
+LrW5YmRAt6y/Xid7JCBNzySQCDQcDiAAsa/DmZ/S98EqOFFwo1MwUTAdBgNVHQ4E
+FgQUZLvoZBYJkxcUeJIgFeH3kUdhl08wHwYDVR0jBBgwFoAUZLvoZBYJkxcUeJIg
+FeH3kUdhl08wDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiAKqbXj
+ICwfgCFx9yL32pXjno3ne+WvyycDPx0M67PUKwIhALFW9Z3MKtB4mecGRfBIcqmS
+gHpkvc/082nbRHV5AjR2
+-----END CERTIFICATE-----";
+
+    #[cfg(feature = "crypto-validation")]
+    #[test]
+    fn test_parse_rsa_certificate_structure() {
+        use crate::primitives::identifiers::crypto::{KeyType, SignatureAlgorithm};
+
+        let cert = super::parse_certificate_pem(RSA_CERT_PEM).expect("valid RSA cert");
+
+        // X.509 v3 (three extensions present)
+        assert_eq!(cert.version, 3);
+
+        // Self-signed: subject == issuer, both carry the expected RDNs.
+        assert!(cert.is_self_signed);
+        assert!(cert.subject.contains("octarine.test"));
+        assert!(cert.subject.contains("Octarine"));
+        assert_eq!(cert.subject, cert.issuer);
+
+        // RSA-2048 public key, SHA-256 signature.
+        assert_eq!(cert.public_key_type, KeyType::Rsa2048);
+        assert_eq!(cert.signature_algorithm, SignatureAlgorithm::RsaPkcs1Sha256);
+
+        // basicConstraints CA:TRUE.
+        assert!(cert.is_ca);
+
+        // not_before strictly precedes not_after; ~10-year validity.
+        assert!(cert.not_before < cert.not_after);
+        let validity_days = (cert.not_after - cert.not_before).num_days();
+        assert!(
+            (3600..3700).contains(&validity_days),
+            "expected ~10y validity, got {validity_days} days"
+        );
+
+        // keyUsage bits set at generation time.
+        assert!(cert.key_usage.contains(&"digitalSignature".to_string()));
+        assert!(cert.key_usage.contains(&"keyCertSign".to_string()));
+
+        // Serial number is a non-empty lowercase hex string.
+        assert!(!cert.serial_number.is_empty());
+        assert!(cert.serial_number.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Subject Alternative Names: the two DNS names and the RFC822 email.
+        assert!(cert.subject_alt_names.iter().any(|s| s == "octarine.test"));
+        assert!(
+            cert.subject_alt_names
+                .iter()
+                .any(|s| s == "www.octarine.test")
+        );
+        assert!(
+            cert.subject_alt_names
+                .iter()
+                .any(|s| s == "email:test@octarine.test")
+        );
+    }
+
+    #[cfg(feature = "crypto-validation")]
+    #[test]
+    fn test_parse_ec_certificate_curve_detection() {
+        use crate::primitives::identifiers::crypto::{KeyType, SignatureAlgorithm};
+
+        let cert = super::parse_certificate_pem(EC_CERT_PEM).expect("valid EC cert");
+
+        // The curve is prime256v1 (P-256). The named curve lives in the
+        // AlgorithmIdentifier parameters, NOT the algorithm OID, so this
+        // asserts the parser reads parameters correctly.
+        assert_eq!(
+            cert.public_key_type,
+            KeyType::P256,
+            "EC prime256v1 cert must be classified as P-256"
+        );
+        assert_eq!(
+            cert.signature_algorithm,
+            SignatureAlgorithm::EcdsaP256Sha256
+        );
+        assert!(cert.is_self_signed);
+        assert!(cert.subject.contains("ec.octarine.test"));
+    }
+
+    #[cfg(feature = "crypto-validation")]
+    #[test]
+    fn test_parse_der_matches_pem() {
+        // Decoding the PEM body and parsing as DER must yield an identical
+        // ParsedCertificate to parsing the PEM directly.
+        let pem = ::pem::parse(RSA_CERT_PEM).expect("pem parses");
+        let from_der = super::parse_certificate_der(pem.contents()).expect("der parses");
+        let from_pem = super::parse_certificate_pem(RSA_CERT_PEM).expect("pem parses");
+        assert_eq!(from_der, from_pem);
+    }
+
+    #[cfg(feature = "crypto-validation")]
+    #[test]
+    fn test_parse_pem_wrong_tag_rejected() {
+        // A valid PEM block whose tag is not CERTIFICATE must be rejected.
+        let key_pem = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n-----END PUBLIC KEY-----";
+        let result = super::parse_certificate_pem(key_pem);
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "crypto-validation")]
+    #[test]
+    fn test_parse_invalid_der_rejected() {
+        let result = super::parse_certificate_der(&[0x00, 0x01, 0x02, 0x03]);
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "crypto-validation")]
+    #[test]
+    fn test_parse_der_size_limit() {
+        let huge = vec![0u8; super::MAX_CERT_SIZE + 1];
+        let result = super::parse_certificate_der(&huge);
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "crypto-validation")]
+    #[test]
+    fn test_validate_format_der_ok_and_pem_ok() {
+        assert!(super::validate_certificate_format_pem(RSA_CERT_PEM).is_ok());
+        let pem = ::pem::parse(RSA_CERT_PEM).expect("pem parses");
+        assert!(super::validate_certificate_format_der(pem.contents()).is_ok());
     }
 }

--- a/crates/octarine/src/primitives/data/paths/filename/construction.rs
+++ b/crates/octarine/src/primitives/data/paths/filename/construction.rs
@@ -515,21 +515,37 @@ pub fn with_timestamp(prefix: &str, extension: &str) -> String {
 /// use octarine::primitives::paths::filename::construction;
 ///
 /// let name = construction::with_uuid("upload", "jpg");
-/// // Returns something like "upload_a1b2c3d4.jpg"
+/// // Returns something like "upload_a1b2c3d400000001.jpg"
 /// ```
 #[must_use]
 pub fn with_uuid(prefix: &str, extension: &str) -> String {
-    // Simple pseudo-UUID using timestamp and random-ish value
+    // Pseudo-unique 16-hex identifier = clock bits ++ atomic counter.
+    //
+    // The two halves are *concatenated*, not combined arithmetically, so each
+    // contributes independently:
+    //   - the low 32 bits of the nanosecond clock distinguish separate process
+    //     runs (a fresh process starts its counter at 0, so the clock is what
+    //     keeps runs from colliding);
+    //   - a process-lifetime `AtomicU32` counter guarantees that no two calls
+    //     *within one process* ever collide — it is strictly monotonic and only
+    //     repeats after 2^32 calls.
+    //
+    // XOR-ing the two (an earlier attempt) does NOT guarantee within-process
+    // uniqueness: the clock delta can cancel the counter delta, so two distinct
+    // calls can hash to the same value. Concatenation cannot cancel.
+    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    let timestamp = SystemTime::now()
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
 
-    // Create a simple hex-like identifier
-    let id = format!("{:016x}", timestamp);
-    let short_id = &id[..8.min(id.len())];
+    let clock = nanos as u32;
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let short_id = format!("{clock:08x}{seq:08x}");
 
     let ext = extension.trim_start_matches('.');
     if ext.is_empty() {
@@ -737,13 +753,20 @@ mod tests {
         assert!(name.starts_with("file_"));
         assert!(!name.contains('.'));
 
-        // Each call should be unique
-        let name1 = with_uuid("test", "txt");
-        std::thread::sleep(std::time::Duration::from_millis(1));
-        let name2 = with_uuid("test", "txt");
-        // They might be equal in fast tests, so just check format
-        assert!(name1.starts_with("test_"));
-        assert!(name2.starts_with("test_"));
+        // Each call must be unique within the process, even for rapid
+        // back-to-back calls with no sleep (the atomic counter guarantees
+        // this — the previous timestamp-high-bits implementation collided).
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        for _ in 0..1000 {
+            let name = with_uuid("test", "txt");
+            assert!(name.starts_with("test_"));
+            assert!(name.ends_with(".txt"));
+            assert!(
+                seen.insert(name.clone()),
+                "with_uuid produced a duplicate: {name}"
+            );
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/crates/octarine/src/primitives/identifiers/token/builder/redaction_provider.rs
+++ b/crates/octarine/src/primitives/identifiers/token/builder/redaction_provider.rs
@@ -225,3 +225,207 @@ impl TokenIdentifierBuilder {
         sanitization::mask_discord_webhook(url)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    fn builder() -> TokenIdentifierBuilder {
+        TokenIdentifierBuilder::new()
+    }
+
+    // A known-valid Stripe key (matches the API_KEY_STRIPE pattern), reused
+    // from the sanitization test suite. Split to avoid secret scanners.
+    fn stripe_key() -> String {
+        format!("sk_live_{}", "EXAMPLE000000000KEY01abcdef")
+    }
+
+    // ========================================================================
+    // Provider redaction with ShowProvider — prefix-driven, so the expected
+    // token is fully determined by the key's leading bytes (RFC-style prefixes).
+    // ========================================================================
+
+    #[test]
+    fn test_redact_aws_key_show_provider() {
+        let b = builder();
+        // AKIA-prefixed access keys map to the AWS provider token.
+        let key = format!("AKIA{}", "IOSFODNN7EXAMPLE");
+        assert_eq!(b.redact_aws_key(&key), "[AWS_KEY]");
+    }
+
+    #[test]
+    fn test_redact_github_token_show_provider() {
+        let b = builder();
+        // ghp_ (and gho_/ghs_/ghr_) prefixes map to the GitHub token.
+        let token = format!("ghp_{}", "0123456789abcdefghij0123456789abcdef");
+        assert_eq!(b.redact_github_token(&token), "[GITHUB_TOKEN]");
+    }
+
+    #[test]
+    fn test_redact_gcp_key_show_provider() {
+        let b = builder();
+        let key = format!("AIza{}", "0123456789abcdefghij0123456789abcde");
+        assert_eq!(b.redact_gcp_key(&key), "[GCP_KEY]");
+    }
+
+    #[test]
+    fn test_redact_azure_key_show_provider_falls_back_to_generic() {
+        let b = builder();
+        // Azure keys have no distinct textual prefix, so ShowProvider yields
+        // the generic API key token.
+        let key = "0123456789abcdef0123456789abcdef";
+        assert_eq!(b.redact_azure_key(key), "[API_KEY]");
+    }
+
+    #[test]
+    fn test_redact_aws_session_token_show_provider() {
+        let b = builder();
+        // Session tokens are not AKIA-prefixed; ShowProvider yields generic.
+        let token = "0123456789abcdefghijklmnopqrstuvwxyz";
+        assert_eq!(b.redact_aws_session_token(token), "[API_KEY]");
+    }
+
+    #[test]
+    fn test_redact_stripe_key_show_prefix() {
+        let b = builder();
+        // Stripe uses ShowPrefix by default: everything through the final
+        // underscore is retained, the secret body is masked with ****.
+        assert_eq!(b.redact_stripe_key(&stripe_key()), "sk_live_****");
+    }
+
+    // ========================================================================
+    // mask_* backed by mask_api_key — first 12 chars shown, rest "***"
+    // ========================================================================
+
+    #[test]
+    fn test_mask_api_key_backed_valid_shows_prefix() {
+        let b = builder();
+        // First 12 chars of "sk_live_EXAMPLE..." then "***".
+        assert_eq!(b.mask_stripe_key(&stripe_key()), "sk_live_EXAM***");
+    }
+
+    #[test]
+    fn test_mask_api_key_backed_invalid_returns_token() {
+        let b = builder();
+        // Non-key input is not recognized; masking returns the type token.
+        assert_eq!(b.mask_aws_key("not-a-key"), "[API_KEY]");
+        assert_eq!(b.mask_gcp_key("short"), "[API_KEY]");
+    }
+
+    // ========================================================================
+    // Structured provider masks — format-preserving, no detection required.
+    // ========================================================================
+
+    #[test]
+    fn test_mask_telegram_bot_token() {
+        let b = builder();
+        // Numeric id retained, secret masked.
+        assert_eq!(
+            b.mask_telegram_bot_token("123456789:AAExampleSecretTokenBody"),
+            "123456789:****"
+        );
+        // No colon => sentinel.
+        assert_eq!(b.mask_telegram_bot_token("nocolon"), "[TELEGRAM_TOKEN]");
+    }
+
+    #[test]
+    fn test_mask_sendgrid_key() {
+        let b = builder();
+        // SG. prefix + first 4 of the body.
+        assert_eq!(b.mask_sendgrid_key("SG.abcdEFGH.ijklMNOP"), "SG.abcd****");
+        assert_eq!(b.mask_sendgrid_key("notprefixed"), "[SENDGRID_KEY]");
+    }
+
+    #[test]
+    fn test_mask_twilio_sids() {
+        let b = builder();
+        assert_eq!(
+            b.mask_twilio_account_sid(&format!("AC{}", "0123456789abcdef0123456789abcdef")),
+            "AC0123****"
+        );
+        assert_eq!(
+            b.mask_twilio_api_key_sid(&format!("SK{}", "0123456789abcdef0123456789abcdef")),
+            "SK0123****"
+        );
+        assert_eq!(b.mask_twilio_account_sid("XX123"), "[TWILIO_SID]");
+    }
+
+    #[test]
+    fn test_mask_slack_token_and_webhook() {
+        let b = builder();
+        assert_eq!(b.mask_slack_token("xoxb-123-456-secret"), "xoxb-****");
+        assert_eq!(b.mask_slack_token("xapp-1-abc"), "xapp-****");
+        assert_eq!(b.mask_slack_token("random-token"), "[SLACK_TOKEN]");
+
+        assert_eq!(
+            b.mask_slack_webhook("https://hooks.slack.com/services/T00/B00/XXXX"),
+            "https://hooks.slack.com/services/****"
+        );
+        assert_eq!(
+            b.mask_slack_webhook("https://example.com/x"),
+            "[SLACK_WEBHOOK]"
+        );
+    }
+
+    #[test]
+    fn test_mask_discord_token_and_webhook() {
+        let b = builder();
+        // Discord bot tokens start with M or N; first segment retained.
+        assert_eq!(
+            b.mask_discord_token("MTAxaBcDeF.GhIjKl.MnOpQrStUv"),
+            "MTAxaBcDeF.****"
+        );
+        assert_eq!(
+            b.mask_discord_token("invalid.token.here"),
+            "[DISCORD_TOKEN]"
+        );
+
+        assert_eq!(
+            b.mask_discord_webhook("https://discord.com/api/webhooks/12345/abcdeToken"),
+            "https://discord.com/api/webhooks/12345/****"
+        );
+        assert_eq!(
+            b.mask_discord_webhook("https://discordapp.com/api/webhooks/999/tok"),
+            "https://discordapp.com/api/webhooks/999/****"
+        );
+        assert_eq!(
+            b.mask_discord_webhook("https://x.com/y"),
+            "[DISCORD_WEBHOOK]"
+        );
+    }
+
+    // ========================================================================
+    // Remaining mask_api_key-backed wrappers exercise the full public surface.
+    // For an unrecognized input they must all return the generic token; this
+    // guards against a wrapper accidentally calling the wrong sanitizer.
+    // ========================================================================
+
+    #[test]
+    fn test_generic_masks_on_invalid_input() {
+        let b = builder();
+        let invalid = "x";
+        for masked in [
+            b.mask_github_token(invalid),
+            b.mask_azure_key(invalid),
+            b.mask_aws_session_token(invalid),
+            b.mask_square_token(invalid),
+            b.mask_shopify_token(invalid),
+            b.mask_paypal_token(invalid),
+            b.mask_mailchimp_key(invalid),
+            b.mask_mailgun_key(invalid),
+            b.mask_resend_key(invalid),
+            b.mask_brevo_key(invalid),
+            b.mask_databricks_token(invalid),
+            b.mask_vault_token(invalid),
+            b.mask_cloudflare_ca_key(invalid),
+            b.mask_npm_token(invalid),
+            b.mask_pypi_token(invalid),
+            b.mask_nuget_key(invalid),
+            b.mask_artifactory_token(invalid),
+            b.mask_docker_hub_token(invalid),
+        ] {
+            assert_eq!(masked, "[API_KEY]");
+        }
+    }
+}

--- a/crates/octarine/src/primitives/security/crypto/detection.rs
+++ b/crates/octarine/src/primitives/security/crypto/detection.rs
@@ -316,6 +316,7 @@ fn detect_deprecated_key_algorithm(key_type: &KeyType) -> Option<CryptoThreat> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
 
     #[test]
@@ -363,5 +364,383 @@ mod tests {
 
         let sha256_threat = detect_hash_threats("SHA256", &policy);
         assert!(sha256_threat.is_none());
+    }
+
+    // ========================================================================
+    // Signature algorithm threat detection
+    // ========================================================================
+
+    #[test]
+    fn test_signature_algorithm_threat_md5_always_insecure() {
+        // MD5 is flagged regardless of policy allowances.
+        let policy = CryptoPolicy::legacy();
+        let threat = detect_signature_algorithm_threat(&SignatureAlgorithm::RsaPkcs1Md5, &policy);
+        assert!(matches!(
+            threat,
+            Some(CryptoThreat::InsecureHashFunction { algorithm }) if algorithm == "MD5"
+        ));
+    }
+
+    #[test]
+    fn test_signature_algorithm_threat_sha1_policy_gated() {
+        // SHA-1 is a threat under standard policy...
+        let standard = CryptoPolicy::standard();
+        assert!(matches!(
+            detect_signature_algorithm_threat(&SignatureAlgorithm::RsaPkcs1Sha1, &standard),
+            Some(CryptoThreat::WeakSignatureAlgorithm { .. })
+        ));
+
+        // ...but permitted under legacy policy (allow_sha1_signatures = true).
+        let legacy = CryptoPolicy::legacy();
+        assert!(
+            detect_signature_algorithm_threat(&SignatureAlgorithm::RsaPkcs1Sha1, &legacy).is_none()
+        );
+    }
+
+    #[test]
+    fn test_signature_algorithm_threat_unknown() {
+        let policy = CryptoPolicy::standard();
+        assert!(matches!(
+            detect_signature_algorithm_threat(&SignatureAlgorithm::Unknown, &policy),
+            Some(CryptoThreat::DeprecatedKeyAlgorithm { .. })
+        ));
+    }
+
+    #[test]
+    fn test_signature_algorithm_threat_secure_none() {
+        let policy = CryptoPolicy::strict();
+        for algo in [
+            SignatureAlgorithm::RsaPkcs1Sha256,
+            SignatureAlgorithm::EcdsaP256Sha256,
+            SignatureAlgorithm::Ed25519,
+        ] {
+            assert!(
+                detect_signature_algorithm_threat(&algo, &policy).is_none(),
+                "{algo:?} should be considered secure"
+            );
+        }
+    }
+
+    // ========================================================================
+    // is_insecure_hash edge cases
+    // ========================================================================
+
+    #[test]
+    fn test_is_insecure_hash_table() {
+        // (input, expected_insecure)
+        let cases = [
+            ("MD5", true),
+            ("md5", true),
+            ("MD4", true),
+            ("SHA1", true),
+            ("sha-1", true),
+            ("SHA-1", true),
+            ("SHA256", false),
+            ("SHA-256", false),
+            ("SHA512", false),
+            ("BLAKE2", false),
+            ("", false),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                is_insecure_hash(input),
+                expected,
+                "is_insecure_hash({input:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_hash_threats_policy_allowances() {
+        // Legacy policy allows SHA-1 but NOT MD5 ("MD5 is never acceptable").
+        let legacy = CryptoPolicy::legacy();
+        assert!(
+            detect_hash_threats("md5", &legacy).is_some(),
+            "MD5 must be flagged even under legacy policy"
+        );
+        assert!(
+            detect_hash_threats("sha1", &legacy).is_none(),
+            "SHA-1 is permitted under legacy policy"
+        );
+
+        // Development policy explicitly allows MD5.
+        let dev = CryptoPolicy::development();
+        assert!(detect_hash_threats("md5", &dev).is_none());
+        assert!(detect_hash_threats("sha1", &dev).is_none());
+
+        // Standard policy flags both MD-family and SHA-1.
+        let standard = CryptoPolicy::standard();
+        assert!(detect_hash_threats("md4", &standard).is_some());
+        assert!(detect_hash_threats("SHA-1", &standard).is_some());
+        // Unknown/secure hashes never flagged.
+        assert!(detect_hash_threats("sha384", &standard).is_none());
+    }
+
+    // ========================================================================
+    // Key size / EC / deprecated key type detection
+    // ========================================================================
+
+    #[test]
+    fn test_weak_ec_key_detection() {
+        let strict = CryptoPolicy::strict(); // min_ec_bits = 384
+        // P-256 (256 bits) is below the strict EC minimum.
+        assert!(is_weak_key_type(&KeyType::P256, &strict));
+        // P-384 meets it; P-521 exceeds it.
+        assert!(!is_weak_key_type(&KeyType::P384, &strict));
+        assert!(!is_weak_key_type(&KeyType::P521, &strict));
+
+        let standard = CryptoPolicy::standard(); // min_ec_bits = 256
+        assert!(!is_weak_key_type(&KeyType::P256, &standard));
+    }
+
+    #[test]
+    fn test_rsa_other_weak_when_below_minimum() {
+        let standard = CryptoPolicy::standard(); // min_rsa_bits = 2048
+        assert!(is_weak_key_type(&KeyType::RsaOther(1024), &standard));
+        assert!(!is_weak_key_type(&KeyType::RsaOther(4096), &standard));
+    }
+
+    #[test]
+    fn test_deprecated_ssh_dsa_algorithm() {
+        // DSA SSH keys are always flagged as deprecated.
+        assert!(matches!(
+            detect_deprecated_key_algorithm(&KeyType::SshDsa),
+            Some(CryptoThreat::DeprecatedKeyAlgorithm { algorithm, .. }) if algorithm == "DSA"
+        ));
+        // Non-DSA keys are not.
+        assert!(detect_deprecated_key_algorithm(&KeyType::SshEd25519).is_none());
+        assert!(detect_deprecated_key_algorithm(&KeyType::Rsa2048).is_none());
+    }
+
+    #[test]
+    fn test_is_deprecated_signature_algorithm_table() {
+        let cases = [
+            (SignatureAlgorithm::RsaPkcs1Md5, true),
+            (SignatureAlgorithm::RsaPkcs1Sha1, true),
+            (SignatureAlgorithm::Unknown, true),
+            (SignatureAlgorithm::RsaPkcs1Sha256, false),
+            (SignatureAlgorithm::EcdsaP256Sha256, false),
+            (SignatureAlgorithm::Ed25519, false),
+        ];
+        for (algo, expected) in cases {
+            assert_eq!(
+                is_deprecated_signature_algorithm(&algo),
+                expected,
+                "{algo:?}"
+            );
+        }
+    }
+
+    // ========================================================================
+    // Feature-gated: parsed-key / certificate threat detection + audits
+    // ========================================================================
+
+    #[cfg(feature = "crypto-validation")]
+    mod gated {
+        use super::*;
+        use crate::primitives::data::crypto::{
+            ParsedCertificate, ParsedPublicKey, ParsedSshPublicKey,
+        };
+        use crate::primitives::identifiers::crypto::KeyFormat;
+        use chrono::{Duration, Utc};
+
+        fn cert_with_validity(
+            not_before: chrono::DateTime<Utc>,
+            not_after: chrono::DateTime<Utc>,
+            self_signed: bool,
+            sig: SignatureAlgorithm,
+            key: KeyType,
+        ) -> ParsedCertificate {
+            ParsedCertificate {
+                version: 3,
+                serial_number: "01".to_string(),
+                subject: "CN=test".to_string(),
+                issuer: if self_signed {
+                    "CN=test".to_string()
+                } else {
+                    "CN=ca".to_string()
+                },
+                not_before,
+                not_after,
+                public_key_type: key,
+                signature_algorithm: sig,
+                is_ca: false,
+                key_usage: Vec::new(),
+                extended_key_usage: Vec::new(),
+                subject_alt_names: Vec::new(),
+                is_self_signed: self_signed,
+            }
+        }
+
+        #[test]
+        fn test_detect_key_threats_weak_rsa() {
+            let policy = CryptoPolicy::strict(); // requires RSA 3072+
+            let key = ParsedPublicKey::new(KeyType::Rsa2048, KeyFormat::Pem, vec![1, 2, 3]);
+            let threats = detect_key_threats(&key, &policy);
+            assert!(
+                threats
+                    .iter()
+                    .any(|t| matches!(t, CryptoThreat::WeakRsaKeySize { .. }))
+            );
+        }
+
+        #[test]
+        fn test_detect_key_threats_oversized_data() {
+            let mut policy = CryptoPolicy::standard();
+            policy.max_key_size = 4;
+            let key = ParsedPublicKey::new(KeyType::Rsa4096, KeyFormat::Pem, vec![0u8; 100]);
+            let threats = detect_key_threats(&key, &policy);
+            assert!(threats.iter().any(|t| matches!(
+                t,
+                CryptoThreat::SuspiciouslyLargeData {
+                    size: 100,
+                    threshold: 4
+                }
+            )));
+        }
+
+        #[test]
+        fn test_detect_ssh_key_threats_deprecated_dsa() {
+            let policy = CryptoPolicy::standard();
+            let key = ParsedSshPublicKey::new(KeyType::SshDsa, "ssh-dss", vec![1, 2, 3]);
+            let threats = detect_ssh_key_threats(&key, &policy);
+            assert!(threats.iter().any(|t| matches!(
+                t,
+                CryptoThreat::DeprecatedKeyAlgorithm { algorithm, .. } if algorithm == "DSA"
+            )));
+        }
+
+        #[test]
+        fn test_detect_cert_threats_expired() {
+            let policy = CryptoPolicy::standard();
+            let now = Utc::now();
+            let cert = cert_with_validity(
+                now - Duration::days(400),
+                now - Duration::days(1), // expired yesterday
+                false,
+                SignatureAlgorithm::RsaPkcs1Sha256,
+                KeyType::Rsa2048,
+            );
+            assert!(is_certificate_expired(&cert));
+            let threats = detect_cert_threats(&cert, &policy);
+            assert!(
+                threats
+                    .iter()
+                    .any(|t| matches!(t, CryptoThreat::ExpiredCertificate { .. }))
+            );
+        }
+
+        #[test]
+        fn test_detect_cert_threats_not_yet_valid() {
+            let policy = CryptoPolicy::standard();
+            let now = Utc::now();
+            let cert = cert_with_validity(
+                now + Duration::days(5), // valid in the future
+                now + Duration::days(400),
+                false,
+                SignatureAlgorithm::RsaPkcs1Sha256,
+                KeyType::Rsa2048,
+            );
+            assert!(is_certificate_not_yet_valid(&cert));
+            let threats = detect_cert_threats(&cert, &policy);
+            assert!(
+                threats
+                    .iter()
+                    .any(|t| matches!(t, CryptoThreat::NotYetValidCertificate { .. }))
+            );
+        }
+
+        #[test]
+        fn test_detect_cert_threats_expiring_soon() {
+            let policy = CryptoPolicy::standard(); // expiry_warning_days = 30
+            let now = Utc::now();
+            let cert = cert_with_validity(
+                now - Duration::days(10),
+                now + Duration::days(10), // expires within the warning window
+                false,
+                SignatureAlgorithm::RsaPkcs1Sha256,
+                KeyType::Rsa2048,
+            );
+            let threats = detect_cert_threats(&cert, &policy);
+            assert!(
+                threats
+                    .iter()
+                    .any(|t| matches!(t, CryptoThreat::CertificateExpiringSoon { .. }))
+            );
+        }
+
+        #[test]
+        fn test_detect_cert_threats_excessive_validity_and_self_signed() {
+            let policy = CryptoPolicy::standard(); // max_validity_days = 825, no self-signed
+            let now = Utc::now();
+            let cert = cert_with_validity(
+                now - Duration::days(1),
+                now + Duration::days(3650), // 10 years > 825
+                true,                       // self-signed
+                SignatureAlgorithm::RsaPkcs1Sha256,
+                KeyType::Rsa2048,
+            );
+            assert!(is_self_signed(&cert));
+            let threats = detect_cert_threats(&cert, &policy);
+            assert!(
+                threats
+                    .iter()
+                    .any(|t| matches!(t, CryptoThreat::ExcessiveValidityPeriod { .. }))
+            );
+            assert!(
+                threats
+                    .iter()
+                    .any(|t| matches!(t, CryptoThreat::SelfSignedCertificate))
+            );
+        }
+
+        #[test]
+        fn test_valid_cert_produces_no_threats() {
+            let policy = CryptoPolicy::standard();
+            let now = Utc::now();
+            let cert = cert_with_validity(
+                now - Duration::days(10),
+                now + Duration::days(200), // well inside limits, not expiring soon
+                false,
+                SignatureAlgorithm::RsaPkcs1Sha256,
+                KeyType::Rsa2048,
+            );
+            let threats = detect_cert_threats(&cert, &policy);
+            assert!(
+                threats.is_empty(),
+                "unexpected threats for a healthy cert: {threats:?}"
+            );
+        }
+
+        #[test]
+        fn test_audit_certificate_blocking() {
+            let policy = CryptoPolicy::standard();
+            let now = Utc::now();
+            // Expired (severity 8, blocking) => audit fails.
+            let cert = cert_with_validity(
+                now - Duration::days(400),
+                now - Duration::days(1),
+                false,
+                SignatureAlgorithm::RsaPkcs1Sha256,
+                KeyType::Rsa2048,
+            );
+            let result = audit_certificate(&cert, &policy);
+            assert!(!result.passed());
+            assert!(!result.blocking_threats().is_empty());
+        }
+
+        #[test]
+        fn test_audit_key_and_ssh_key() {
+            let policy = CryptoPolicy::strict();
+            let key = ParsedPublicKey::new(KeyType::Rsa2048, KeyFormat::Pem, vec![1, 2, 3]);
+            let audit = audit_key(&key, &policy);
+            // WeakRsaKeySize at 2048 has severity 5 (non-blocking) => audit passes
+            // but records a warning.
+            assert!(!audit.warnings().is_empty());
+
+            let ssh = ParsedSshPublicKey::new(KeyType::SshDsa, "ssh-dss", vec![1, 2, 3]);
+            let ssh_audit = audit_ssh_key(&ssh, &policy);
+            assert!(!ssh_audit.threats.is_empty());
+        }
     }
 }


### PR DESCRIPTION
## Summary

Raises 10 low-coverage primitive/data files above 80% line coverage (`random.rs`, security-sensitive, above 90%). Expected values are derived from each spec — real cert structures, RFC-defined curve OIDs, checksum/entropy contracts — not from current parser output.

## Two production bugs found and fixed

**1. EC certificates always classified `KeyType::Unknown`** (`primitives/data/crypto/x509.rs`). The code matched the curve name against the *algorithm* OID, but for EC keys that OID is always `id-ecPublicKey` (1.2.840.10045.2.1) — the named curve lives in the AlgorithmIdentifier **parameters**. Fixed to read the curve OID from parameters and match RFC 5480 values (verified: 1.2.840.10045.3.1.7→P256, 1.3.132.0.34→P384, 1.3.132.0.35→P521). A real P-256 cert now classifies correctly.

**2. `with_uuid` produced duplicate "unique" filenames** (`primitives/data/paths/filename/construction.rs`). It used the slow-changing *high* nanosecond bits, so back-to-back calls collided. Fixed to **concatenate** the low clock bits with a strictly-monotonic process-lifetime `AtomicU32` counter, guaranteeing within-process uniqueness. (An interim XOR approach was rejected during review because the clock delta can cancel the counter delta — reproduced 3 collisions in 200k calls; concatenation cannot cancel.)

Two *test* assumptions that were wrong (not code bugs) were corrected to match documented contracts: legacy `CryptoPolicy` forbids MD5 but allows SHA-1; `sanitize_strict` rejects rather than strips; `is_variable_expansion_present` matches `$VAR` not `${VAR}`.

## Test plan

- `just test-mod` for x509 (9, `crypto-validation`), detection (24, `crypto-validation`), random (6+), iso27001 (22), redaction_provider, paths types/filename, io formats, observe compliance → all pass
- `just clippy`, `just fmt-check`, `just arch-check`, `just doc` → clean

Closes #659