### PR TITLE
fix(claude): correct stale paths in three audit agents

### DIFF
--- a/.claude/agents/audit-octarine-identifiers/audit-octarine-identifiers.md
+++ b/.claude/agents/audit-octarine-identifiers/audit-octarine-identifiers.md
@@ -48,7 +48,7 @@ partial error.
 3. Sanitization fn  primitives/identifiers/{domain}/sanitization/ sanitize_{type}() or redact_{type}()
 4. Prim builder     primitives/identifiers/{domain}/builder/      delegation methods
 5. Public builder   identifiers/builder/{domain}.rs               wrapped methods + observe
-6. Shortcuts        identifiers/shortcuts.rs                      convenience functions
+6. Shortcuts        identifiers/shortcuts/                        convenience functions
 ```
 
 ## Workflow
@@ -104,7 +104,7 @@ For common operations, check shortcuts:
 
 ```text
 Grep pattern="fn is_{type}\|fn validate_{type}\|fn redact_{type}" \
-  path="crates/octarine/src/identifiers/shortcuts.rs"
+  path="crates/octarine/src/identifiers/shortcuts/"
 ```
 
 ### octarine-identifiers/incomplete-dual-api (severity: medium)

--- a/.claude/agents/audit-octarine-observe/audit-octarine-observe.md
+++ b/.claude/agents/audit-octarine-observe/audit-octarine-observe.md
@@ -43,7 +43,7 @@ When invoked, you receive a work manifest in the task prompt containing:
 Every builder in these directories wraps primitives with observe:
 
 - `crates/octarine/src/identifiers/builder/`
-- `crates/octarine/src/data/*/builder/`
+- `crates/octarine/src/data/*/builder*`
 - `crates/octarine/src/security/*/builder*`
 - `crates/octarine/src/crypto/*/builder*`
 

--- a/.claude/agents/audit-octarine-pii-sync/audit-octarine-pii-sync.md
+++ b/.claude/agents/audit-octarine-pii-sync/audit-octarine-pii-sync.md
@@ -35,17 +35,31 @@ MUST NOT:
 
 | Registry | File | Role |
 |----------|------|------|
-| `IdentifierType` | `crates/octarine/src/primitives/identifiers/types.rs` | Primitives-level enum (source of truth) |
-| `PiiType` | `crates/octarine/src/observe/pii/types.rs` | PII classification enum |
+| `IdentifierType` | `crates/octarine/src/primitives/identifiers/types/core.rs` | Primitives-level enum (source of truth) |
+| `PiiType` | `crates/octarine/src/observe/pii/types/mod.rs` | PII classification enum |
 | Scanner domains | `crates/octarine/src/observe/pii/scanner/domains.rs` | Detection dispatch |
+
+Both `types/` entries are directories that may re-split in future refactors.
+To stay robust against a move without misreading sibling enums, **locate the
+enum by its declaration, then read only that block** — grep the whole `types/`
+directory for `pub enum IdentifierType` / `pub enum PiiType` to find the file,
+then extract variants from between that `{` and its matching `}`. Do NOT scan
+every capitalized line across the directory: `types/` holds other public enums
+(`CreditCardType`, `CryptoAddressType`, `PhoneRegion`, `CredentialType`,
+`DetectionConfidence`), and a blanket capitalized-token grep would fold their
+variants into the `IdentifierType` set and produce false `missing-pii-variant`
+findings.
 
 ## Workflow
 
 1. Parse the manifest from the task prompt
-2. Verify all three registry files exist. If any missing, return a critical
+2. Verify all three registries resolve (the `types/` directories exist and the
+   `scanner/domains.rs` file exists). If any missing, return a critical
    finding with category `octarine-pii-sync/registry-not-found` and stop
-3. Read `primitives/identifiers/types.rs` and extract `IdentifierType` variants
-4. Read `observe/pii/types.rs` and extract `PiiType` variants
+3. Read `primitives/identifiers/types/core.rs` (scan the `types/` directory if
+   the enum has moved) and extract `IdentifierType` variants
+4. Read `observe/pii/types/mod.rs` (scan the `types/` directory if the enum has
+   moved) and extract `PiiType` variants
 5. Compare variant sets — every `IdentifierType` should have a `PiiType`
 6. Read `observe/pii/scanner/domains.rs` and extract builder method calls
 7. Cross-reference scanner calls against identifier builder methods


### PR DESCRIPTION
## Summary

Fixes the three stale-path findings in #406. After source-tree refactors split
single `.rs` files into directories, three `audit-octarine-*` agents referenced
paths that no longer exist:

- **pii-sync** (`ai-config-001`): `types.rs` files are now `types/` directories.
  The registry-exists guard was returning a spurious critical
  `registry-not-found` finding **every run** and skipping all sync analysis.
  Now points at `types/core.rs` and `types/mod.rs`, and locates the enum by its
  `pub enum` declaration (not a blanket capitalized-token grep, which would fold
  sibling enums' variants into the set).
- **identifiers** (`ai-config-002`): `identifiers/shortcuts.rs` is now a
  14-module `shortcuts/` directory, so the `missing-shortcut` grep never
  matched. Rule + chain table now point at `shortcuts/`.
- **observe** (`ai-config-007`): `data/*/builder/` (trailing slash) only matched
  the one `data/paths/builder/` directory; the other three data builders are
  `builder.rs` files. Now `data/*/builder*`, consistent with the pre-existing
  `security/*/builder*` and `crypto/*/builder*` entries.

## Test plan

- `just fmt-check` — clean.
- Path existence verified on disk: the new targets (`types/core.rs`,
  `types/mod.rs`, `shortcuts/`, `data/*/builder*`) all resolve; the old paths do
  not.
- pre-push `cargo clippy --workspace --all-features -D warnings` + `cargo test
  --workspace` — green.

## Scope note

Kept deliberately to the three findings enumerated in #406. An adversarial
pre-PR review (3 cycles) surfaced a **broader, pre-existing** class of
layout-brittle grep paths in these and sibling agents — the `missing-validation`
/ `missing-builder-method` / `missing-public-builder-method` /
`inheritance-arrow-violation` rules assume one layout, and the correct
layout-agnostic fix is the `path=<dir> glob=<pattern>` convention (a `*` in a
Grep `path` arg does **not** expand). That is a real convention change spanning
multiple agents plus two CRITICAL skill docs that still reference the old paths,
so it is tracked as a scoped follow-up in **#670** rather than expanded into
this trivial fix.

> [!NOTE]
> The pre-PR review loop reached its cycle cap without going fully clean — the
> two remaining HIGH findings are the pre-existing out-of-scope paths now
> tracked in #670 (they are not touched or regressed by this diff). Flagging for
> a human merge decision rather than auto-merging.

Closes #406