### PR TITLE
refactor(identifiers): keyword registry keyed by (IdentifierType, language)

### DIFF
--- a/crates/octarine/src/primitives/identifiers/common/keywords/ar.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/ar.rs
@@ -1,0 +1,10 @@
+//! Arabic (`ar`) context keywords for identifier confidence scoring.
+//!
+//! Relocated from the previously flat `ApiKey` keyword list. Additional
+//! identifier translations are added by the follow-up translation PRs.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Arabic context keyword table, keyed by identifier type.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] =
+    &[(IdentifierType::ApiKey, &["مفتاح api", "رمز", "مصادقة"])];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/de.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/de.rs
@@ -1,0 +1,12 @@
+//! German (`de`) context keywords for identifier confidence scoring.
+//!
+//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
+//! exists so the per-language layout is complete; keyword data is sourced from
+//! Presidio's MIT-licensed `country_specific/de` files with attribution.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// German (`de`) context keyword table, keyed by identifier type.
+///
+/// Empty until the translation PR populates it.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/en.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/en.rs
@@ -1,0 +1,365 @@
+//! English (`en`) context keywords for identifier confidence scoring.
+//!
+//! Holds the base English keyword dictionaries for every identifier type that
+//! has context coverage, including the 17 entities backfilled per LOW-3 of the
+//! Presidio gap analysis. Keywords are lowercase — the analyzer lowercases the
+//! text window before matching (enforced by `test_all_keywords_are_lowercase`).
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// English context keyword table, keyed by identifier type.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[
+    (
+        IdentifierType::Ssn,
+        &[
+            "social security",
+            "ssn",
+            "ss#",
+            "social security number",
+            "tax id",
+            "taxpayer",
+            "itin",
+            "individual taxpayer",
+        ],
+    ),
+    (
+        IdentifierType::CreditCard,
+        &[
+            "credit card",
+            "card number",
+            "card no",
+            "card #",
+            "cc#",
+            "cc number",
+            "debit card",
+            "visa",
+            "mastercard",
+            "amex",
+            "american express",
+            "payment card",
+            "pan",
+        ],
+    ),
+    (
+        IdentifierType::Email,
+        &[
+            "email",
+            "e-mail",
+            "mail",
+            "email address",
+            "contact",
+            "send to",
+            "reply to",
+        ],
+    ),
+    (
+        IdentifierType::PhoneNumber,
+        &[
+            "phone",
+            "telephone",
+            "tel",
+            "mobile",
+            "cell",
+            "fax",
+            "call",
+            "phone number",
+            "contact number",
+        ],
+    ),
+    (
+        IdentifierType::BankAccount,
+        &[
+            "bank account",
+            "account number",
+            "account no",
+            "acct",
+            "iban",
+            "routing",
+            "aba",
+            "swift",
+            "bic",
+            "checking",
+            "savings",
+        ],
+    ),
+    (
+        IdentifierType::DriverLicense,
+        &[
+            "driver license",
+            "driver's license",
+            "driving license",
+            "dl",
+            "dl#",
+            "license number",
+            "licence",
+        ],
+    ),
+    (
+        IdentifierType::Passport,
+        &[
+            "passport",
+            "passport number",
+            "passport no",
+            "travel document",
+        ],
+    ),
+    (
+        IdentifierType::Birthdate,
+        &[
+            "date of birth",
+            "dob",
+            "birth date",
+            "birthday",
+            "born",
+            "birth",
+        ],
+    ),
+    (
+        IdentifierType::IpAddress,
+        &[
+            "ip address",
+            "ip addr",
+            "ip",
+            "source ip",
+            "destination ip",
+            "client ip",
+            "server ip",
+            "remote addr",
+            "host",
+        ],
+    ),
+    (
+        IdentifierType::ApiKey,
+        &[
+            "api key",
+            "api_key",
+            "apikey",
+            "api token",
+            "api secret",
+            "access key",
+            "secret key",
+            "auth token",
+            "authorization",
+        ],
+    ),
+    (
+        IdentifierType::AwsAccessKey,
+        &[
+            "aws",
+            "aws_access_key",
+            "aws_secret",
+            "access key id",
+            "secret access key",
+            "iam",
+            "amazon web services",
+        ],
+    ),
+    (
+        IdentifierType::PersonalName,
+        &[
+            "name",
+            "full name",
+            "first name",
+            "last name",
+            "surname",
+            "given name",
+            "family name",
+            "patient name",
+            "customer name",
+        ],
+    ),
+    (
+        IdentifierType::RoutingNumber,
+        &[
+            "routing",
+            "routing number",
+            "aba",
+            "transit number",
+            "bank routing",
+        ],
+    ),
+    (
+        IdentifierType::NamedLocation,
+        &[
+            "live in",
+            "lives in",
+            "lived in",
+            "from",
+            "visiting",
+            "visit to",
+            "located in",
+            "located at",
+            "located near",
+            "address",
+            "addressed to",
+            "near",
+            "traveled to",
+            "travelled to",
+            "flew to",
+            "flying to",
+            "moving to",
+            "moved to",
+            "city of",
+            "country of",
+            "town of",
+            "village of",
+            "hometown",
+            "birthplace",
+            "born in",
+            "residing in",
+            "resides in",
+            "based in",
+            "headquartered in",
+            "stationed in",
+        ],
+    ),
+    // ------------------------------------------------------------------------
+    // LOW-3 backfill: identifiers that previously returned `&[]`.
+    // ------------------------------------------------------------------------
+    (
+        IdentifierType::Iban,
+        &[
+            "iban",
+            "international bank account",
+            "bank account number",
+            "account number",
+        ],
+    ),
+    (
+        IdentifierType::CryptoAddress,
+        &[
+            "wallet",
+            "wallet address",
+            "crypto address",
+            "bitcoin",
+            "ethereum",
+            "btc",
+            "eth",
+            "blockchain",
+        ],
+    ),
+    (
+        IdentifierType::MacAddress,
+        &[
+            "mac address",
+            "mac addr",
+            "hardware address",
+            "physical address",
+            "ethernet address",
+        ],
+    ),
+    (
+        IdentifierType::Url,
+        &[
+            "url",
+            "link",
+            "website",
+            "web address",
+            "http",
+            "https",
+            "endpoint",
+        ],
+    ),
+    (
+        IdentifierType::Jwt,
+        &[
+            "jwt",
+            "json web token",
+            "bearer",
+            "token",
+            "access token",
+            "id token",
+        ],
+    ),
+    (
+        IdentifierType::BearerToken,
+        &[
+            "bearer",
+            "bearer token",
+            "authorization",
+            "auth token",
+            "access token",
+        ],
+    ),
+    (
+        IdentifierType::OAuthToken,
+        &[
+            "oauth",
+            "oauth token",
+            "access token",
+            "refresh token",
+            "authorization",
+        ],
+    ),
+    (
+        IdentifierType::SshKey,
+        &[
+            "ssh",
+            "ssh key",
+            "private key",
+            "public key",
+            "id_rsa",
+            "authorized_keys",
+        ],
+    ),
+    (
+        IdentifierType::SessionId,
+        &["session", "session id", "session token", "sid", "cookie"],
+    ),
+    (
+        IdentifierType::Uuid,
+        &["uuid", "guid", "unique id", "identifier", "correlation id"],
+    ),
+    (
+        IdentifierType::Username,
+        &[
+            "username",
+            "user name",
+            "login",
+            "user id",
+            "userid",
+            "account",
+        ],
+    ),
+    (
+        IdentifierType::Password,
+        &["password", "passwd", "pwd", "pass", "secret", "credential"],
+    ),
+    (
+        IdentifierType::ConnectionString,
+        &[
+            "connection string",
+            "connection",
+            "dsn",
+            "database url",
+            "conn str",
+        ],
+    ),
+    (
+        IdentifierType::HighEntropyString,
+        &["secret", "token", "key", "credential", "api key"],
+    ),
+    (
+        IdentifierType::OnePasswordToken,
+        &[
+            "1password",
+            "op token",
+            "service account token",
+            "onepassword",
+        ],
+    ),
+    (
+        IdentifierType::OnePasswordVaultRef,
+        &[
+            "1password",
+            "vault",
+            "op://",
+            "secret reference",
+            "onepassword",
+        ],
+    ),
+    (
+        IdentifierType::UrlWithCredentials,
+        &["url", "credentials", "username", "password", "connection"],
+    ),
+];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/es.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/es.rs
@@ -1,0 +1,12 @@
+//! Spanish (`es`) context keywords for identifier confidence scoring.
+//!
+//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
+//! exists so the per-language layout is complete; keyword data is sourced from
+//! Presidio's MIT-licensed `country_specific/es` files with attribution.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Spanish (`es`) context keyword table, keyed by identifier type.
+///
+/// Empty until the translation PR populates it.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/fi.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/fi.rs
@@ -1,0 +1,12 @@
+//! Finnish (`fi`) context keywords for identifier confidence scoring.
+//!
+//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
+//! exists so the per-language layout is complete; keyword data is sourced from
+//! Presidio's MIT-licensed `country_specific/fi` files with attribution.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Finnish (`fi`) context keyword table, keyed by identifier type.
+///
+/// Empty until the translation PR populates it.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/fr.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/fr.rs
@@ -1,0 +1,12 @@
+//! French (`fr`) context keywords for identifier confidence scoring.
+//!
+//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
+//! exists so the per-language layout is complete; keyword data is sourced from
+//! Presidio's MIT-licensed `country_specific/fr` files with attribution.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// French (`fr`) context keyword table, keyed by identifier type.
+///
+/// Empty until the translation PR populates it.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/hi.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/hi.rs
@@ -1,0 +1,10 @@
+//! Hindi (`hi`) context keywords for identifier confidence scoring.
+//!
+//! Relocated from the previously flat `ApiKey` keyword list. Additional
+//! identifier translations are added by the follow-up translation PRs.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Hindi context keyword table, keyed by identifier type.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] =
+    &[(IdentifierType::ApiKey, &["एपीआई कुंजी", "टोकन", "प्रमाणीकरण"])];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/it.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/it.rs
@@ -1,0 +1,12 @@
+//! Italian (`it`) context keywords for identifier confidence scoring.
+//!
+//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
+//! exists so the per-language layout is complete; keyword data is sourced from
+//! Presidio's MIT-licensed `country_specific/it` files with attribution.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Italian (`it`) context keyword table, keyed by identifier type.
+///
+/// Empty until the translation PR populates it.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/ja.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/ja.rs
@@ -1,0 +1,12 @@
+//! Japanese (`ja`) context keywords for identifier confidence scoring.
+//!
+//! Relocated from the previously flat `ApiKey` keyword list. Additional
+//! identifier translations are added by the follow-up translation PRs.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Japanese context keyword table, keyed by identifier type.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[(
+    IdentifierType::ApiKey,
+    &["apiキー", "認証", "トークン", "秘密鍵"],
+)];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/ko.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/ko.rs
@@ -1,0 +1,10 @@
+//! Korean (`ko`) context keywords for identifier confidence scoring.
+//!
+//! Relocated from the previously flat `ApiKey` keyword list. Additional
+//! identifier translations are added by the follow-up translation PRs.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Korean context keyword table, keyed by identifier type.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] =
+    &[(IdentifierType::ApiKey, &["api키", "인증", "토큰", "비밀키"])];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/mod.rs
@@ -1,0 +1,133 @@
+//! Per-language context keyword dictionaries for identifier confidence scoring.
+//!
+//! Each identifier type can carry context keywords in multiple languages. The
+//! data lives in one file per language (`en.rs`, `de.rs`, …) mirroring
+//! Presidio's per-language YAML layout, each declaring a `KEYWORDS` table of
+//! `(IdentifierType, &[keyword])`. [`KeywordLanguage`] selects the table.
+//!
+//! # Design
+//!
+//! - **No logging / no dependencies** — pure static data (Layer 1 rules).
+//! - **Lowercase invariant** — every keyword is lowercase; the analyzer
+//!   lowercases the text window before matching.
+//! - **Additive** — a language table only lists the identifier types it covers;
+//!   an absent type resolves to an empty slice, never a panic.
+
+mod ar;
+mod de;
+mod en;
+mod es;
+mod fi;
+mod fr;
+mod hi;
+mod it;
+mod ja;
+mod ko;
+mod pl;
+mod sv;
+mod th;
+mod tr;
+mod zh_hans;
+mod zh_hant;
+
+/// A language for which context keywords may be defined.
+///
+/// Covers Presidio's 12 supported languages plus the CJK / Arabic / Hindi
+/// scripts octarine already ships for `ApiKey`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeywordLanguage {
+    /// English
+    En,
+    /// German
+    De,
+    /// Spanish
+    Es,
+    /// Finnish
+    Fi,
+    /// French
+    Fr,
+    /// Italian
+    It,
+    /// Japanese
+    Ja,
+    /// Korean
+    Ko,
+    /// Polish
+    Pl,
+    /// Swedish
+    Sv,
+    /// Thai
+    Th,
+    /// Turkish
+    Tr,
+    /// Arabic
+    Ar,
+    /// Hindi
+    Hi,
+    /// Chinese (Simplified)
+    ZhHans,
+    /// Chinese (Traditional)
+    ZhHant,
+}
+
+impl KeywordLanguage {
+    /// Every supported language, in a stable order.
+    ///
+    /// Used to scan across all languages when no language hint is supplied,
+    /// preserving the pre-refactor behavior of matching any known keyword.
+    pub const ALL: [KeywordLanguage; 16] = [
+        KeywordLanguage::En,
+        KeywordLanguage::De,
+        KeywordLanguage::Es,
+        KeywordLanguage::Fi,
+        KeywordLanguage::Fr,
+        KeywordLanguage::It,
+        KeywordLanguage::Ja,
+        KeywordLanguage::Ko,
+        KeywordLanguage::Pl,
+        KeywordLanguage::Sv,
+        KeywordLanguage::Th,
+        KeywordLanguage::Tr,
+        KeywordLanguage::Ar,
+        KeywordLanguage::Hi,
+        KeywordLanguage::ZhHans,
+        KeywordLanguage::ZhHant,
+    ];
+
+    /// Iterate over every supported language.
+    pub fn all() -> impl Iterator<Item = KeywordLanguage> {
+        Self::ALL.into_iter()
+    }
+
+    /// The keyword table for this language.
+    ///
+    /// Returns `(IdentifierType, &[keyword])` pairs; identifier types absent
+    /// from the language resolve to an empty slice in
+    /// [`context_keywords`](crate::primitives::identifiers::confidence::context_keywords).
+    #[must_use]
+    pub(crate) fn keywords(
+        self,
+    ) -> &'static [(
+        crate::primitives::identifiers::IdentifierType,
+        &'static [&'static str],
+    )] {
+        match self {
+            KeywordLanguage::En => en::KEYWORDS,
+            KeywordLanguage::De => de::KEYWORDS,
+            KeywordLanguage::Es => es::KEYWORDS,
+            KeywordLanguage::Fi => fi::KEYWORDS,
+            KeywordLanguage::Fr => fr::KEYWORDS,
+            KeywordLanguage::It => it::KEYWORDS,
+            KeywordLanguage::Ja => ja::KEYWORDS,
+            KeywordLanguage::Ko => ko::KEYWORDS,
+            KeywordLanguage::Pl => pl::KEYWORDS,
+            KeywordLanguage::Sv => sv::KEYWORDS,
+            KeywordLanguage::Th => th::KEYWORDS,
+            KeywordLanguage::Tr => tr::KEYWORDS,
+            KeywordLanguage::Ar => ar::KEYWORDS,
+            KeywordLanguage::Hi => hi::KEYWORDS,
+            KeywordLanguage::ZhHans => zh_hans::KEYWORDS,
+            KeywordLanguage::ZhHant => zh_hant::KEYWORDS,
+        }
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/common/keywords/pl.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/pl.rs
@@ -1,0 +1,12 @@
+//! Polish (`pl`) context keywords for identifier confidence scoring.
+//!
+//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
+//! exists so the per-language layout is complete; keyword data is sourced from
+//! Presidio's MIT-licensed `country_specific/pl` files with attribution.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Polish (`pl`) context keyword table, keyed by identifier type.
+///
+/// Empty until the translation PR populates it.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/sv.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/sv.rs
@@ -1,0 +1,12 @@
+//! Swedish (`sv`) context keywords for identifier confidence scoring.
+//!
+//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
+//! exists so the per-language layout is complete; keyword data is sourced from
+//! Presidio's MIT-licensed `country_specific/sv` files with attribution.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Swedish (`sv`) context keyword table, keyed by identifier type.
+///
+/// Empty until the translation PR populates it.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/th.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/th.rs
@@ -1,0 +1,12 @@
+//! Thai (`th`) context keywords for identifier confidence scoring.
+//!
+//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
+//! exists so the per-language layout is complete; keyword data is sourced from
+//! Presidio's MIT-licensed `country_specific/th` files with attribution.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Thai (`th`) context keyword table, keyed by identifier type.
+///
+/// Empty until the translation PR populates it.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/tr.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/tr.rs
@@ -1,0 +1,12 @@
+//! Turkish (`tr`) context keywords for identifier confidence scoring.
+//!
+//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
+//! exists so the per-language layout is complete; keyword data is sourced from
+//! Presidio's MIT-licensed `country_specific/tr` files with attribution.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Turkish (`tr`) context keyword table, keyed by identifier type.
+///
+/// Empty until the translation PR populates it.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/zh_hans.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/zh_hans.rs
@@ -1,0 +1,11 @@
+//! Chinese Simplified (`zh-Hans`) context keywords for identifier confidence
+//! scoring.
+//!
+//! Relocated from the previously flat `ApiKey` keyword list. Additional
+//! identifier translations are added by the follow-up translation PRs.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Chinese Simplified context keyword table, keyed by identifier type.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] =
+    &[(IdentifierType::ApiKey, &["api密钥", "认证", "令牌", "密钥"])];

--- a/crates/octarine/src/primitives/identifiers/common/keywords/zh_hant.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/zh_hant.rs
@@ -1,0 +1,11 @@
+//! Chinese Traditional (`zh-Hant`) context keywords for identifier confidence
+//! scoring.
+//!
+//! Relocated from the previously flat `ApiKey` keyword list. Additional
+//! identifier translations are added by the follow-up translation PRs.
+
+use crate::primitives::identifiers::IdentifierType;
+
+/// Chinese Traditional context keyword table, keyed by identifier type.
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] =
+    &[(IdentifierType::ApiKey, &["api密鑰", "認證", "密鑰"])];

