### PR TITLE
feat(identifiers): add German core identifier suite (TaxId, IdCard, Passport)

### DIFF
--- a/crates/octarine/src/identifiers/builder/government/germany.rs
+++ b/crates/octarine/src/identifiers/builder/government/germany.rs
@@ -1,0 +1,270 @@
+//! German government-identifier methods — Steuer-IdNr (tax ID),
+//! Personalausweis (nPA), Reisepass (passport).
+
+use super::*;
+
+impl GovernmentBuilder {
+    // ---- Steuer-IdNr ---------------------------------------------------------
+
+    /// Check if value matches a German Steuer-IdNr
+    #[must_use]
+    pub fn is_germany_tax_id(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_germany_tax_id(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Validate German Steuer-IdNr format
+    pub fn validate_germany_tax_id(&self, value: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_germany_tax_id(value);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "germany_tax_id_validation_failed",
+                    "Invalid Germany Steuer-IdNr format",
+                );
+            }
+        }
+        result
+    }
+
+    /// Validate German Steuer-IdNr with ISO 7064 mod-11,10 checksum verification
+    pub fn validate_germany_tax_id_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        self.inner.validate_germany_tax_id_with_checksum(value)
+    }
+
+    /// Find all German Steuer-IdNr mentions in text
+    #[must_use]
+    pub fn find_germany_tax_ids_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_germany_tax_ids_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    // ---- Personalausweis (nPA) -----------------------------------------------
+
+    /// Check if value matches a German Personalausweis (nPA) number
+    #[must_use]
+    pub fn is_germany_id_card(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_germany_id_card(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Validate German Personalausweis format
+    pub fn validate_germany_id_card(&self, value: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_germany_id_card(value);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "germany_id_card_validation_failed",
+                    "Invalid Germany Personalausweis format",
+                );
+            }
+        }
+        result
+    }
+
+    /// Validate German Personalausweis with ICAO Doc 9303 check-digit verification
+    pub fn validate_germany_id_card_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        self.inner.validate_germany_id_card_with_checksum(value)
+    }
+
+    /// Find all German Personalausweis mentions in text
+    #[must_use]
+    pub fn find_germany_id_cards_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_germany_id_cards_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    // ---- Reisepass (passport) ------------------------------------------------
+
+    /// Check if value matches a German Reisepass (passport) number
+    #[must_use]
+    pub fn is_germany_passport(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_germany_passport(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Validate German Reisepass format
+    pub fn validate_germany_passport(&self, value: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_germany_passport(value);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "germany_passport_validation_failed",
+                    "Invalid Germany Reisepass format",
+                );
+            }
+        }
+        result
+    }
+
+    /// Validate German Reisepass with ICAO Doc 9303 check-digit verification
+    pub fn validate_germany_passport_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        self.inner.validate_germany_passport_with_checksum(value)
+    }
+
+    /// Find all German Reisepass mentions in text
+    #[must_use]
+    pub fn find_germany_passports_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_germany_passports_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    const VALID_TAX_ID: &str = "10002345676";
+    const VALID_ID_CARD: &str = "CH20064148";
+    const VALID_PASSPORT: &str = "T220001293";
+
+    #[test]
+    fn test_germany_tax_id() {
+        let b = GovernmentBuilder::silent();
+        assert!(b.is_germany_tax_id(VALID_TAX_ID));
+        assert!(b.validate_germany_tax_id(VALID_TAX_ID).is_ok());
+        // Wrong length.
+        assert!(b.validate_germany_tax_id("1000234567").is_err());
+        assert!(
+            b.validate_germany_tax_id_with_checksum(VALID_TAX_ID)
+                .is_ok()
+        );
+        // Tampered check digit.
+        assert!(
+            b.validate_germany_tax_id_with_checksum("10002345675")
+                .is_err()
+        );
+        assert!(
+            !b.find_germany_tax_ids_in_text(&format!("Steuer-IdNr: {VALID_TAX_ID}"))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_germany_tax_id_events_enabled() {
+        let b = GovernmentBuilder::new();
+        assert!(b.is_germany_tax_id(VALID_TAX_ID));
+        assert!(b.validate_germany_tax_id(VALID_TAX_ID).is_ok());
+    }
+
+    #[test]
+    fn test_germany_id_card() {
+        let b = GovernmentBuilder::silent();
+        assert!(b.is_germany_id_card(VALID_ID_CARD));
+        assert!(b.validate_germany_id_card(VALID_ID_CARD).is_ok());
+        assert!(b.validate_germany_id_card("!!!").is_err());
+        assert!(
+            b.validate_germany_id_card_with_checksum(VALID_ID_CARD)
+                .is_ok()
+        );
+        // Tampered check digit.
+        assert!(
+            b.validate_germany_id_card_with_checksum("CH20064149")
+                .is_err()
+        );
+        assert!(
+            !b.find_germany_id_cards_in_text(&format!("Personalausweis {VALID_ID_CARD}"))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_germany_passport() {
+        let b = GovernmentBuilder::silent();
+        assert!(b.is_germany_passport(VALID_PASSPORT));
+        assert!(b.validate_germany_passport(VALID_PASSPORT).is_ok());
+        assert!(b.validate_germany_passport("!!!").is_err());
+        assert!(
+            b.validate_germany_passport_with_checksum(VALID_PASSPORT)
+                .is_ok()
+        );
+        // Tampered check digit.
+        assert!(
+            b.validate_germany_passport_with_checksum("T220001294")
+                .is_err()
+        );
+        assert!(
+            !b.find_germany_passports_in_text(&format!("Reisepass {VALID_PASSPORT}"))
+                .is_empty()
+        );
+    }
+}

--- a/crates/octarine/src/identifiers/builder/government/mod.rs
+++ b/crates/octarine/src/identifiers/builder/government/mod.rs
@@ -40,6 +40,7 @@ mod brazil;
 mod cache;
 mod driver_license;
 mod europe;
+mod germany;
 mod india;
 mod korea;
 mod mexico;

--- a/crates/octarine/src/identifiers/shortcuts/government.rs
+++ b/crates/octarine/src/identifiers/shortcuts/government.rs
@@ -576,6 +576,100 @@ pub fn validate_sweden_orgnummer_with_checksum(value: &str) -> Result<(), Proble
     GovernmentBuilder::new().validate_sweden_orgnummer_with_checksum(value)
 }
 
+// ============================================================================
+// Germany — Steuer-IdNr, Personalausweis (nPA), Reisepass
+// ============================================================================
+
+/// Check if value is a valid German Steuer-IdNr (tax ID)
+#[must_use]
+pub fn is_germany_tax_id(value: &str) -> bool {
+    GovernmentBuilder::new().is_germany_tax_id(value)
+}
+
+/// Find all German Steuer-IdNr mentions in text (label-anchored only)
+#[must_use]
+pub fn find_germany_tax_ids(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_germany_tax_ids_in_text(text)
+}
+
+/// Validate a German Steuer-IdNr format (structural + checksum rules)
+///
+/// # Errors
+///
+/// Returns `Problem` if the value is not a valid Steuer-IdNr.
+pub fn validate_germany_tax_id(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_germany_tax_id(value)
+}
+
+/// Validate a German Steuer-IdNr with ISO 7064 mod-11,10 checksum verification
+///
+/// # Errors
+///
+/// Returns `Problem` if the format, structural rule, or checksum is invalid.
+pub fn validate_germany_tax_id_with_checksum(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_germany_tax_id_with_checksum(value)
+}
+
+/// Check if value is a valid German Personalausweis (nPA) number
+#[must_use]
+pub fn is_germany_id_card(value: &str) -> bool {
+    GovernmentBuilder::new().is_germany_id_card(value)
+}
+
+/// Find all German Personalausweis mentions in text (label-anchored only)
+#[must_use]
+pub fn find_germany_id_cards(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_germany_id_cards_in_text(text)
+}
+
+/// Validate a German Personalausweis format
+///
+/// # Errors
+///
+/// Returns `Problem` if the value is not a valid nPA number.
+pub fn validate_germany_id_card(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_germany_id_card(value)
+}
+
+/// Validate a German Personalausweis with ICAO Doc 9303 check-digit verification
+///
+/// # Errors
+///
+/// Returns `Problem` if the format or check digit is invalid.
+pub fn validate_germany_id_card_with_checksum(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_germany_id_card_with_checksum(value)
+}
+
+/// Check if value is a valid German Reisepass (passport) number
+#[must_use]
+pub fn is_germany_passport(value: &str) -> bool {
+    GovernmentBuilder::new().is_germany_passport(value)
+}
+
+/// Find all German Reisepass mentions in text (label-anchored only)
+#[must_use]
+pub fn find_germany_passports(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_germany_passports_in_text(text)
+}
+
+/// Validate a German Reisepass format
+///
+/// # Errors
+///
+/// Returns `Problem` if the value is not a valid passport number.
+pub fn validate_germany_passport(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_germany_passport(value)
+}
+
+/// Validate a German Reisepass with ICAO Doc 9303 check-digit verification
+///
+/// # Errors
+///
+/// Returns `Problem` if the format or check digit is invalid.
+pub fn validate_germany_passport_with_checksum(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_germany_passport_with_checksum(value)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
@@ -751,5 +845,41 @@ mod tests {
         // Label-gated text scanning.
         assert!(!find_sweden_orgnummers("orgnr: 556016-0680").is_empty());
         assert!(find_sweden_orgnummers("556016-0680").is_empty());
+    }
+
+    #[test]
+    fn test_germany_tax_id_shortcuts() {
+        // 10002345676: valid ISO 7064 mod-11,10 checksum + structural rule.
+        assert!(is_germany_tax_id("10002345676"));
+        assert!(validate_germany_tax_id("10002345676").is_ok());
+        assert!(validate_germany_tax_id_with_checksum("10002345676").is_ok());
+        assert!(validate_germany_tax_id("").is_err());
+        // Tampered check digit rejected.
+        assert!(validate_germany_tax_id_with_checksum("10002345675").is_err());
+        // Label-gated text scanning — bare 11 digits collide with other IDs.
+        assert!(!find_germany_tax_ids("Steuer-IdNr: 10002345676").is_empty());
+        assert!(find_germany_tax_ids("10002345676").is_empty());
+    }
+
+    #[test]
+    fn test_germany_id_card_shortcuts() {
+        assert!(is_germany_id_card("CH20064148"));
+        assert!(validate_germany_id_card("CH20064148").is_ok());
+        assert!(validate_germany_id_card_with_checksum("CH20064148").is_ok());
+        assert!(validate_germany_id_card("").is_err());
+        // Tampered check digit rejected.
+        assert!(validate_germany_id_card_with_checksum("CH20064149").is_err());
+        assert!(!find_germany_id_cards("Personalausweis CH20064148").is_empty());
+    }
+
+    #[test]
+    fn test_germany_passport_shortcuts() {
+        assert!(is_germany_passport("T220001293"));
+        assert!(validate_germany_passport("T220001293").is_ok());
+        assert!(validate_germany_passport_with_checksum("T220001293").is_ok());
+        assert!(validate_germany_passport("").is_err());
+        // Tampered check digit rejected.
+        assert!(validate_germany_passport_with_checksum("T220001294").is_err());
+        assert!(!find_germany_passports("Reisepass T220001293").is_empty());
     }
 }

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -209,7 +209,10 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             | PiiType::UkPassport
             | PiiType::UkDrivingLicence
             | PiiType::SwedenPersonnummer
-            | PiiType::SwedenOrgnummer => {
+            | PiiType::SwedenOrgnummer
+            | PiiType::GermanyTaxId
+            | PiiType::GermanyIdCard
+            | PiiType::GermanyPassport => {
                 // Generic government ID redaction routes through
                 // redact_all_government_ids_in_text_with_policy, which already
                 // covers all country-specific finders.

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -277,6 +277,18 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
             GovernmentIdentifierBuilder::find_sweden_orgnummers_in_text,
             PiiType::SwedenOrgnummer,
         ),
+        (
+            GovernmentIdentifierBuilder::find_germany_tax_ids_in_text,
+            PiiType::GermanyTaxId,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_germany_id_cards_in_text,
+            PiiType::GermanyIdCard,
+        ),
+        (
+            GovernmentIdentifierBuilder::find_germany_passports_in_text,
+            PiiType::GermanyPassport,
+        ),
     ];
 
     let government = GovernmentIdentifierBuilder::new();

--- a/crates/octarine/src/observe/pii/types/classification.rs
+++ b/crates/octarine/src/observe/pii/types/classification.rs
@@ -31,6 +31,7 @@ impl PiiType {
             Self::SpainNif | Self::SpainNie | Self::UkNi |
             Self::UkNhs | Self::UkPassport | Self::UkDrivingLicence |
             Self::SwedenPersonnummer | Self::SwedenOrgnummer |
+            Self::GermanyTaxId | Self::GermanyIdCard | Self::GermanyPassport |
             // Medical (HIPAA)
             Self::Mrn | Self::Npi | Self::InsuranceNumber | Self::DeaNumber | Self::IcdCode | Self::PrescriptionNumber |
             // Biometric (irreplaceable)
@@ -78,6 +79,10 @@ impl PiiType {
             Self::SpainNif | Self::SpainNie | Self::UkNi |
             Self::UkNhs | Self::UkPassport | Self::UkDrivingLicence |
             Self::SwedenPersonnummer | Self::SwedenOrgnummer |
+            // German IDs — Steuer-IdNr protected under §§ 139a-139e AO + DSGVO,
+            // nPA/Reisepass under BDSG. (Health insurance / KVNR is Art. 9
+            // health data and lands with the follow-up PR2.)
+            Self::GermanyTaxId | Self::GermanyIdCard | Self::GermanyPassport |
             // Financial — IBAN identifies an EU account holder (Recital 30 /
             // Art. 4(1)). Crypto addresses are pseudonymous by design and are
             // excluded unless linked to an identifiable person upstream.

--- a/crates/octarine/src/observe/pii/types/core.rs
+++ b/crates/octarine/src/observe/pii/types/core.rs
@@ -73,6 +73,9 @@ impl PiiType {
             Self::UkDrivingLicence => "uk_driving_licence",
             Self::SwedenPersonnummer => "sweden_personnummer",
             Self::SwedenOrgnummer => "sweden_orgnummer",
+            Self::GermanyTaxId => "germany_tax_id",
+            Self::GermanyIdCard => "germany_id_card",
+            Self::GermanyPassport => "germany_passport",
             // Medical
             Self::Mrn => "mrn",
             Self::Npi => "npi",
@@ -229,7 +232,10 @@ impl PiiType {
             | Self::UkPassport
             | Self::UkDrivingLicence
             | Self::SwedenPersonnummer
-            | Self::SwedenOrgnummer => "government",
+            | Self::SwedenOrgnummer
+            | Self::GermanyTaxId
+            | Self::GermanyIdCard
+            | Self::GermanyPassport => "government",
             Self::Mrn
             | Self::Npi
             | Self::InsuranceNumber

--- a/crates/octarine/src/observe/pii/types/mapping.rs
+++ b/crates/octarine/src/observe/pii/types/mapping.rs
@@ -120,6 +120,9 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::UkDrivingLicence => Self::UkDrivingLicence,
             IdentifierType::SwedenPersonnummer => Self::SwedenPersonnummer,
             IdentifierType::SwedenOrgnummer => Self::SwedenOrgnummer,
+            IdentifierType::GermanyTaxId => Self::GermanyTaxId,
+            IdentifierType::GermanyIdCard => Self::GermanyIdCard,
+            IdentifierType::GermanyPassport => Self::GermanyPassport,
 
             // Organizational
             IdentifierType::EmployeeId => Self::EmployeeId,

--- a/crates/octarine/src/observe/pii/types/mod.rs
+++ b/crates/octarine/src/observe/pii/types/mod.rs
@@ -177,6 +177,12 @@ pub enum PiiType {
     SwedenPersonnummer,
     /// Swedish organisationsnummer (company identity number)
     SwedenOrgnummer,
+    /// German Steuer-IdNr (lifelong personal tax identification number)
+    GermanyTaxId,
+    /// German Personalausweis / nPA (national identity card)
+    GermanyIdCard,
+    /// German Reisepass (passport)
+    GermanyPassport,
 
     // =========================================================================
     // Medical Domain (PHI - Protected Health Information)

--- a/crates/octarine/src/observe/pii/types/tests.rs
+++ b/crates/octarine/src/observe/pii/types/tests.rs
@@ -212,6 +212,9 @@ fn test_country_specific_government_classifications() {
         PiiType::SpainNif,
         PiiType::SpainNie,
         PiiType::UkNi,
+        PiiType::GermanyTaxId,
+        PiiType::GermanyIdCard,
+        PiiType::GermanyPassport,
     ] {
         assert_eq!(pii.domain(), "government", "{pii:?} domain");
         assert!(pii.is_high_risk(), "{pii:?} should be high-risk");
@@ -259,6 +262,9 @@ fn test_country_specific_government_classifications() {
     assert_eq!(PiiType::ItalyDriverLicense.name(), "italy_driver_license");
     assert_eq!(PiiType::SpainNie.name(), "spain_nie");
     assert_eq!(PiiType::UkNi.name(), "uk_ni");
+    assert_eq!(PiiType::GermanyTaxId.name(), "germany_tax_id");
+    assert_eq!(PiiType::GermanyIdCard.name(), "germany_id_card");
+    assert_eq!(PiiType::GermanyPassport.name(), "germany_passport");
 }
 
 #[test]
@@ -508,6 +514,18 @@ fn from_identifier_type_direct_mappings() {
     assert_eq!(PiiType::from(IdentifierType::SpainNif), PiiType::SpainNif);
     assert_eq!(PiiType::from(IdentifierType::SpainNie), PiiType::SpainNie);
     assert_eq!(PiiType::from(IdentifierType::UkNi), PiiType::UkNi);
+    assert_eq!(
+        PiiType::from(IdentifierType::GermanyTaxId),
+        PiiType::GermanyTaxId
+    );
+    assert_eq!(
+        PiiType::from(IdentifierType::GermanyIdCard),
+        PiiType::GermanyIdCard
+    );
+    assert_eq!(
+        PiiType::from(IdentifierType::GermanyPassport),
+        PiiType::GermanyPassport
+    );
 
     // Organizational
     assert_eq!(

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -39,14 +39,14 @@ pub(crate) use network::{email, phone, username};
 pub(crate) use personal::{
     NATIONALITIES, POLITICAL_AFFILIATIONS, RELIGIONS, age, australia_abn, australia_acn,
     australia_medicare, australia_tfn, birthdate, brazil_cnpj, brazil_cpf, driver_license,
-    employee_id, finland_hetu, india_aadhaar, india_gstin, india_pan, india_passport,
-    india_vehicle_reg, india_voter_id, italy_driver_license, italy_fiscal_code,
-    italy_identity_card, italy_passport, italy_vat, korea_brn, korea_driver_license, korea_frn,
-    korea_passport, korea_rrn, mexico_curp, national_id, nigeria_bvn, nigeria_nin,
-    nigeria_vehicle_reg, passport, personal_name, poland_pesel, singapore_nric, singapore_uen,
-    spain_nie, spain_nif, ssn, student_id, sweden_orgnummer, sweden_personnummer, tax_id,
-    thailand_tnin, turkey_license_plate, turkey_tckn, uk_driving_licence, uk_nhs, uk_ni,
-    uk_passport,
+    employee_id, finland_hetu, germany_id_card, germany_passport, germany_tax_id, india_aadhaar,
+    india_gstin, india_pan, india_passport, india_vehicle_reg, india_voter_id,
+    italy_driver_license, italy_fiscal_code, italy_identity_card, italy_passport, italy_vat,
+    korea_brn, korea_driver_license, korea_frn, korea_passport, korea_rrn, mexico_curp,
+    national_id, nigeria_bvn, nigeria_nin, nigeria_vehicle_reg, passport, personal_name,
+    poland_pesel, singapore_nric, singapore_uen, spain_nie, spain_nif, ssn, student_id,
+    sweden_orgnummer, sweden_personnummer, tax_id, thailand_tnin, turkey_license_plate,
+    turkey_tckn, uk_driving_licence, uk_nhs, uk_ni, uk_passport,
 };
 
 // medical, biometric, location, and vehicle modules are already accessible via pub mod declarations

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
@@ -37,10 +37,11 @@ pub(crate) use global_identifiers::{
 };
 pub(crate) use nrp::{NATIONALITIES, POLITICAL_AFFILIATIONS, RELIGIONS};
 pub(crate) use regional_identifiers::{
-    birthdate, brazil_cnpj, brazil_cpf, finland_hetu, italy_driver_license, italy_fiscal_code,
-    italy_identity_card, italy_passport, italy_vat, mexico_curp, nigeria_bvn, nigeria_nin,
-    nigeria_vehicle_reg, personal_name, poland_pesel, singapore_nric, singapore_uen, spain_nie,
-    spain_nif, sweden_orgnummer, sweden_personnummer, thailand_tnin, turkey_license_plate,
-    turkey_tckn, uk_driving_licence, uk_nhs, uk_ni, uk_passport,
+    birthdate, brazil_cnpj, brazil_cpf, finland_hetu, germany_id_card, germany_passport,
+    germany_tax_id, italy_driver_license, italy_fiscal_code, italy_identity_card, italy_passport,
+    italy_vat, mexico_curp, nigeria_bvn, nigeria_nin, nigeria_vehicle_reg, personal_name,
+    poland_pesel, singapore_nric, singapore_uen, spain_nie, spain_nif, sweden_orgnummer,
+    sweden_personnummer, thailand_tnin, turkey_license_plate, turkey_tckn, uk_driving_licence,
+    uk_nhs, uk_ni, uk_passport,
 };
 pub(crate) use us_identifiers::{driver_license, employee_id, passport, ssn, student_id, tax_id};

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
@@ -762,6 +762,110 @@ pub(crate) mod sweden_orgnummer {
     }
 }
 
+/// Germany Steuer-IdNr (tax identification number) patterns — 11 digits
+///
+/// Format: 11 bare digits (may be grouped `NN NNN NNN NNN`). The first 10
+/// digits carry an ISO 7064 mod-11,10 check digit in position 11, plus the
+/// structural "exactly one repeated digit" rule enforced by
+/// `is_germany_tax_id` / `validate_germany_tax_id`. A bare 11-digit run
+/// collides with Nigeria NIN/BVN and Italy VAT, so text scanning is
+/// label-anchored only.
+pub(crate) mod germany_tax_id {
+    use super::*;
+
+    /// Bare 11-digit shape (optionally space-grouped as `NN NNN NNN NNN`).
+    pub static STANDARD: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"\b\d{2}[ ]?\d{3}[ ]?\d{3}[ ]?\d{3}\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// Steuer-IdNr with explicit label (German + English aliases).
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:steuer[\s-]?identifikationsnummer|steuer[\s-]?id(?:nr)?|steuerliche[\s-]?identifikationsnummer|idnr|tax[\s-]?id(?:entification)?(?:[\s-]?number)?)[\s:#-]*((?:\d[ ]?){11})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
+    }
+
+    /// Label-anchored only — the bare 11-digit shape collides with Nigeria
+    /// NIN/BVN and Italy VAT, so scanning requires surrounding context.
+    pub fn labeled_only() -> Vec<&'static Regex> {
+        vec![&*LABELED]
+    }
+}
+
+/// Germany Personalausweis (nPA / national identity card) patterns
+///
+/// Format: 9 alphanumeric document-number characters + ICAO Doc 9303 check
+/// digit. The document-number alphabet excludes `A B D E I O Q S U`
+/// (letters that could be confused with digits or each other). The ICAO
+/// check digit is verified by `validate_germany_id_card` via the shared
+/// `icao_doc_9303` helper.
+pub(crate) mod germany_id_card {
+    use super::*;
+
+    /// Shape: 9 chars from the reduced alphabet `[C-HJ-NPR-TV-Z0-9]` + 1
+    /// check digit. (Excludes A,B,D,E,I,O,Q,S,U per German nPA rules.)
+    pub static STANDARD: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\b[C-HJ-NPR-TV-Z0-9]{9}\d\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// nPA with explicit label (German + English aliases).
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:personalausweis(?:nummer)?|ausweisnummer|npa|(?:german[\s-]?)?id[\s-]?card(?:[\s-]?number|[\s-]?no\.?)?)[\s:#-]*([C-HJ-NPR-TV-Z0-9]{9}\d)\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
+    }
+
+    /// Label-anchored only — the bare 10-char alphanumeric shape collides
+    /// with the German passport and other document numbers.
+    pub fn labeled_only() -> Vec<&'static Regex> {
+        vec![&*LABELED]
+    }
+}
+
+/// Germany Reisepass (passport) patterns
+///
+/// Same ICAO Doc 9303 structure and reduced alphabet as the nPA: 9
+/// document-number characters + 1 check digit, alphabet excluding
+/// `A B D E I O Q S U`. Verified by `validate_germany_passport` via the
+/// shared `icao_doc_9303` helper.
+pub(crate) mod germany_passport {
+    use super::*;
+
+    /// Shape: 9 chars from the reduced alphabet `[C-HJ-NPR-TV-Z0-9]` + 1
+    /// check digit.
+    pub static STANDARD: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?i)\b[C-HJ-NPR-TV-Z0-9]{9}\d\b").expect("BUG: Invalid regex pattern")
+    });
+
+    /// Reisepass with explicit label (German + English aliases).
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:reisepass(?:nummer)?|passnummer|(?:german[\s-]?)?passport(?:[\s-]?number|[\s-]?no\.?)?)[\s:#-]*([C-HJ-NPR-TV-Z0-9]{9}\d)\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
+    }
+
+    /// Label-anchored only — the bare 10-char alphanumeric shape collides
+    /// with the German nPA and other document numbers.
+    pub fn labeled_only() -> Vec<&'static Regex> {
+        vec![&*LABELED]
+    }
+}
+
 pub(crate) mod personal_name {
     use super::*;
 

--- a/crates/octarine/src/primitives/identifiers/government/builder/germany.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/germany.rs
@@ -1,0 +1,110 @@
+//! German identifier operations on `GovernmentIdentifierBuilder` —
+//! Steuer-IdNr (tax ID), Personalausweis (nPA), Reisepass (passport).
+
+use super::*;
+
+impl GovernmentIdentifierBuilder {
+    // ------------------------------------------------------------------
+    // Steuer-IdNr — 11 digits, ISO 7064 mod-11,10 + structural rule
+    // ------------------------------------------------------------------
+
+    /// Check if value is a valid German Steuer-IdNr
+    #[must_use]
+    pub fn is_germany_tax_id(&self, value: &str) -> bool {
+        detection::is_germany_tax_id(value)
+    }
+
+    /// Find all German Steuer-IdNr patterns in text (label-anchored)
+    #[must_use]
+    pub fn find_germany_tax_ids_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_germany_tax_ids_in_text(text)
+    }
+
+    /// Validate German Steuer-IdNr format (structural + checksum rules)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem::Validation` if the value is not a valid Steuer-IdNr.
+    pub fn validate_germany_tax_id(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_germany_tax_id(value)
+    }
+
+    /// Validate German Steuer-IdNr including the ISO 7064 mod-11,10 checksum
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem::Validation` if the format, structural rule, or
+    /// checksum is invalid.
+    pub fn validate_germany_tax_id_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_germany_tax_id_with_checksum(value)
+    }
+
+    // ------------------------------------------------------------------
+    // Personalausweis (nPA) — ICAO Doc 9303 check digit
+    // ------------------------------------------------------------------
+
+    /// Check if value is a valid German Personalausweis (nPA) number
+    #[must_use]
+    pub fn is_germany_id_card(&self, value: &str) -> bool {
+        detection::is_germany_id_card(value)
+    }
+
+    /// Find all German Personalausweis patterns in text (label-anchored)
+    #[must_use]
+    pub fn find_germany_id_cards_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_germany_id_cards_in_text(text)
+    }
+
+    /// Validate German Personalausweis format
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem::Validation` if the value is not a valid nPA number.
+    pub fn validate_germany_id_card(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_germany_id_card(value)
+    }
+
+    /// Validate German Personalausweis including the ICAO Doc 9303 check digit
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem::Validation` if the format or check digit is invalid.
+    pub fn validate_germany_id_card_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_germany_id_card_with_checksum(value)
+    }
+
+    // ------------------------------------------------------------------
+    // Reisepass (passport) — ICAO Doc 9303 check digit
+    // ------------------------------------------------------------------
+
+    /// Check if value is a valid German Reisepass (passport) number
+    #[must_use]
+    pub fn is_germany_passport(&self, value: &str) -> bool {
+        detection::is_germany_passport(value)
+    }
+
+    /// Find all German Reisepass patterns in text (label-anchored)
+    #[must_use]
+    pub fn find_germany_passports_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_germany_passports_in_text(text)
+    }
+
+    /// Validate German Reisepass format
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem::Validation` if the value is not a valid passport
+    /// number.
+    pub fn validate_germany_passport(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_germany_passport(value)
+    }
+
+    /// Validate German Reisepass including the ICAO Doc 9303 check digit
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem::Validation` if the format or check digit is invalid.
+    pub fn validate_germany_passport_with_checksum(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_germany_passport_with_checksum(value)
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/builder/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/mod.rs
@@ -58,6 +58,7 @@ mod brazil;
 mod cache;
 mod driver_license;
 mod europe;
+mod germany;
 mod india;
 mod korea;
 mod mexico;

--- a/crates/octarine/src/primitives/identifiers/government/common.rs
+++ b/crates/octarine/src/primitives/identifiers/government/common.rs
@@ -115,10 +115,166 @@ pub(super) fn is_test_ssn(ssn: &str) -> bool {
     false
 }
 
+/// ICAO Doc 9303 machine-readable-zone check-digit helpers.
+///
+/// Used by both German nPA (`GermanyIdCard`) and Reisepass
+/// (`GermanyPassport`), and reusable for any future ICAO-compliant national
+/// document number (Netherlands, France, …). Pure numeric helpers — no
+/// `Result`, no observe — so both detection and validation may consult them
+/// without violating the inheritance arrow.
+pub(super) mod icao_doc_9303 {
+    /// Repeating positional weights `7, 3, 1` per ICAO Doc 9303.
+    const WEIGHTS: [u32; 3] = [7, 3, 1];
+
+    /// Map a single MRZ character to its ICAO numeric value.
+    ///
+    /// Digits map to `0..=9`, letters `A..=Z` map to `10..=35`, and the
+    /// filler `<` maps to `0`. Returns `None` for any other character.
+    #[must_use]
+    pub(crate) fn char_value(c: char) -> Option<u32> {
+        match c {
+            '0'..='9' => c.to_digit(10),
+            'A'..='Z' => Some((c as u32).saturating_sub('A' as u32).saturating_add(10)),
+            'a'..='z' => Some((c as u32).saturating_sub('a' as u32).saturating_add(10)),
+            '<' => Some(0),
+            _ => None,
+        }
+    }
+
+    /// Compute the ICAO Doc 9303 check digit over `field`.
+    ///
+    /// Returns `None` if any character is outside the ICAO alphabet. The
+    /// result is the weighted sum modulo 10.
+    #[must_use]
+    pub(crate) fn check_digit(field: &str) -> Option<u32> {
+        let mut sum: u32 = 0;
+        for (i, c) in field.chars().enumerate() {
+            let value = char_value(c)?;
+            let weight = WEIGHTS.get(i % 3).copied().unwrap_or(1);
+            sum = sum.saturating_add(value.saturating_mul(weight));
+        }
+        Some(sum % 10)
+    }
+
+    /// Verify that the final character of `value` is the correct ICAO check
+    /// digit for the preceding `body_len` characters.
+    ///
+    /// `value` must be exactly `body_len + 1` characters long; the trailing
+    /// character is the check digit.
+    #[must_use]
+    pub(crate) fn verify(value: &str, body_len: usize) -> bool {
+        let chars: Vec<char> = value.chars().collect();
+        if chars.len() != body_len.saturating_add(1) {
+            return false;
+        }
+        let body: String = chars.iter().take(body_len).collect();
+        let Some(expected) = check_digit(&body) else {
+            return false;
+        };
+        let Some(actual) = chars.get(body_len).and_then(|c| c.to_digit(10)) else {
+            return false;
+        };
+        expected == actual
+    }
+}
+
+/// Germany Steuer-IdNr (ISO 7064 mod-11,10) check-digit helpers.
+///
+/// Shared by `detection::is_germany_tax_id` and
+/// `validation::validate_germany_tax_id_with_checksum`. Pure numeric — no
+/// `Result`, no observe.
+pub(super) mod germany_tax_id {
+    /// Verify the ISO 7064 mod-11,10 check digit over an 11-digit string.
+    ///
+    /// The first 10 digits feed the algorithm; the 11th is the check digit.
+    /// Returns `false` for any non-11-digit input or checksum mismatch.
+    #[must_use]
+    pub(crate) fn verify_checksum(digits: &str) -> bool {
+        let ds: Vec<u32> = digits.chars().filter_map(|c| c.to_digit(10)).collect();
+        if ds.len() != 11 {
+            return false;
+        }
+        // ISO 7064 mod 11,10: iterate over the first 10 digits.
+        let mut product: u32 = 10;
+        for &d in ds.iter().take(10) {
+            let mut sum = (d.saturating_add(product)) % 10;
+            if sum == 0 {
+                sum = 10;
+            }
+            product = (sum.saturating_mul(2)) % 11;
+        }
+        let check = (11u32.saturating_sub(product)) % 10;
+        ds.get(10).copied() == Some(check)
+    }
+
+    /// Verify the German structural rule for a Steuer-IdNr's first 10 digits.
+    ///
+    /// Among the first 10 digits exactly one digit appears more than once
+    /// (either twice, or — since 2016 — three times consecutively), and the
+    /// leading digit is non-zero. Digits appearing 4+ times, or two distinct
+    /// repeated digits, are invalid.
+    #[must_use]
+    pub(crate) fn verify_structure(digits: &str) -> bool {
+        let ds: Vec<u32> = digits.chars().filter_map(|c| c.to_digit(10)).collect();
+        if ds.len() != 11 {
+            return false;
+        }
+        if ds.first().copied() == Some(0) {
+            return false;
+        }
+        let mut counts = [0u8; 10];
+        for &d in ds.iter().take(10) {
+            if let Some(slot) = counts.get_mut(d as usize) {
+                *slot = slot.saturating_add(1);
+            }
+        }
+        let repeated = counts.iter().filter(|&&c| c >= 2).count();
+        let max_count = counts.iter().copied().max().unwrap_or(0);
+        // Exactly one digit repeats, and it repeats at most three times.
+        repeated == 1 && (2..=3).contains(&max_count)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
+
+    #[test]
+    fn test_icao_check_digit_known_vectors() {
+        // ICAO Doc 9303 canonical MRZ example: passport number "L898902C3"
+        // has published check digit 6.
+        assert_eq!(icao_doc_9303::check_digit("L898902C3"), Some(6));
+        // Date-of-birth field "740812" → check digit 2.
+        assert_eq!(icao_doc_9303::check_digit("740812"), Some(2));
+        // Expiry "120415" → check digit 9.
+        assert_eq!(icao_doc_9303::check_digit("120415"), Some(9));
+        // Non-ICAO character rejected.
+        assert_eq!(icao_doc_9303::check_digit("ABC!"), None);
+    }
+
+    #[test]
+    fn test_icao_verify() {
+        assert!(icao_doc_9303::verify("L898902C36", 9));
+        assert!(!icao_doc_9303::verify("L898902C35", 9)); // wrong check digit
+        assert!(!icao_doc_9303::verify("L898902C3", 9)); // too short
+    }
+
+    #[test]
+    fn test_germany_tax_id_structure_and_checksum() {
+        // 10002345676: first 10 digits 1000234567, digit '0' repeats 3×
+        // (exactly one repeated digit), leading digit non-zero, valid ISO
+        // 7064 mod-11,10 check digit 6.
+        assert!(germany_tax_id::verify_structure("10002345676"));
+        assert!(germany_tax_id::verify_checksum("10002345676"));
+        // Leading zero → invalid structure (BZSt doc examples like
+        // 02476291358 are deliberately non-issuable).
+        assert!(!germany_tax_id::verify_structure("02476291358"));
+        // Ascending, no repeats → invalid (no repeated digit).
+        assert!(!germany_tax_id::verify_structure("12345678905"));
+        // Tampered check digit → checksum fails.
+        assert!(!germany_tax_id::verify_checksum("10002345675"));
+    }
 
     #[test]
     fn test_is_itin_area() {

--- a/crates/octarine/src/primitives/identifiers/government/detection/germany.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/germany.rs
@@ -1,0 +1,294 @@
+//! German government-identifier detection — Steuer-IdNr (tax ID),
+//! Personalausweis (nPA / national ID card), and Reisepass (passport).
+//!
+//! `is_*` checks are precise: the tax ID verifies the ISO 7064 mod-11,10
+//! checksum plus the German structural rule, and the nPA/passport verify the
+//! ICAO Doc 9303 check digit. This keeps the aggregate dispatcher from
+//! misclassifying an arbitrary 11-digit run or 10-character token as a German
+//! identifier. Deep checksum re-verification with `Result` errors lives in
+//! `super::super::validation`.
+
+use super::super::super::common::patterns;
+use super::super::super::types::{IdentifierMatch, IdentifierType};
+use super::super::common::{germany_tax_id as tax_id_checks, icao_doc_9303};
+use super::helpers::{
+    MAX_IDENTIFIER_LENGTH, MAX_INPUT_LENGTH, deduplicate_matches, exceeds_safe_length,
+    get_full_match,
+};
+
+/// Length of the ICAO document-number body (before the check digit) for the
+/// German nPA and Reisepass.
+const ICAO_DOC_BODY_LEN: usize = 9;
+
+/// Extract just the digits from a value (drops spaces/grouping).
+fn digits_only(value: &str) -> String {
+    value.chars().filter(|c| c.is_ascii_digit()).collect()
+}
+
+/// Return the captured document number (group 1) if the pattern has one,
+/// else the full match. Labeled patterns capture the bare identifier in
+/// group 1 so checksum verification runs on the number, not the label.
+fn captured_id<'a>(capture: &regex::Captures<'a>, full: &regex::Match<'a>) -> String {
+    capture
+        .get(1)
+        .map_or_else(|| full.as_str().to_string(), |m| m.as_str().to_string())
+}
+
+// ============================================================================
+// Steuer-IdNr (tax identification number)
+// ============================================================================
+
+/// Check if a value is a valid German Steuer-IdNr.
+///
+/// Verifies the 11-digit shape, the ISO 7064 mod-11,10 check digit, and the
+/// German structural rule (exactly one repeated digit among the first ten,
+/// non-zero leading digit).
+#[must_use]
+pub fn is_germany_tax_id(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    if !patterns::germany_tax_id::all()
+        .iter()
+        .any(|p| p.is_match(value))
+    {
+        return false;
+    }
+    let digits = digits_only(value);
+    tax_id_checks::verify_structure(&digits) && tax_id_checks::verify_checksum(&digits)
+}
+
+/// Find all German Steuer-IdNr matches in text.
+///
+/// Label-anchored only: a bare 11-digit run collides with Nigeria NIN/BVN and
+/// Italy VAT, so scanning requires a surrounding German/tax label.
+#[must_use]
+pub fn find_germany_tax_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::germany_tax_id::labeled_only() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            let digits = digits_only(full_match.as_str());
+            if tax_id_checks::verify_structure(&digits) && tax_id_checks::verify_checksum(&digits) {
+                matches.push(IdentifierMatch::high_confidence(
+                    full_match.start(),
+                    full_match.end(),
+                    full_match.as_str().to_string(),
+                    IdentifierType::GermanyTaxId,
+                ));
+            }
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+// ============================================================================
+// Personalausweis (nPA / national ID card)
+// ============================================================================
+
+/// Check if a value is a valid German Personalausweis (nPA) number.
+///
+/// Verifies the 9-character document body plus ICAO Doc 9303 check digit.
+#[must_use]
+pub fn is_germany_id_card(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    if !patterns::germany_id_card::all()
+        .iter()
+        .any(|p| p.is_match(value))
+    {
+        return false;
+    }
+    icao_doc_9303::verify(&value.to_uppercase(), ICAO_DOC_BODY_LEN)
+}
+
+/// Find all German Personalausweis matches in text.
+///
+/// Label-anchored only: the bare 10-character alphanumeric shape collides with
+/// the German passport and other document numbers.
+#[must_use]
+pub fn find_germany_id_cards_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::germany_id_card::labeled_only() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            let id = captured_id(&capture, &full_match);
+            if icao_doc_9303::verify(&id.to_uppercase(), ICAO_DOC_BODY_LEN) {
+                matches.push(IdentifierMatch::high_confidence(
+                    full_match.start(),
+                    full_match.end(),
+                    full_match.as_str().to_string(),
+                    IdentifierType::GermanyIdCard,
+                ));
+            }
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+// ============================================================================
+// Reisepass (passport)
+// ============================================================================
+
+/// Check if a value is a valid German Reisepass (passport) number.
+///
+/// Verifies the 9-character document body plus ICAO Doc 9303 check digit,
+/// using the same reduced alphabet as the nPA.
+#[must_use]
+pub fn is_germany_passport(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    if !patterns::germany_passport::all()
+        .iter()
+        .any(|p| p.is_match(value))
+    {
+        return false;
+    }
+    icao_doc_9303::verify(&value.to_uppercase(), ICAO_DOC_BODY_LEN)
+}
+
+/// Find all German Reisepass matches in text.
+///
+/// Label-anchored only: the bare 10-character alphanumeric shape collides with
+/// the German nPA and other document numbers.
+#[must_use]
+pub fn find_germany_passports_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::germany_passport::labeled_only() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            let id = captured_id(&capture, &full_match);
+            if icao_doc_9303::verify(&id.to_uppercase(), ICAO_DOC_BODY_LEN) {
+                matches.push(IdentifierMatch::high_confidence(
+                    full_match.start(),
+                    full_match.end(),
+                    full_match.as_str().to_string(),
+                    IdentifierType::GermanyPassport,
+                ));
+            }
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    // 10002345676: valid ISO 7064 mod-11,10 checksum, digit '0' repeats 3×,
+    // non-zero leading digit.
+    const VALID_TAX_ID: &str = "10002345676";
+    // ICAO Doc 9303 document numbers with valid check digit and the German
+    // reduced alphabet (excludes A,B,D,E,I,O,Q,S,U).
+    const VALID_ID_CARD: &str = "CH20064148";
+    const VALID_PASSPORT: &str = "T220001293";
+
+    // ----- Steuer-IdNr -----
+
+    #[test]
+    fn test_is_germany_tax_id_valid() {
+        assert!(is_germany_tax_id(VALID_TAX_ID));
+    }
+
+    #[test]
+    fn test_is_germany_tax_id_rejects_bad_checksum() {
+        assert!(!is_germany_tax_id("10002345675"));
+    }
+
+    #[test]
+    fn test_is_germany_tax_id_rejects_leading_zero() {
+        // BZSt documentation example — deliberately non-issuable.
+        assert!(!is_germany_tax_id("02476291358"));
+    }
+
+    #[test]
+    fn test_is_germany_tax_id_rejects_wrong_length() {
+        assert!(!is_germany_tax_id("1000234567"));
+        assert!(!is_germany_tax_id("100023456760"));
+    }
+
+    #[test]
+    fn test_find_germany_tax_ids_requires_label() {
+        let labeled = find_germany_tax_ids_in_text(&format!("Steuer-IdNr: {VALID_TAX_ID}"));
+        assert_eq!(labeled.len(), 1);
+        assert_eq!(
+            labeled.first().expect("one match").identifier_type,
+            IdentifierType::GermanyTaxId
+        );
+        // Bare, unlabeled → not scanned.
+        let bare = find_germany_tax_ids_in_text(&format!("value {VALID_TAX_ID} here"));
+        assert!(bare.is_empty());
+    }
+
+    // ----- Personalausweis (nPA) -----
+
+    #[test]
+    fn test_is_germany_id_card_valid() {
+        assert!(is_germany_id_card(VALID_ID_CARD));
+    }
+
+    #[test]
+    fn test_is_germany_id_card_rejects_bad_check_digit() {
+        assert!(!is_germany_id_card("CH20064149"));
+    }
+
+    #[test]
+    fn test_find_germany_id_cards_requires_label() {
+        let labeled = find_germany_id_cards_in_text(&format!("Personalausweis {VALID_ID_CARD}"));
+        assert_eq!(labeled.len(), 1);
+        assert_eq!(
+            labeled.first().expect("one match").identifier_type,
+            IdentifierType::GermanyIdCard
+        );
+    }
+
+    // ----- Reisepass -----
+
+    #[test]
+    fn test_is_germany_passport_valid() {
+        assert!(is_germany_passport(VALID_PASSPORT));
+    }
+
+    #[test]
+    fn test_is_germany_passport_rejects_bad_check_digit() {
+        assert!(!is_germany_passport("T220001294"));
+    }
+
+    #[test]
+    fn test_find_germany_passports_requires_label() {
+        let labeled = find_germany_passports_in_text(&format!("Reisepass {VALID_PASSPORT}"));
+        assert_eq!(labeled.len(), 1);
+        assert_eq!(
+            labeled.first().expect("one match").identifier_type,
+            IdentifierType::GermanyPassport
+        );
+    }
+
+    #[test]
+    fn test_empty_input() {
+        assert!(!is_germany_tax_id(""));
+        assert!(!is_germany_id_card(""));
+        assert!(!is_germany_passport(""));
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
@@ -47,6 +47,7 @@ mod australia;
 mod brazil;
 mod driver_license;
 mod europe;
+mod germany;
 mod helpers;
 mod india;
 mod itin;
@@ -84,6 +85,10 @@ pub use europe::{
     find_uk_nhs_in_text, find_uk_passports_in_text, is_finland_hetu, is_italy_driver_license,
     is_italy_fiscal_code, is_italy_identity_card, is_italy_passport, is_italy_vat, is_poland_pesel,
     is_spain_nie, is_spain_nif, is_uk_driving_licence, is_uk_nhs, is_uk_passport,
+};
+pub use germany::{
+    find_germany_id_cards_in_text, find_germany_passports_in_text, find_germany_tax_ids_in_text,
+    is_germany_id_card, is_germany_passport, is_germany_tax_id,
 };
 pub use india::{
     find_india_aadhaars_in_text, find_india_gstins_in_text, find_india_pans_in_text,
@@ -211,6 +216,14 @@ pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
         Some(IdentifierType::SwedenPersonnummer)
     } else if is_sweden_orgnummer(value) {
         Some(IdentifierType::SwedenOrgnummer)
+    } else if is_germany_tax_id(value) {
+        // Checksum + structure verified, so a bare 11-digit value only
+        // reaches here if it is a genuine Steuer-IdNr.
+        Some(IdentifierType::GermanyTaxId)
+    } else if is_germany_id_card(value) {
+        Some(IdentifierType::GermanyIdCard)
+    } else if is_germany_passport(value) {
+        Some(IdentifierType::GermanyPassport)
     } else if is_italy_fiscal_code(value) {
         Some(IdentifierType::ItalyFiscalCode)
     } else if is_spain_nif(value) {
@@ -294,6 +307,9 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
     all_matches.extend(find_poland_pesels_in_text(text));
     all_matches.extend(find_sweden_personnummers_in_text(text));
     all_matches.extend(find_sweden_orgnummers_in_text(text));
+    all_matches.extend(find_germany_tax_ids_in_text(text));
+    all_matches.extend(find_germany_id_cards_in_text(text));
+    all_matches.extend(find_germany_passports_in_text(text));
     all_matches.extend(find_italy_fiscal_codes_in_text(text));
     all_matches.extend(find_italy_vats_in_text(text));
     all_matches.extend(find_italy_passports_in_text(text));

--- a/crates/octarine/src/primitives/identifiers/government/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/mod.rs
@@ -118,8 +118,8 @@ pub use validation::{clear_government_caches, ssn_cache_stats, vin_cache_stats};
 // Export test pattern detection functions (observe module testing)
 pub use validation::{
     is_test_australia_abn, is_test_australia_tfn, is_test_brazil_cnpj, is_test_brazil_cpf,
-    is_test_driver_license, is_test_ein, is_test_finland_hetu, is_test_india_aadhaar,
-    is_test_india_gstin, is_test_india_pan, is_test_india_passport,
+    is_test_driver_license, is_test_ein, is_test_finland_hetu, is_test_germany_tax_id,
+    is_test_india_aadhaar, is_test_india_gstin, is_test_india_pan, is_test_india_passport,
     is_test_india_vehicle_registration, is_test_india_voter_id, is_test_italy_driver_license,
     is_test_italy_fiscal_code, is_test_italy_identity_card, is_test_italy_passport,
     is_test_italy_vat, is_test_korea_rrn, is_test_mexico_curp, is_test_nigeria_nin,
@@ -142,6 +142,13 @@ pub use validation::{
 
 // Export Finland validation functions
 pub use validation::{validate_finland_hetu, validate_finland_hetu_with_checksum};
+
+// Export Germany validation functions
+pub use validation::{
+    validate_germany_id_card, validate_germany_id_card_with_checksum, validate_germany_passport,
+    validate_germany_passport_with_checksum, validate_germany_tax_id,
+    validate_germany_tax_id_with_checksum,
+};
 
 // Export Poland validation functions
 pub use validation::{validate_poland_pesel, validate_poland_pesel_with_checksum};

--- a/crates/octarine/src/primitives/identifiers/government/validation/germany.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/germany.rs
@@ -1,0 +1,243 @@
+//! German government-identifier validation — Steuer-IdNr (tax ID),
+//! Personalausweis (nPA), and Reisepass (passport).
+//!
+//! Format validators check shape and reject empty input; the
+//! `*_with_checksum` variants additionally verify the ISO 7064 mod-11,10
+//! (tax ID) or ICAO Doc 9303 (nPA/passport) check digit. Each validator calls
+//! detection first, honoring the inheritance arrow.
+
+use super::super::common::{germany_tax_id as tax_id_checks, icao_doc_9303};
+use super::super::detection;
+use crate::primitives::types::Problem;
+
+/// Length of the ICAO document-number body (before the check digit).
+const ICAO_DOC_BODY_LEN: usize = 9;
+
+// ============================================================================
+// Steuer-IdNr
+// ============================================================================
+
+/// Validate German Steuer-IdNr format (11 digits, structural + checksum rules).
+///
+/// Because the Steuer-IdNr's validity is defined by its checksum and
+/// structural rule, this format check is equivalent to full validation:
+/// `is_germany_tax_id` already enforces both.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the value is not a valid Steuer-IdNr.
+pub fn validate_germany_tax_id(value: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation(
+            "Germany Steuer-IdNr cannot be empty".to_string(),
+        ));
+    }
+    if !detection::is_germany_tax_id(trimmed) {
+        return Err(Problem::Validation(
+            "Invalid Germany Steuer-IdNr format".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate German Steuer-IdNr with explicit ISO 7064 mod-11,10 checksum.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format, structural rule, or checksum
+/// is invalid.
+pub fn validate_germany_tax_id_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_germany_tax_id(value)?;
+
+    let digits: String = value.chars().filter(|c| c.is_ascii_digit()).collect();
+    if !tax_id_checks::verify_structure(&digits) {
+        return Err(Problem::Validation(
+            "Germany Steuer-IdNr structural rule failed (expected exactly one repeated digit)"
+                .to_string(),
+        ));
+    }
+    if !tax_id_checks::verify_checksum(&digits) {
+        return Err(Problem::Validation(
+            "Germany Steuer-IdNr ISO 7064 mod-11,10 checksum failed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Check if a value is a well-known test/dummy Steuer-IdNr.
+///
+/// The BZSt documentation number `02476291358` (leading-zero, not issuable)
+/// and repeated-digit placeholders are treated as test patterns.
+#[must_use]
+pub fn is_test_germany_tax_id(value: &str) -> bool {
+    let digits: String = value.chars().filter(|c| c.is_ascii_digit()).collect();
+    if digits.len() != 11 {
+        return false;
+    }
+    // Documentation example, and any leading-zero value (non-issuable).
+    if digits.starts_with('0') {
+        return true;
+    }
+    // All-same or trivially sequential leading run.
+    let bytes = digits.as_bytes();
+    let first = bytes.first().copied();
+    if first.is_some() && bytes.iter().all(|&b| Some(b) == first) {
+        return true;
+    }
+    false
+}
+
+// ============================================================================
+// Personalausweis (nPA)
+// ============================================================================
+
+/// Validate German Personalausweis (nPA) format.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the value is not a valid nPA number.
+pub fn validate_germany_id_card(value: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation(
+            "Germany Personalausweis cannot be empty".to_string(),
+        ));
+    }
+    if !detection::is_germany_id_card(trimmed) {
+        return Err(Problem::Validation(
+            "Invalid Germany Personalausweis format".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate German Personalausweis with explicit ICAO Doc 9303 check digit.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format or check digit is invalid.
+pub fn validate_germany_id_card_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_germany_id_card(value)?;
+    if !icao_doc_9303::verify(&value.trim().to_uppercase(), ICAO_DOC_BODY_LEN) {
+        return Err(Problem::Validation(
+            "Germany Personalausweis ICAO Doc 9303 check digit failed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Reisepass (passport)
+// ============================================================================
+
+/// Validate German Reisepass (passport) format.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the value is not a valid passport number.
+pub fn validate_germany_passport(value: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation(
+            "Germany Reisepass cannot be empty".to_string(),
+        ));
+    }
+    if !detection::is_germany_passport(trimmed) {
+        return Err(Problem::Validation(
+            "Invalid Germany Reisepass format".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate German Reisepass with explicit ICAO Doc 9303 check digit.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the format or check digit is invalid.
+pub fn validate_germany_passport_with_checksum(value: &str) -> Result<(), Problem> {
+    validate_germany_passport(value)?;
+    if !icao_doc_9303::verify(&value.trim().to_uppercase(), ICAO_DOC_BODY_LEN) {
+        return Err(Problem::Validation(
+            "Germany Reisepass ICAO Doc 9303 check digit failed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    const VALID_TAX_ID: &str = "10002345676";
+    const VALID_ID_CARD: &str = "CH20064148";
+    const VALID_PASSPORT: &str = "T220001293";
+
+    // ----- Steuer-IdNr -----
+
+    #[test]
+    fn test_validate_germany_tax_id_valid() {
+        assert!(validate_germany_tax_id(VALID_TAX_ID).is_ok());
+        assert!(validate_germany_tax_id_with_checksum(VALID_TAX_ID).is_ok());
+    }
+
+    #[test]
+    fn test_validate_germany_tax_id_empty() {
+        assert!(validate_germany_tax_id("").is_err());
+    }
+
+    #[test]
+    fn test_validate_germany_tax_id_bad_checksum() {
+        assert!(validate_germany_tax_id_with_checksum("10002345675").is_err());
+    }
+
+    #[test]
+    fn test_validate_germany_tax_id_wrong_length() {
+        assert!(validate_germany_tax_id("1000234567").is_err());
+    }
+
+    #[test]
+    fn test_is_test_germany_tax_id() {
+        assert!(is_test_germany_tax_id("02476291358")); // doc example
+        assert!(is_test_germany_tax_id("11111111111")); // all same
+        assert!(!is_test_germany_tax_id(VALID_TAX_ID));
+    }
+
+    // ----- Personalausweis -----
+
+    #[test]
+    fn test_validate_germany_id_card_valid() {
+        assert!(validate_germany_id_card(VALID_ID_CARD).is_ok());
+        assert!(validate_germany_id_card_with_checksum(VALID_ID_CARD).is_ok());
+    }
+
+    #[test]
+    fn test_validate_germany_id_card_bad_check_digit() {
+        assert!(validate_germany_id_card_with_checksum("CH20064149").is_err());
+    }
+
+    #[test]
+    fn test_validate_germany_id_card_empty() {
+        assert!(validate_germany_id_card("").is_err());
+    }
+
+    // ----- Reisepass -----
+
+    #[test]
+    fn test_validate_germany_passport_valid() {
+        assert!(validate_germany_passport(VALID_PASSPORT).is_ok());
+        assert!(validate_germany_passport_with_checksum(VALID_PASSPORT).is_ok());
+    }
+
+    #[test]
+    fn test_validate_germany_passport_bad_check_digit() {
+        assert!(validate_germany_passport_with_checksum("T220001294").is_err());
+    }
+
+    #[test]
+    fn test_validate_germany_passport_empty() {
+        assert!(validate_germany_passport("").is_err());
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
@@ -42,6 +42,7 @@ mod cache;
 mod driver_license;
 mod ein;
 mod finland;
+mod germany;
 mod india;
 mod italy;
 mod itin;
@@ -104,6 +105,13 @@ pub use finland::{
 // Re-export Poland functions
 pub use poland::{
     is_test_poland_pesel, validate_poland_pesel, validate_poland_pesel_with_checksum,
+};
+
+// Re-export Germany functions
+pub use germany::{
+    is_test_germany_tax_id, validate_germany_id_card, validate_germany_id_card_with_checksum,
+    validate_germany_passport, validate_germany_passport_with_checksum, validate_germany_tax_id,
+    validate_germany_tax_id_with_checksum,
 };
 
 // Re-export Italy functions

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -490,6 +490,18 @@ impl StreamingScanner {
                 GovernmentIdentifierBuilder::find_sweden_orgnummers_in_text,
             ),
             (
+                |t| matches!(t, IdentifierType::GermanyTaxId),
+                GovernmentIdentifierBuilder::find_germany_tax_ids_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::GermanyIdCard),
+                GovernmentIdentifierBuilder::find_germany_id_cards_in_text,
+            ),
+            (
+                |t| matches!(t, IdentifierType::GermanyPassport),
+                GovernmentIdentifierBuilder::find_germany_passports_in_text,
+            ),
+            (
                 |t| matches!(t, IdentifierType::VehicleId),
                 GovernmentIdentifierBuilder::find_vehicle_ids_in_text,
             ),

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -110,6 +110,9 @@ pub enum IdentifierType {
     UkDrivingLicence,   // UK DVLA Driving Licence (16-char DVLA structural format)
     SwedenPersonnummer, // Swedish personal identity number (YYMMDD/YYYYMMDD + NNN + Luhn)
     SwedenOrgnummer,    // Swedish organisationsnummer (10 digits, third digit >= 2, Luhn)
+    GermanyTaxId,       // German Steuer-IdNr (11 digits, ISO 7064 mod-11,10 + structural rule)
+    GermanyIdCard,      // German Personalausweis / nPA (ICAO Doc 9303 check digit)
+    GermanyPassport,    // German Reisepass (ICAO Doc 9303 check digit)
 
     // Organizational identifiers
     EmployeeId,


### PR DESCRIPTION
## Summary

Adds the three highest-value German government identifiers (Presidio parity gap CRIT-9), taking octarine from **zero** German coverage to end-to-end detection, validation, both builder layers, shortcuts, and PII scanning/redaction:

- **`GermanyTaxId`** (Steuer-IdNr) — 11 digits, ISO 7064 mod-11,10 checksum + German structural rule (exactly one repeated digit among the first ten, non-zero leading digit).
- **`GermanyIdCard`** (Personalausweis / nPA) and **`GermanyPassport`** (Reisepass) — ICAO Doc 9303 check digit (weights 7-3-1) over the reduced document-number alphabet excluding `A,B,D,E,I,O,Q,S,U`.

A shared **`icao_doc_9303::check_digit`** helper in `government/common.rs` makes future ICAO-compliant national passports (NL, FR, …) cheap to add.

All three PII registries stay in lockstep: `IdentifierType`, `PiiType` (+ `name()`/`domain()`), the no-wildcard `From<IdentifierType>` mapping, `scanner/domains.rs`, the redactor, and the streaming FINDERS table. The new types are classified **high-risk + GDPR-protected** (DSGVO §§ 139a-139e AO / BDSG). Label-anchored text scanning avoids collisions with Nigeria NIN/BVN and Italy VAT (bare 11-digit) and between the nPA and passport (bare 10-char).

## Scope

Per the issue's recommended 2-PR phasing, this delivers the **core three**. The remaining nine German recognizers (`DriverLicense`, `VatId`, `TaxNumber`, `SocialSecurity`, `HealthInsurance`, `Bsnr`, `Lanr`, `Handelsregister`, `Kfz`) are tracked in **#668**.

## Test plan

- 31 new unit tests (detection, validation with valid + tampered-checksum + wrong-length + test-pattern cases, both builder layers with silent+events, shortcuts). Checksum vectors verified against the ISO 7064 / ICAO algorithms.
- PII bridge round-trip assertions extended (`PiiType::from(IdentifierType::Germany*)`, `.name()`, GDPR classification).
- Full workspace suite green: **8348 tests passed, 0 failed**.
- `just clippy` (`-D warnings`), `just arch-check`, `just doc` (strict) all clean.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)