--- a/crates/octarine/src/primitives/identifiers/common/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/mod.rs
@@ -6,6 +6,7 @@
 //! - `luhn` - Luhn algorithm for credit card validation
 //! - `masking` - Masking and redaction strategies
 //! - `utils` - Common validation utilities
+//! - `keywords` - Per-language context keyword dictionaries
 //!
 //! ## Design Principles
 //!
@@ -13,10 +14,14 @@
 //! 2. **No Dependencies**: Only external crates (regex, etc.)
 //! 3. **Reusable**: Used by all domain modules
 
+pub(crate) mod keywords;
 pub(crate) mod luhn;
 pub(crate) mod masking;
 pub(crate) mod patterns;
 pub(crate) mod utils;
+
+// Re-export the language selector used by confidence scoring
+pub(crate) use keywords::KeywordLanguage;
 
 // Re-export commonly used utilities for sibling modules
 pub use luhn::{

--- a/crates/octarine/src/primitives/identifiers/confidence/context.rs
+++ b/crates/octarine/src/primitives/identifiers/confidence/context.rs
@@ -7,6 +7,7 @@
 use super::keywords::context_keywords;
 use super::types::ContextConfig;
 use crate::primitives::identifiers::IdentifierType;
+use crate::primitives::identifiers::common::KeywordLanguage;
 
 // ============================================================================
 // ContextAnalyzer
@@ -132,11 +133,6 @@ impl ContextAnalyzer {
         match_end: usize,
         entity_type: &IdentifierType,
     ) -> bool {
-        let keywords = context_keywords(entity_type);
-        if keywords.is_empty() {
-            return false;
-        }
-
         // Calculate window boundaries (byte offsets, clamped to text bounds)
         let window_start = match_start.saturating_sub(self.config.window_size);
         let window_end = match_end
@@ -157,8 +153,15 @@ impl ContextAnalyzer {
         // Case-insensitive: lowercase the window (keywords are already lowercase)
         let window_lower = window.to_lowercase();
 
-        // Check for any keyword — first match is sufficient (no double-boost)
-        keywords.iter().any(|kw| window_lower.contains(kw))
+        // Scan every language's keyword table. With no language hint the analyzer
+        // matches any known keyword regardless of script — preserving the
+        // pre-refactor behavior where non-Latin keywords lived in the same list.
+        // First match is sufficient (no double-boost).
+        KeywordLanguage::all().any(|language| {
+            context_keywords(entity_type, language)
+                .iter()
+                .any(|kw| window_lower.contains(kw))
+        })
     }
 }
 

--- a/crates/octarine/src/primitives/identifiers/confidence/keywords.rs
+++ b/crates/octarine/src/primitives/identifiers/confidence/keywords.rs
@@ -1,225 +1,46 @@
-//! Per-entity keyword dictionaries for context-aware confidence scoring
+//! Per-entity, per-language keyword lookup for context-aware confidence scoring
 //!
-//! Maps identifier types to contextual keywords that, when found near a
-//! pattern match, indicate higher confidence. Keywords are lowercase and
-//! drawn from Presidio's context-aware approach.
+//! Maps `(identifier type, language)` to contextual keywords that, when found
+//! near a pattern match, indicate higher confidence. The keyword data lives in
+//! [`crate::primitives::identifiers::common::keywords`], one file per language
+//! mirroring Presidio's per-language layout; this module is the lookup over
+//! those tables. Keywords are lowercase and drawn from Presidio's
+//! context-aware approach.
 
 use crate::primitives::identifiers::IdentifierType;
+use crate::primitives::identifiers::common::KeywordLanguage;
 
 // ============================================================================
-// Keyword Dictionaries
+// Keyword Lookup
 // ============================================================================
 
-/// Returns context keywords for the given identifier type.
+/// Returns context keywords for the given identifier type in one language.
 ///
 /// Keywords are lowercase strings that, when found in the text window
 /// surrounding a pattern match, suggest the match is a true positive.
 ///
-/// Returns an empty slice for identifier types without defined keywords.
+/// Returns an empty slice for identifier types that have no keywords defined
+/// in the requested language.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use octarine::primitives::identifiers::confidence::context_keywords;
+/// use octarine::primitives::identifiers::confidence::{context_keywords, KeywordLanguage};
 /// use octarine::primitives::identifiers::IdentifierType;
 ///
-/// let keywords = context_keywords(&IdentifierType::Ssn);
+/// let keywords = context_keywords(&IdentifierType::Ssn, KeywordLanguage::En);
 /// assert!(keywords.contains(&"social security"));
 /// ```
 #[must_use]
-pub fn context_keywords(entity_type: &IdentifierType) -> &'static [&'static str] {
-    match entity_type {
-        IdentifierType::Ssn => &[
-            "social security",
-            "ssn",
-            "ss#",
-            "social security number",
-            "tax id",
-            "taxpayer",
-            "itin",
-            "individual taxpayer",
-        ],
-        IdentifierType::CreditCard => &[
-            "credit card",
-            "card number",
-            "card no",
-            "card #",
-            "cc#",
-            "cc number",
-            "debit card",
-            "visa",
-            "mastercard",
-            "amex",
-            "american express",
-            "payment card",
-            "pan",
-        ],
-        IdentifierType::Email => &[
-            "email",
-            "e-mail",
-            "mail",
-            "email address",
-            "contact",
-            "send to",
-            "reply to",
-        ],
-        IdentifierType::PhoneNumber => &[
-            "phone",
-            "telephone",
-            "tel",
-            "mobile",
-            "cell",
-            "fax",
-            "call",
-            "phone number",
-            "contact number",
-        ],
-        IdentifierType::BankAccount => &[
-            "bank account",
-            "account number",
-            "account no",
-            "acct",
-            "iban",
-            "routing",
-            "aba",
-            "swift",
-            "bic",
-            "checking",
-            "savings",
-        ],
-        IdentifierType::DriverLicense => &[
-            "driver license",
-            "driver's license",
-            "driving license",
-            "dl",
-            "dl#",
-            "license number",
-            "licence",
-        ],
-        IdentifierType::Passport => &[
-            "passport",
-            "passport number",
-            "passport no",
-            "travel document",
-        ],
-        IdentifierType::Birthdate => &[
-            "date of birth",
-            "dob",
-            "birth date",
-            "birthday",
-            "born",
-            "birth",
-        ],
-        IdentifierType::IpAddress => &[
-            "ip address",
-            "ip addr",
-            "ip",
-            "source ip",
-            "destination ip",
-            "client ip",
-            "server ip",
-            "remote addr",
-            "host",
-        ],
-        IdentifierType::ApiKey => &[
-            "api key",
-            "api_key",
-            "apikey",
-            "api token",
-            "api secret",
-            "access key",
-            "secret key",
-            "auth token",
-            "authorization",
-            // Japanese
-            "apiキー",
-            "認証",
-            "トークン",
-            "秘密鍵",
-            // Chinese (Simplified)
-            "api密钥",
-            "认证",
-            "令牌",
-            "密钥",
-            // Chinese (Traditional)
-            "api密鑰",
-            "認證",
-            "密鑰",
-            // Korean
-            "api키",
-            "인증",
-            "토큰",
-            "비밀키",
-            // Arabic
-            "مفتاح api",
-            "رمز",
-            "مصادقة",
-            // Hindi
-            "एपीआई कुंजी",
-            "टोकन",
-            "प्रमाणीकरण",
-        ],
-        IdentifierType::AwsAccessKey => &[
-            "aws",
-            "aws_access_key",
-            "aws_secret",
-            "access key id",
-            "secret access key",
-            "iam",
-            "amazon web services",
-        ],
-        IdentifierType::PersonalName => &[
-            "name",
-            "full name",
-            "first name",
-            "last name",
-            "surname",
-            "given name",
-            "family name",
-            "patient name",
-            "customer name",
-        ],
-        IdentifierType::RoutingNumber => &[
-            "routing",
-            "routing number",
-            "aba",
-            "transit number",
-            "bank routing",
-        ],
-        IdentifierType::NamedLocation => &[
-            "live in",
-            "lives in",
-            "lived in",
-            "from",
-            "visiting",
-            "visit to",
-            "located in",
-            "located at",
-            "located near",
-            "address",
-            "addressed to",
-            "near",
-            "traveled to",
-            "travelled to",
-            "flew to",
-            "flying to",
-            "moving to",
-            "moved to",
-            "city of",
-            "country of",
-            "town of",
-            "village of",
-            "hometown",
-            "birthplace",
-            "born in",
-            "residing in",
-            "resides in",
-            "based in",
-            "headquartered in",
-            "stationed in",
-        ],
-        _ => &[],
-    }
+pub fn context_keywords(
+    entity_type: &IdentifierType,
+    language: KeywordLanguage,
+) -> &'static [&'static str] {
+    language
+        .keywords()
+        .iter()
+        .find(|(ty, _)| ty == entity_type)
+        .map_or(&[], |(_, keywords)| *keywords)
 }
 
 // ============================================================================
@@ -233,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_ssn_keywords() {
-        let keywords = context_keywords(&IdentifierType::Ssn);
+        let keywords = context_keywords(&IdentifierType::Ssn, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"social security"));
         assert!(keywords.contains(&"ssn"));
@@ -241,7 +62,7 @@ mod tests {
 
     #[test]
     fn test_credit_card_keywords() {
-        let keywords = context_keywords(&IdentifierType::CreditCard);
+        let keywords = context_keywords(&IdentifierType::CreditCard, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"credit card"));
         assert!(keywords.contains(&"card number"));
@@ -249,14 +70,14 @@ mod tests {
 
     #[test]
     fn test_email_keywords() {
-        let keywords = context_keywords(&IdentifierType::Email);
+        let keywords = context_keywords(&IdentifierType::Email, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"email"));
     }
 
     #[test]
     fn test_phone_keywords() {
-        let keywords = context_keywords(&IdentifierType::PhoneNumber);
+        let keywords = context_keywords(&IdentifierType::PhoneNumber, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"phone"));
         assert!(keywords.contains(&"mobile"));
@@ -264,7 +85,7 @@ mod tests {
 
     #[test]
     fn test_bank_account_keywords() {
-        let keywords = context_keywords(&IdentifierType::BankAccount);
+        let keywords = context_keywords(&IdentifierType::BankAccount, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"bank account"));
         assert!(keywords.contains(&"iban"));
@@ -272,21 +93,21 @@ mod tests {
 
     #[test]
     fn test_driver_license_keywords() {
-        let keywords = context_keywords(&IdentifierType::DriverLicense);
+        let keywords = context_keywords(&IdentifierType::DriverLicense, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"driver license"));
     }
 
     #[test]
     fn test_passport_keywords() {
-        let keywords = context_keywords(&IdentifierType::Passport);
+        let keywords = context_keywords(&IdentifierType::Passport, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"passport"));
     }
 
     #[test]
     fn test_birthdate_keywords() {
-        let keywords = context_keywords(&IdentifierType::Birthdate);
+        let keywords = context_keywords(&IdentifierType::Birthdate, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"date of birth"));
         assert!(keywords.contains(&"dob"));
@@ -294,93 +115,139 @@ mod tests {
 
     #[test]
     fn test_ip_address_keywords() {
-        let keywords = context_keywords(&IdentifierType::IpAddress);
+        let keywords = context_keywords(&IdentifierType::IpAddress, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"ip address"));
     }
 
     #[test]
     fn test_api_key_keywords() {
-        let keywords = context_keywords(&IdentifierType::ApiKey);
+        let keywords = context_keywords(&IdentifierType::ApiKey, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"api key"));
     }
 
     #[test]
-    fn test_api_key_keywords_include_non_latin_scripts() {
-        let keywords = context_keywords(&IdentifierType::ApiKey);
-        // Spot-check one keyword per script family. Existing
-        // `test_all_keywords_are_lowercase` enforces the lowercase invariant
-        // across every entry.
-        assert!(keywords.contains(&"apiキー"), "Japanese api key missing");
-        assert!(keywords.contains(&"api密钥"), "Chinese Simplified missing");
-        assert!(keywords.contains(&"api密鑰"), "Chinese Traditional missing");
-        assert!(keywords.contains(&"api키"), "Korean missing");
-        assert!(keywords.contains(&"مفتاح api"), "Arabic missing");
-        assert!(keywords.contains(&"एपीआई कुंजी"), "Hindi missing");
+    fn test_api_key_keywords_resolve_per_language() {
+        // The non-Latin ApiKey keywords now live in their own language tables
+        // rather than being flat-appended to the English list. Spot-check one
+        // keyword per script family. `test_all_keywords_are_lowercase` enforces
+        // the lowercase invariant across every entry and language.
+        assert!(
+            context_keywords(&IdentifierType::ApiKey, KeywordLanguage::Ja).contains(&"apiキー"),
+            "Japanese api key missing"
+        );
+        assert!(
+            context_keywords(&IdentifierType::ApiKey, KeywordLanguage::ZhHans).contains(&"api密钥"),
+            "Chinese Simplified missing"
+        );
+        assert!(
+            context_keywords(&IdentifierType::ApiKey, KeywordLanguage::ZhHant).contains(&"api密鑰"),
+            "Chinese Traditional missing"
+        );
+        assert!(
+            context_keywords(&IdentifierType::ApiKey, KeywordLanguage::Ko).contains(&"api키"),
+            "Korean missing"
+        );
+        assert!(
+            context_keywords(&IdentifierType::ApiKey, KeywordLanguage::Ar).contains(&"مفتاح api"),
+            "Arabic missing"
+        );
+        assert!(
+            context_keywords(&IdentifierType::ApiKey, KeywordLanguage::Hi).contains(&"एपीआई कुंजी"),
+            "Hindi missing"
+        );
+    }
+
+    #[test]
+    fn test_api_key_english_excludes_non_latin() {
+        // The English table must no longer carry the non-Latin keywords.
+        let en = context_keywords(&IdentifierType::ApiKey, KeywordLanguage::En);
+        assert!(!en.contains(&"apiキー"));
+        assert!(!en.contains(&"api密钥"));
     }
 
     #[test]
     fn test_aws_keywords() {
-        let keywords = context_keywords(&IdentifierType::AwsAccessKey);
+        let keywords = context_keywords(&IdentifierType::AwsAccessKey, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"aws"));
     }
 
     #[test]
     fn test_personal_name_keywords() {
-        let keywords = context_keywords(&IdentifierType::PersonalName);
+        let keywords = context_keywords(&IdentifierType::PersonalName, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"name"));
     }
 
     #[test]
     fn test_routing_number_keywords() {
-        let keywords = context_keywords(&IdentifierType::RoutingNumber);
+        let keywords = context_keywords(&IdentifierType::RoutingNumber, KeywordLanguage::En);
         assert!(!keywords.is_empty());
         assert!(keywords.contains(&"routing"));
     }
 
     #[test]
+    fn test_low3_backfill_non_empty() {
+        // LOW-3: entities that previously returned `&[]` now have English
+        // context keywords.
+        let backfilled = [
+            IdentifierType::Iban,
+            IdentifierType::CryptoAddress,
+            IdentifierType::MacAddress,
+            IdentifierType::Url,
+            IdentifierType::Jwt,
+            IdentifierType::BearerToken,
+            IdentifierType::OAuthToken,
+            IdentifierType::SshKey,
+            IdentifierType::SessionId,
+            IdentifierType::Uuid,
+            IdentifierType::Username,
+            IdentifierType::Password,
+            IdentifierType::ConnectionString,
+            IdentifierType::HighEntropyString,
+            IdentifierType::OnePasswordToken,
+            IdentifierType::OnePasswordVaultRef,
+            IdentifierType::UrlWithCredentials,
+        ];
+        for ty in &backfilled {
+            assert!(
+                !context_keywords(ty, KeywordLanguage::En).is_empty(),
+                "LOW-3 backfill missing English keywords for {ty:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_unknown_type_returns_empty() {
-        let keywords = context_keywords(&IdentifierType::Unknown);
-        assert!(keywords.is_empty());
+        // Unknown resolves to an empty slice in every language.
+        for language in KeywordLanguage::all() {
+            assert!(context_keywords(&IdentifierType::Unknown, language).is_empty());
+        }
     }
 
     #[test]
     fn test_all_keywords_are_lowercase() {
-        let types_with_keywords = [
-            IdentifierType::Ssn,
-            IdentifierType::CreditCard,
-            IdentifierType::Email,
-            IdentifierType::PhoneNumber,
-            IdentifierType::BankAccount,
-            IdentifierType::DriverLicense,
-            IdentifierType::Passport,
-            IdentifierType::Birthdate,
-            IdentifierType::IpAddress,
-            IdentifierType::ApiKey,
-            IdentifierType::AwsAccessKey,
-            IdentifierType::PersonalName,
-            IdentifierType::RoutingNumber,
-        ];
-
-        for entity_type in &types_with_keywords {
-            for keyword in context_keywords(entity_type) {
-                assert_eq!(
-                    *keyword,
-                    keyword.to_lowercase(),
-                    "Keyword '{}' for {:?} is not lowercase",
-                    keyword,
-                    entity_type
-                );
+        // Walk every identifier type present in every language table and confirm
+        // the lowercase invariant holds across all scripts.
+        for language in KeywordLanguage::all() {
+            for (entity_type, keywords) in language.keywords() {
+                for keyword in *keywords {
+                    assert_eq!(
+                        *keyword,
+                        keyword.to_lowercase(),
+                        "Keyword '{keyword}' for {entity_type:?} ({language:?}) is not lowercase"
+                    );
+                }
             }
         }
     }
 
     #[test]
     fn test_minimum_entity_coverage() {
-        // Ensure at least 11 entity types have keywords (acceptance criteria)
+        // Ensure at least 11 entity types have English keywords (acceptance
+        // criteria from the original context-keyword work).
         let all_types = [
             IdentifierType::Ssn,
             IdentifierType::CreditCard,
@@ -399,13 +266,21 @@ mod tests {
 
         let covered = all_types
             .iter()
-            .filter(|t| !context_keywords(t).is_empty())
+            .filter(|t| !context_keywords(t, KeywordLanguage::En).is_empty())
             .count();
 
         assert!(
             covered >= 11,
-            "Expected at least 11 entity types with keywords, got {}",
-            covered
+            "Expected at least 11 entity types with keywords, got {covered}"
         );
+    }
+
+    #[test]
+    fn test_every_language_table_resolves() {
+        // Every KeywordLanguage variant must resolve to a (possibly empty)
+        // table without panicking.
+        for language in KeywordLanguage::all() {
+            let _ = language.keywords();
+        }
     }
 }

--- a/crates/octarine/src/primitives/identifiers/confidence/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/confidence/mod.rs
@@ -13,3 +13,4 @@ pub use self::builder::ConfidenceBuilder;
 pub use self::context::ContextAnalyzer;
 pub use self::keywords::context_keywords;
 pub use self::types::ContextConfig;
+pub use crate::primitives::identifiers::common::keywords::KeywordLanguage;

--- a/crates/octarine/src/primitives/identifiers/location/detection/named.rs
+++ b/crates/octarine/src/primitives/identifiers/location/detection/named.rs
@@ -37,7 +37,7 @@ use once_cell::sync::Lazy;
 use super::super::super::common::patterns::location::gazetteer::{
     AMBIGUOUS_PLACE_NAMES, CITIES, COUNTRIES,
 };
-use super::super::super::confidence::context_keywords;
+use super::super::super::confidence::{KeywordLanguage, context_keywords};
 use super::super::super::types::{DetectionConfidence, IdentifierMatch, IdentifierType};
 
 /// Maximum input length for ReDoS protection.
@@ -164,7 +164,7 @@ fn has_word_boundaries(bytes: &[u8], start: usize, end: usize) -> bool {
 /// byte panics, so a non-ASCII codepoint inside the window must not cause
 /// a split mid-codepoint.
 fn is_in_location_context(text: &str, match_start: usize, match_end: usize) -> bool {
-    let keywords = context_keywords(&IdentifierType::NamedLocation);
+    let keywords = context_keywords(&IdentifierType::NamedLocation, KeywordLanguage::En);
     if keywords.is_empty() {
         return false;
     }


### PR DESCRIPTION
## Summary

PR **1 of 3** for #432 — the foundation only. Replaces the flat, English-only
`context_keywords(&IdentifierType)` with a `(IdentifierType, KeywordLanguage)`
registry backed by per-language data files under
`primitives/identifiers/common/keywords/`, mirroring Presidio's per-language
layout.

- **`KeywordLanguage` enum** — 16 variants (Presidio's 12 + the CJK/Arabic/Hindi
  scripts octarine already shipped for `ApiKey`).
- **Per-language data files** — keyword data moved out of the giant `match` into
  16 files. `en.rs` holds the 14 existing English sets; `ja/zh_hans/zh_hant/ko/ar/hi`
  carry the `ApiKey` non-Latin keywords that were previously **flat-appended** to
  the English list.
- **LOW-3 backfill** — English context keywords added to the 17 identifiers that
  previously returned `&[]` (Iban, CryptoAddress, MacAddress, Url, Jwt,
  BearerToken, OAuthToken, SshKey, SessionId, Uuid, Username, Password,
  ConnectionString, HighEntropyString, OnePasswordToken, OnePasswordVaultRef,
  UrlWithCredentials).
- **Behavior preserved** — `ContextAnalyzer` unions all languages when no hint is
  supplied, so existing non-Latin `ApiKey` matches still boost. No caller sees a
  behavior change.
- **Translation stubs** — `de/es/fi/fr/it/pl/sv/th/tr` are present-but-empty for
  the follow-up translation PRs, satisfying the issue's 16-file layout without
  inventing unsourced translations.

## Deferred (tracked, not in this PR)

Per #432's own recommended split, this PR does **not** include:

- **Step 3** — translating the top-20 identifiers into the 12 Presidio languages
  (requires sourcing/attributing Presidio's MIT-licensed `country_specific/{lang}`
  data).
- **Step 4** — the `ContextWindow`/Layer-3 `with_language(KeywordLanguage)` hint
  API (no `ContextWindow` type exists today).

#432 stays **open** to track these; a follow-up issue captures them.

## Test plan

- `just fmt`, `just clippy`, `just doc` (rustdoc `-D warnings`) — all clean.
- `just test-mod "confidence"` — 64 tests pass, incl. new per-language, LOW-3,
  and cross-language lowercase-invariant tests.
- `just test-mod "identifiers"` — 3075 tests pass.
- Full `cargo test --workspace` green via the pre-push hook.

Refs #432