### PR TITLE
feat(identifiers): add US Medicare Beneficiary Identifier (MBI)

### DIFF
--- a/crates/octarine/src/identifiers/builder/government/mod.rs
+++ b/crates/octarine/src/identifiers/builder/government/mod.rs
@@ -54,6 +54,7 @@ mod test_patterns;
 mod thailand;
 mod turkey;
 mod uk;
+mod us_mbi;
 mod vehicle_id;
 
 crate::define_metrics! {

--- a/crates/octarine/src/identifiers/builder/government/us_mbi.rs
+++ b/crates/octarine/src/identifiers/builder/government/us_mbi.rs
@@ -1,0 +1,118 @@
+//! US Medicare Beneficiary Identifier (MBI) methods.
+
+use super::*;
+
+impl GovernmentBuilder {
+    /// Check if value is a valid US Medicare Beneficiary Identifier (MBI)
+    ///
+    /// Strict — enforces the 11-character CMS layout
+    /// (`C A AN N A AN N A A N N`) and the letter alphabet
+    /// `ACDEFGHJKMNPQRTUVWXY` (excluding `S, L, O, I, B, Z`). Accepts both the
+    /// bare and dashed `XXXX-XXX-XXXX` forms.
+    #[must_use]
+    pub fn is_us_mbi(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_us_mbi(value);
+
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+                observe::debug("mbi_detected", "MBI pattern detected");
+            }
+        }
+
+        result
+    }
+
+    /// Find all valid US MBIs in text
+    #[must_use]
+    pub fn find_us_mbis_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let results = self.inner.find_us_mbis_in_text(text);
+
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !results.is_empty() {
+                increment_by(metric_names::detected(), results.len() as u64);
+                observe::debug(
+                    "mbis_found",
+                    format!("Found {} MBI(s) in text", results.len()),
+                );
+            }
+        }
+
+        results
+    }
+
+    /// Validate a US MBI format
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the MBI length, dash grouping, positional layout,
+    /// or letter alphabet is invalid.
+    pub fn validate_us_mbi(&self, mbi: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_us_mbi(mbi);
+
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn("mbi_validation_failed", "Invalid MBI format");
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+    use crate::identifiers::types::IdentifierType;
+
+    // Valid CMS-shaped MBI (Presidio's documented sample). "1AB2C3D4EF5" from
+    // the issue is deliberately invalid (excluded letter 'B' at pos 3, and 'F'
+    // must be numeric at pos 10).
+    const VALID_MBI: &str = "1EG4TE5MK73";
+    const VALID_MBI_DASHED: &str = "1EG4-TE5-MK73";
+    const INVALID_MBI: &str = "1AB2C3D4EF5";
+
+    #[test]
+    fn test_is_us_mbi_valid_invalid() {
+        let b = GovernmentBuilder::silent();
+        assert!(b.is_us_mbi(VALID_MBI));
+        assert!(b.is_us_mbi(VALID_MBI_DASHED));
+        assert!(!b.is_us_mbi(INVALID_MBI));
+    }
+
+    #[test]
+    fn test_find_us_mbis_in_text() {
+        let b = GovernmentBuilder::silent();
+        let matches = b.find_us_mbis_in_text("Medicare MBI: 1EG4-TE5-MK73 on file");
+        assert!(!matches.is_empty());
+        assert_eq!(
+            matches.first().expect("one match").identifier_type,
+            IdentifierType::Mbi
+        );
+        assert!(b.find_us_mbis_in_text("no mbi here").is_empty());
+    }
+
+    #[test]
+    fn test_validate_us_mbi() {
+        let b = GovernmentBuilder::silent();
+        assert!(b.validate_us_mbi(VALID_MBI).is_ok());
+        assert!(b.validate_us_mbi(INVALID_MBI).is_err());
+    }
+}

--- a/crates/octarine/src/identifiers/shortcuts/government.rs
+++ b/crates/octarine/src/identifiers/shortcuts/government.rs
@@ -92,6 +92,36 @@ pub fn validate_itin(itin: &str) -> Result<(), Problem> {
 }
 
 // =============================================================================
+// US MBI (Medicare Beneficiary Identifier)
+// =============================================================================
+
+/// Check if value is a valid US Medicare Beneficiary Identifier (MBI)
+///
+/// Strict — enforces the 11-character CMS layout and the letter alphabet
+/// `ACDEFGHJKMNPQRTUVWXY` (excluding `S, L, O, I, B, Z`). Accepts both the bare
+/// and dashed `XXXX-XXX-XXXX` forms.
+#[must_use]
+pub fn is_us_mbi(value: &str) -> bool {
+    GovernmentBuilder::new().is_us_mbi(value)
+}
+
+/// Find all valid US MBIs in text
+#[must_use]
+pub fn find_us_mbis(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_us_mbis_in_text(text)
+}
+
+/// Validate a US MBI format
+///
+/// # Errors
+///
+/// Returns `Problem` if the MBI length, dash grouping, positional layout, or
+/// letter alphabet is invalid.
+pub fn validate_us_mbi(mbi: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_us_mbi(mbi)
+}
+
+// =============================================================================
 // Singapore UEN
 // =============================================================================
 
@@ -682,6 +712,16 @@ mod tests {
         // Invalid SSN (all zeros area)
         assert!(validate_ssn("000-00-0000").is_err());
         assert!(validate_ssn("not-an-ssn").is_err());
+    }
+
+    #[test]
+    fn test_us_mbi_shortcuts() {
+        assert!(is_us_mbi("1EG4TE5MK73"));
+        assert!(is_us_mbi("1EG4-TE5-MK73"));
+        assert!(!is_us_mbi("1AB2C3D4EF5")); // excluded letter / bad layout
+        assert!(validate_us_mbi("1EG4TE5MK73").is_ok());
+        assert!(validate_us_mbi("").is_err());
+        assert!(!find_us_mbis("Medicare MBI: 1EG4-TE5-MK73").is_empty());
     }
 
     #[test]

--- a/crates/octarine/src/observe/pii/redactor/government.rs
+++ b/crates/octarine/src/observe/pii/redactor/government.rs
@@ -115,6 +115,16 @@ mod tests {
     }
 
     #[test]
+    fn test_redact_government_ids_mbi_strict() {
+        // Issue #428: MBIs (Medicare PHI) must be scrubbed by the production
+        // redaction path, not just detected.
+        let text = "Patient MBI 1EG4-TE5-MK73 enrolled";
+        let result = redact_government_ids(text, RedactionProfile::ProductionStrict);
+        assert!(result.contains("[MBI]"));
+        assert!(!result.contains("1EG4-TE5-MK73"));
+    }
+
+    #[test]
     fn test_redact_government_ids_testing_unchanged() {
         let text = "VIN: 1HGBH41JXMN109186";
         let result = redact_government_ids(text, RedactionProfile::Testing);

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -167,6 +167,7 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             PiiType::Vin
             | PiiType::Ein
             | PiiType::Itin
+            | PiiType::Mbi
             | PiiType::TaxId
             | PiiType::NationalId
             | PiiType::KoreaRrn

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -102,6 +102,10 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
             PiiType::Itin,
         ),
         (
+            GovernmentIdentifierBuilder::find_us_mbis_in_text,
+            PiiType::Mbi,
+        ),
+        (
             GovernmentIdentifierBuilder::find_tax_ids_in_text,
             PiiType::TaxId,
         ),

--- a/crates/octarine/src/observe/pii/types/classification.rs
+++ b/crates/octarine/src/observe/pii/types/classification.rs
@@ -20,7 +20,7 @@ impl PiiType {
             Self::CreditCard | Self::BankAccount | Self::RoutingNumber | Self::PaymentToken |
             Self::Iban | Self::CryptoAddress |
             // Government (identity theft risk)
-            Self::Ssn | Self::DriverLicense | Self::Passport | Self::Ein | Self::Itin | Self::TaxId | Self::NationalId | Self::Vin |
+            Self::Ssn | Self::DriverLicense | Self::Passport | Self::Ein | Self::Itin | Self::Mbi | Self::TaxId | Self::NationalId | Self::Vin |
             Self::KoreaRrn | Self::KoreaFrn | Self::KoreaDriverLicense | Self::KoreaPassport | Self::KoreaBrn |
             Self::AustraliaTfn | Self::AustraliaAbn | Self::IndiaAadhaar | Self::IndiaPan |
             Self::IndiaGstin | Self::IndiaVehicleReg | Self::IndiaVoterId | Self::IndiaPassport |
@@ -121,6 +121,7 @@ impl PiiType {
                 | Self::DeaNumber
                 | Self::Ssn // SSN is also PHI in medical context
                 | Self::Itin // ITIN is also PHI in medical context (IRS-issued tax ID for patients)
+                | Self::Mbi // MBI is Medicare PHI — it appears on every claim/prescription/EHR field (mirrors UkNhs HIPAA-equivalent treatment)
                 | Self::Name // Names in medical context
                 | Self::Birthdate // DOB in medical context
                 | Self::Age // Age in medical context — HIPAA Safe Harbor requires aggregating > 89

--- a/crates/octarine/src/observe/pii/types/core.rs
+++ b/crates/octarine/src/observe/pii/types/core.rs
@@ -30,6 +30,7 @@ impl PiiType {
             Self::Vin => "vin",
             Self::Ein => "ein",
             Self::Itin => "itin",
+            Self::Mbi => "mbi",
             Self::TaxId => "tax_id",
             Self::NationalId => "national_id",
             Self::KoreaRrn => "korea_rrn",
@@ -190,6 +191,7 @@ impl PiiType {
             | Self::Vin
             | Self::Ein
             | Self::Itin
+            | Self::Mbi
             | Self::TaxId
             | Self::NationalId
             | Self::KoreaRrn

--- a/crates/octarine/src/observe/pii/types/mapping.rs
+++ b/crates/octarine/src/observe/pii/types/mapping.rs
@@ -77,6 +77,7 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::Passport => Self::Passport,
             IdentifierType::Ein => Self::Ein,
             IdentifierType::Itin => Self::Itin,
+            IdentifierType::Mbi => Self::Mbi,
             IdentifierType::TaxId => Self::TaxId,
             IdentifierType::NationalId => Self::NationalId,
             IdentifierType::KoreaRrn => Self::KoreaRrn,

--- a/crates/octarine/src/observe/pii/types/mod.rs
+++ b/crates/octarine/src/observe/pii/types/mod.rs
@@ -91,6 +91,8 @@ pub enum PiiType {
     Ein,
     /// US Individual Taxpayer Identification Number (area 9XX, IRS middle group 50-65/70-88/90-92/94-99)
     Itin,
+    /// US Medicare Beneficiary Identifier (11-char CMS layout, letters exclude S/L/O/I/B/Z; Medicare PHI)
+    Mbi,
     /// Tax ID (generic)
     TaxId,
     /// National ID number (non-US government identifiers)

--- a/crates/octarine/src/observe/pii/types/tests.rs
+++ b/crates/octarine/src/observe/pii/types/tests.rs
@@ -253,6 +253,16 @@ fn test_country_specific_government_classifications() {
         assert!(!pii.is_secret(), "{pii:?} not a secret");
     }
 
+    // MBI is a Medicare identifier: government domain, high-risk, and HIPAA
+    // PHI (mirrors UkNhs), but not GDPR/PCI/secret.
+    assert_eq!(PiiType::Mbi.domain(), "government");
+    assert!(PiiType::Mbi.is_high_risk());
+    assert!(PiiType::Mbi.is_hipaa_protected());
+    assert!(!PiiType::Mbi.is_gdpr_protected());
+    assert!(!PiiType::Mbi.is_pci_protected());
+    assert!(!PiiType::Mbi.is_secret());
+    assert_eq!(PiiType::Mbi.name(), "mbi");
+
     // Names follow the IdentifierType variant naming
     assert_eq!(PiiType::KoreaRrn.name(), "korea_rrn");
     assert_eq!(PiiType::ItalyFiscalCode.name(), "italy_fiscal_code");

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -42,7 +42,7 @@ pub(crate) use personal::{
     employee_id, finland_hetu, germany_id_card, germany_passport, germany_tax_id, india_aadhaar,
     india_gstin, india_pan, india_passport, india_vehicle_reg, india_voter_id,
     italy_driver_license, italy_fiscal_code, italy_identity_card, italy_passport, italy_vat,
-    korea_brn, korea_driver_license, korea_frn, korea_passport, korea_rrn, mexico_curp,
+    korea_brn, korea_driver_license, korea_frn, korea_passport, korea_rrn, mbi, mexico_curp,
     national_id, nigeria_bvn, nigeria_nin, nigeria_vehicle_reg, passport, personal_name,
     poland_pesel, singapore_nric, singapore_uen, spain_nie, spain_nif, ssn, student_id,
     sweden_orgnummer, sweden_personnummer, tax_id, thailand_tnin, turkey_license_plate,

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
@@ -44,4 +44,6 @@ pub(crate) use regional_identifiers::{
     sweden_personnummer, thailand_tnin, turkey_license_plate, turkey_tckn, uk_driving_licence,
     uk_nhs, uk_ni, uk_passport,
 };
-pub(crate) use us_identifiers::{driver_license, employee_id, passport, ssn, student_id, tax_id};
+pub(crate) use us_identifiers::{
+    driver_license, employee_id, mbi, passport, ssn, student_id, tax_id,
+};

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/us_identifiers.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/us_identifiers.rs
@@ -116,6 +116,61 @@ pub(crate) mod tax_id {
     }
 }
 
+/// Medicare Beneficiary Identifier (MBI) patterns
+///
+/// The MBI is an 11-character CMS identifier that replaced SSN-based HICNs on
+/// Medicare cards in 2018. Its structure is fixed (CMS "Understanding the New
+/// MBI"):
+///
+/// ```text
+/// Format:  C  A  AN  N  A  AN  N  A  A  N  N     (11 chars)
+/// Pos:     1  2   3  4  5   6  7  8  9 10 11
+///   C / N  (pos 1,4,7,10,11) = numeric 0-9
+///   A      (pos 2,5,8,9)     = letter from ACDEFGHJKMNPQRTUVWXY (excludes S,L,O,I,B,Z)
+///   AN     (pos 3,6)         = numeric OR that same restricted letter set
+/// ```
+///
+/// The excluded letters `S, L, O, I, B, Z` avoid visual confusion with digits
+/// (e.g. `O`/`0`, `I`/`1`). The dashed display form is `XXXX-XXX-XXXX`.
+pub(crate) mod mbi {
+    use super::*;
+
+    /// Valid MBI letter alphabet — A-Z excluding S, L, O, I, B, Z.
+    const ALPHA: &str = "[ACDEFGHJKMNPQRTUVWXY]";
+    /// Numeric position.
+    const NUM: &str = "[0-9]";
+    /// Alphanumeric position — digit or a valid MBI letter.
+    const ALPHANUM: &str = "[0-9ACDEFGHJKMNPQRTUVWXY]";
+
+    /// Bare 11-character MBI (weak confidence — no separators, collides with
+    /// arbitrary alphanumeric identifiers).
+    /// Example: `1EG4TE5MK73`
+    pub static NO_DASH: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(&format!(
+            r"\b{NUM}{ALPHA}{ALPHANUM}{NUM}{ALPHA}{ALPHANUM}{NUM}{ALPHA}{ALPHA}{NUM}{NUM}\b"
+        ))
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    /// Dashed MBI in the CMS display form `XXXX-XXX-XXXX` (medium confidence —
+    /// the layout is far more distinctive than the bare form).
+    /// Example: `1EG4-TE5-MK73`
+    pub static WITH_DASH: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(&format!(
+            r"\b{NUM}{ALPHA}{ALPHANUM}{NUM}-{ALPHA}{ALPHANUM}{NUM}-{ALPHA}{ALPHA}{NUM}{NUM}\b"
+        ))
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    /// Anchored exact-match form (bare or dashed) for the validator.
+    pub static EXACT: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(&format!(
+            r"^(?:{NUM}{ALPHA}{ALPHANUM}{NUM}{ALPHA}{ALPHANUM}{NUM}{ALPHA}{ALPHA}{NUM}{NUM}|{NUM}{ALPHA}{ALPHANUM}{NUM}-{ALPHA}{ALPHANUM}{NUM}-{ALPHA}{ALPHA}{NUM}{NUM})$"
+        ))
+        .expect("BUG: Invalid regex pattern")
+    });
+}
+
 /// Driver's license patterns
 pub(crate) mod driver_license {
     use super::*;

--- a/crates/octarine/src/primitives/identifiers/government/builder/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/mod.rs
@@ -72,6 +72,7 @@ mod test_patterns;
 mod thailand;
 mod turkey;
 mod uk;
+mod us_mbi;
 mod vehicle_id;
 
 /// Builder for government identifier operations

--- a/crates/octarine/src/primitives/identifiers/government/builder/us_mbi.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/us_mbi.rs
@@ -1,0 +1,57 @@
+//! US Medicare Beneficiary Identifier (MBI) operations on
+//! `GovernmentIdentifierBuilder`.
+
+use super::*;
+
+impl GovernmentIdentifierBuilder {
+    /// Check if value is a valid US Medicare Beneficiary Identifier (MBI)
+    ///
+    /// Strict — enforces the 11-character CMS layout
+    /// (`C A AN N A AN N A A N N`) and the letter alphabet
+    /// `ACDEFGHJKMNPQRTUVWXY` (excluding `S, L, O, I, B, Z`). Accepts both the
+    /// bare and dashed `XXXX-XXX-XXXX` forms.
+    #[must_use]
+    pub fn is_us_mbi(&self, value: &str) -> bool {
+        detection::is_us_mbi(value)
+    }
+
+    /// Find all valid US MBIs in text
+    ///
+    /// Dashed matches get `High` confidence; bare 11-character matches get
+    /// `Medium`. Only structurally valid MBIs are returned.
+    #[must_use]
+    pub fn find_us_mbis_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_us_mbis_in_text(text)
+    }
+
+    /// Validate a US MBI
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the MBI length, dash grouping, positional layout,
+    /// or letter alphabet is invalid.
+    pub fn validate_us_mbi(&self, mbi: &str) -> Result<(), Problem> {
+        validation::validate_us_mbi(mbi)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    fn builder() -> GovernmentIdentifierBuilder {
+        GovernmentIdentifierBuilder::new()
+    }
+
+    #[test]
+    fn test_us_mbi_operations() {
+        let gov = builder();
+        assert!(gov.is_us_mbi("1EG4TE5MK73"));
+        assert!(gov.is_us_mbi("1EG4-TE5-MK73"));
+        assert!(!gov.is_us_mbi("1AB2C3D4EF5")); // excluded letter / bad layout
+        assert!(gov.validate_us_mbi("1EG4TE5MK73").is_ok());
+        assert!(gov.validate_us_mbi("").is_err());
+        assert!(!gov.find_us_mbis_in_text("MBI: 1EG4-TE5-MK73").is_empty());
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
@@ -66,6 +66,7 @@ mod sweden;
 mod tax_id;
 mod thailand;
 mod turkey;
+mod us_mbi;
 mod vehicle_id;
 
 pub use australia::{
@@ -124,6 +125,7 @@ pub use turkey::{
     find_turkey_license_plates_in_text, find_turkey_tckns_in_text, is_turkey_license_plate,
     is_turkey_tckn,
 };
+pub use us_mbi::{find_us_mbis_in_text, is_us_mbi};
 pub use vehicle_id::{find_vehicle_ids_in_text, is_vehicle_id};
 
 /// Detect which type of government identifier a value is
@@ -167,6 +169,12 @@ pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
         Some(IdentifierType::Itin)
     } else if is_tax_id(value) {
         Some(IdentifierType::TaxId)
+    } else if is_us_mbi(value) {
+        // MBI is an 11-char alphanumeric with a strict CMS layout; it does not
+        // overlap the 9-digit SSN/ITIN/EIN shapes, so it is safe to check here
+        // after the tax IDs and before the looser driver-license/passport
+        // patterns that could otherwise shadow it.
+        Some(IdentifierType::Mbi)
     } else if is_driver_license(value) {
         Some(IdentifierType::DriverLicense)
     } else if is_passport(value) {
@@ -275,6 +283,7 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
     all_matches.extend(find_eins_in_text(text));
     all_matches.extend(find_itins_in_text(text));
     all_matches.extend(find_tax_ids_in_text(text));
+    all_matches.extend(find_us_mbis_in_text(text));
     all_matches.extend(find_driver_licenses_in_text(text));
     all_matches.extend(find_passports_in_text(text));
     all_matches.extend(find_korea_rrns_in_text(text));
@@ -375,6 +384,8 @@ mod tests {
             "11-90-123456-78",   // Korea Driver License
             "M12345678",         // Korea Passport
             "123-45-67890",      // Korea BRN
+            "1EG4TE5MK73",       // US MBI (bare)
+            "1EG4-TE5-MK73",     // US MBI (dashed)
             "not an id",         // Invalid
             "",                  // Empty
         ];
@@ -436,6 +447,24 @@ mod tests {
         assert_eq!(
             detect_government_identifier("912-34-5678"),
             Some(IdentifierType::TaxId)
+        );
+    }
+
+    #[test]
+    fn test_detect_government_identifier_mbi() {
+        // Both bare and dashed MBIs dispatch to the dedicated Mbi variant.
+        assert_eq!(
+            detect_government_identifier("1EG4TE5MK73"),
+            Some(IdentifierType::Mbi)
+        );
+        assert_eq!(
+            detect_government_identifier("1EG4-TE5-MK73"),
+            Some(IdentifierType::Mbi)
+        );
+        // The issue's invalid fixture (excluded letter) is not classified as MBI.
+        assert_ne!(
+            detect_government_identifier("1AB2C3D4EF5"),
+            Some(IdentifierType::Mbi)
         );
     }
 

--- a/crates/octarine/src/primitives/identifiers/government/detection/us_mbi.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/us_mbi.rs
@@ -1,0 +1,148 @@
+//! US Medicare Beneficiary Identifier (MBI) detection.
+//!
+//! - `is_us_mbi` is strict — it delegates to `validation::validate_us_mbi`, so
+//!   it enforces the full CMS positional layout and the excluded-letter
+//!   alphabet.
+//! - `find_us_mbis_in_text` scans for the structural patterns and tags matches
+//!   as `IdentifierType::Mbi`. The dashed `XXXX-XXX-XXXX` form is distinctive
+//!   enough for `High` confidence; the bare 11-character form gets `Medium`
+//!   because it overlaps with arbitrary alphanumeric identifiers.
+
+use super::super::super::common::patterns;
+use super::super::super::types::{DetectionConfidence, IdentifierMatch, IdentifierType};
+use super::helpers::{MAX_INPUT_LENGTH, deduplicate_matches, exceeds_safe_length, get_full_match};
+
+/// Check if a value is a valid US Medicare Beneficiary Identifier (MBI).
+///
+/// Strict: enforces the 11-character CMS layout (`C A AN N A AN N A A N N`)
+/// and the letter alphabet `ACDEFGHJKMNPQRTUVWXY` (excluding `S, L, O, I, B,
+/// Z`). Accepts both the bare and dashed `XXXX-XXX-XXXX` forms.
+#[must_use]
+pub fn is_us_mbi(value: &str) -> bool {
+    super::super::validation::validate_us_mbi(value).is_ok()
+}
+
+/// Find all valid US MBI patterns in text.
+///
+/// Scans for the dashed form first (`High` confidence — the `XXXX-XXX-XXXX`
+/// layout is highly distinctive) and then the bare 11-character form
+/// (`Medium`). Every candidate is re-checked through `is_us_mbi` so only
+/// structurally valid MBIs are returned. Matches are tagged
+/// `IdentifierType::Mbi`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::detection;
+///
+/// let text = "Medicare MBI: 1EG4-TE5-MK73";
+/// let matches = detection::find_us_mbis_in_text(text);
+/// assert_eq!(matches.len(), 1);
+/// ```
+#[must_use]
+pub fn find_us_mbis_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    // Dashed form first (High confidence).
+    for capture in patterns::mbi::WITH_DASH.captures_iter(text) {
+        let full_match = get_full_match(&capture);
+        let matched_text = full_match.as_str();
+        if !is_us_mbi(matched_text) {
+            continue;
+        }
+        matches.push(IdentifierMatch::high_confidence(
+            full_match.start(),
+            full_match.end(),
+            matched_text.to_string(),
+            IdentifierType::Mbi,
+        ));
+    }
+
+    // Bare 11-character form (Medium confidence).
+    for capture in patterns::mbi::NO_DASH.captures_iter(text) {
+        let full_match = get_full_match(&capture);
+        let matched_text = full_match.as_str();
+        if !is_us_mbi(matched_text) {
+            continue;
+        }
+        matches.push(IdentifierMatch::new(
+            full_match.start(),
+            full_match.end(),
+            matched_text.to_string(),
+            IdentifierType::Mbi,
+            DetectionConfidence::Medium,
+        ));
+    }
+
+    deduplicate_matches(matches)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_is_us_mbi_accepts_valid() {
+        assert!(is_us_mbi("1EG4TE5MK73"));
+        assert!(is_us_mbi("1EG4-TE5-MK73"));
+    }
+
+    #[test]
+    fn test_is_us_mbi_rejects_invalid() {
+        // Excluded letter 'B' at position 3 (the issue's bad fixture).
+        assert!(!is_us_mbi("1AB2C3D4EF5"));
+        // Starts with a letter.
+        assert!(!is_us_mbi("AEG4TE5MK73"));
+        assert!(!is_us_mbi(""));
+    }
+
+    #[test]
+    fn test_find_us_mbis_in_text_dashed_high() {
+        let text = "Medicare MBI: 1EG4-TE5-MK73 on the card";
+        let matches = find_us_mbis_in_text(text);
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("should detect dashed MBI");
+        assert_eq!(first.identifier_type, IdentifierType::Mbi);
+        assert_eq!(first.confidence, DetectionConfidence::High);
+    }
+
+    #[test]
+    fn test_find_us_mbis_in_text_bare_medium() {
+        let text = "Beneficiary 1EG4TE5MK73 enrolled";
+        let matches = find_us_mbis_in_text(text);
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("should detect bare MBI");
+        assert_eq!(first.identifier_type, IdentifierType::Mbi);
+        assert_eq!(first.confidence, DetectionConfidence::Medium);
+    }
+
+    #[test]
+    fn test_find_us_mbis_in_text_skips_invalid() {
+        // Structurally invalid strings must not surface as MBI matches.
+        let text = "Reference 1AB2C3D4EF5 is not an MBI";
+        let matches = find_us_mbis_in_text(text);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_find_us_mbis_in_text_multiple() {
+        let text = "First 1EG4TE5MK73 then 9YK8MQ3PW21";
+        let matches = find_us_mbis_in_text(text);
+        assert_eq!(matches.len(), 2);
+        assert!(
+            matches
+                .iter()
+                .all(|m| m.identifier_type == IdentifierType::Mbi)
+        );
+    }
+
+    #[test]
+    fn test_find_us_mbis_in_text_empty() {
+        assert!(find_us_mbis_in_text("").is_empty());
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/government/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/mod.rs
@@ -190,15 +190,15 @@ pub use validation::{validate_thailand_tnin, validate_thailand_tnin_with_checksu
 
 // Export strategy types for explicit redaction control
 pub use sanitization::{
-    DriverLicenseRedactionStrategy, NationalIdRedactionStrategy, PassportRedactionStrategy,
-    TaxIdRedactionStrategy, VehicleIdRedactionStrategy,
+    DriverLicenseRedactionStrategy, MbiRedactionStrategy, NationalIdRedactionStrategy,
+    PassportRedactionStrategy, TaxIdRedactionStrategy, VehicleIdRedactionStrategy,
 };
 
 // Export strategy-based redaction functions
 pub use sanitization::{
-    redact_driver_license_with_strategy, redact_national_id_with_strategy,
-    redact_passport_with_strategy, redact_ssn_with_strategy, redact_tax_id_with_strategy,
-    redact_vehicle_id_with_strategy,
+    redact_driver_license_with_strategy, redact_mbi_with_strategy,
+    redact_national_id_with_strategy, redact_passport_with_strategy, redact_ssn_with_strategy,
+    redact_tax_id_with_strategy, redact_vehicle_id_with_strategy,
 };
 
 // Export strategy-based text redaction functions
@@ -206,7 +206,7 @@ pub use sanitization::{
     redact_all_government_ids_in_text_with_policy, redact_driver_licenses_in_text_with_strategy,
     redact_national_ids_in_text_with_strategy, redact_passports_in_text_with_strategy,
     redact_ssns_in_text_with_strategy, redact_tax_ids_in_text_with_strategy,
-    redact_vehicle_ids_in_text_with_strategy,
+    redact_us_mbis_in_text_with_strategy, redact_vehicle_ids_in_text_with_strategy,
 };
 
 // Export strict sanitization functions

--- a/crates/octarine/src/primitives/identifiers/government/redaction.rs
+++ b/crates/octarine/src/primitives/identifiers/government/redaction.rs
@@ -57,8 +57,9 @@
 //! ```
 
 use super::sanitization::{
-    DriverLicenseRedactionStrategy, NationalIdRedactionStrategy, PassportRedactionStrategy,
-    SsnRedactionStrategy, TaxIdRedactionStrategy, VehicleIdRedactionStrategy,
+    DriverLicenseRedactionStrategy, MbiRedactionStrategy, NationalIdRedactionStrategy,
+    PassportRedactionStrategy, SsnRedactionStrategy, TaxIdRedactionStrategy,
+    VehicleIdRedactionStrategy,
 };
 
 /// Generic redaction policy for text scanning
@@ -131,6 +132,17 @@ impl TextRedactionPolicy {
             Self::Partial => NationalIdRedactionStrategy::LastFour,
             Self::Complete => NationalIdRedactionStrategy::Token,
             Self::Anonymous => NationalIdRedactionStrategy::Anonymous,
+        }
+    }
+
+    /// Convert policy to MBI redaction strategy
+    #[must_use]
+    pub const fn to_mbi_strategy(self) -> MbiRedactionStrategy {
+        match self {
+            Self::Skip => MbiRedactionStrategy::Skip,
+            Self::Partial => MbiRedactionStrategy::LastFour,
+            Self::Complete => MbiRedactionStrategy::Token,
+            Self::Anonymous => MbiRedactionStrategy::Anonymous,
         }
     }
 
@@ -254,6 +266,26 @@ mod tests {
         assert_eq!(
             TextRedactionPolicy::Anonymous.to_national_id_strategy(),
             NationalIdRedactionStrategy::Anonymous
+        );
+    }
+
+    #[test]
+    fn test_text_policy_to_mbi_strategy() {
+        assert_eq!(
+            TextRedactionPolicy::Skip.to_mbi_strategy(),
+            MbiRedactionStrategy::Skip
+        );
+        assert_eq!(
+            TextRedactionPolicy::Partial.to_mbi_strategy(),
+            MbiRedactionStrategy::LastFour
+        );
+        assert_eq!(
+            TextRedactionPolicy::Complete.to_mbi_strategy(),
+            MbiRedactionStrategy::Token
+        );
+        assert_eq!(
+            TextRedactionPolicy::Anonymous.to_mbi_strategy(),
+            MbiRedactionStrategy::Anonymous
         );
     }
 

--- a/crates/octarine/src/primitives/identifiers/government/sanitization/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/sanitization/mod.rs
@@ -47,8 +47,9 @@ mod text;
 // ============================================================================
 
 pub use strategy::{
-    DriverLicenseRedactionStrategy, NationalIdRedactionStrategy, PassportRedactionStrategy,
-    SsnRedactionStrategy, TaxIdRedactionStrategy, VehicleIdRedactionStrategy,
+    DriverLicenseRedactionStrategy, MbiRedactionStrategy, NationalIdRedactionStrategy,
+    PassportRedactionStrategy, SsnRedactionStrategy, TaxIdRedactionStrategy,
+    VehicleIdRedactionStrategy,
 };
 
 // ============================================================================
@@ -56,8 +57,9 @@ pub use strategy::{
 // ============================================================================
 
 pub use redaction::{
-    redact_driver_license_with_strategy, redact_national_id_with_strategy,
-    redact_passport_with_strategy, redact_tax_id_with_strategy, redact_vehicle_id_with_strategy,
+    redact_driver_license_with_strategy, redact_mbi_with_strategy,
+    redact_national_id_with_strategy, redact_passport_with_strategy, redact_tax_id_with_strategy,
+    redact_vehicle_id_with_strategy,
 };
 
 pub use ssn::redact_ssn_with_strategy;
@@ -70,7 +72,8 @@ pub use text::{
     redact_all_government_ids_in_text_with_policy, redact_driver_licenses_in_text_with_strategy,
     redact_national_ids_in_text_with_strategy, redact_passports_in_text_with_strategy,
     redact_ssns_in_text_with_strategy, redact_tax_ids_in_text_with_strategy,
-    redact_uk_nis_in_text_with_strategy, redact_vehicle_ids_in_text_with_strategy,
+    redact_uk_nis_in_text_with_strategy, redact_us_mbis_in_text_with_strategy,
+    redact_vehicle_ids_in_text_with_strategy,
 };
 
 // ============================================================================

--- a/crates/octarine/src/primitives/identifiers/government/sanitization/redaction.rs
+++ b/crates/octarine/src/primitives/identifiers/government/sanitization/redaction.rs
@@ -4,8 +4,8 @@
 
 use super::super::super::common::masking;
 use super::strategy::{
-    DriverLicenseRedactionStrategy, NationalIdRedactionStrategy, PassportRedactionStrategy,
-    TaxIdRedactionStrategy, VehicleIdRedactionStrategy,
+    DriverLicenseRedactionStrategy, MbiRedactionStrategy, NationalIdRedactionStrategy,
+    PassportRedactionStrategy, TaxIdRedactionStrategy, VehicleIdRedactionStrategy,
 };
 
 // ============================================================================
@@ -298,10 +298,113 @@ pub fn redact_vehicle_id_with_strategy(
     }
 }
 
+// ============================================================================
+// MBI Redaction
+// ============================================================================
+
+/// Redact a US Medicare Beneficiary Identifier (MBI) with explicit strategy
+///
+/// # Strategies
+///
+/// - `Token` → `[MBI]`
+/// - `Mask` → `***********` (11 asterisks)
+/// - `Anonymous` → `[Redacted]`
+/// - `LastFour` → `*******MK73` (shows last 4 characters)
+/// - `Skip` → unchanged
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::sanitization::{
+///     redact_mbi_with_strategy, MbiRedactionStrategy
+/// };
+///
+/// let token = redact_mbi_with_strategy("1EG4TE5MK73", MbiRedactionStrategy::Token);
+/// assert_eq!(token, "[MBI]");
+///
+/// let last4 = redact_mbi_with_strategy("1EG4TE5MK73", MbiRedactionStrategy::LastFour);
+/// assert_eq!(last4, "*******MK73");
+/// ```
+#[must_use]
+pub fn redact_mbi_with_strategy(mbi: &str, strategy: MbiRedactionStrategy) -> String {
+    // MBIs may carry the display dashes (XXXX-XXX-XXXX); redact on the
+    // separator-free characters so masking/last-four are consistent.
+    let cleaned: String = mbi
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect::<String>()
+        .to_uppercase();
+
+    match strategy {
+        MbiRedactionStrategy::Token => "[MBI]".to_string(),
+
+        MbiRedactionStrategy::Mask => masking::mask_all(&cleaned, '*'),
+
+        MbiRedactionStrategy::Anonymous => "[Redacted]".to_string(),
+
+        MbiRedactionStrategy::LastFour => {
+            if cleaned.chars().count() >= 4 {
+                let last_four: String = cleaned
+                    .chars()
+                    .skip(cleaned.chars().count().saturating_sub(4))
+                    .collect();
+                format!("*******{last_four}")
+            } else {
+                "[MBI]".to_string()
+            }
+        }
+
+        MbiRedactionStrategy::Skip => mbi.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
+    use super::super::strategy::MbiRedactionStrategy;
     use super::*;
+
+    // ========================================================================
+    // MBI Tests
+    // ========================================================================
+
+    #[test]
+    fn test_redact_mbi_with_strategy() {
+        assert_eq!(
+            redact_mbi_with_strategy("1EG4TE5MK73", MbiRedactionStrategy::Token),
+            "[MBI]"
+        );
+        assert_eq!(
+            redact_mbi_with_strategy("1EG4TE5MK73", MbiRedactionStrategy::Mask),
+            "***********"
+        );
+        assert_eq!(
+            redact_mbi_with_strategy("1EG4TE5MK73", MbiRedactionStrategy::Anonymous),
+            "[Redacted]"
+        );
+        assert_eq!(
+            redact_mbi_with_strategy("1EG4TE5MK73", MbiRedactionStrategy::LastFour),
+            "*******MK73"
+        );
+        // Dashed form redacts on the separator-free characters.
+        assert_eq!(
+            redact_mbi_with_strategy("1EG4-TE5-MK73", MbiRedactionStrategy::LastFour),
+            "*******MK73"
+        );
+        assert_eq!(
+            redact_mbi_with_strategy("1EG4TE5MK73", MbiRedactionStrategy::Skip),
+            "1EG4TE5MK73"
+        );
+    }
+
+    #[test]
+    fn test_redact_mbi_short() {
+        // Too short for LastFour → fallback to token.
+        assert_eq!(
+            redact_mbi_with_strategy("1A", MbiRedactionStrategy::LastFour),
+            "[MBI]"
+        );
+    }
 
     // ========================================================================
     // Tax ID Tests

--- a/crates/octarine/src/primitives/identifiers/government/sanitization/strategy.rs
+++ b/crates/octarine/src/primitives/identifiers/government/sanitization/strategy.rs
@@ -172,10 +172,45 @@ impl VehicleIdRedactionStrategy {
     }
 }
 
+// ============================================================================
+// MBI Redaction Strategies
+// ============================================================================
+
+/// US Medicare Beneficiary Identifier (MBI) redaction strategy
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MbiRedactionStrategy {
+    /// Replace with `[MBI]` token
+    #[default]
+    Token,
+    /// Replace all characters with asterisks
+    Mask,
+    /// Replace with generic `[REDACTED]`
+    Anonymous,
+    /// Show last 4 characters: `*******MK73`
+    LastFour,
+    /// Skip redaction (pass-through)
+    Skip,
+}
+
+impl MbiRedactionStrategy {
+    /// Check if strategy is risky for production use
+    #[must_use]
+    pub fn is_risky(&self) -> bool {
+        matches!(self, Self::Skip)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
     use super::*;
+
+    #[test]
+    fn test_mbi_strategy_risky() {
+        assert!(!MbiRedactionStrategy::Token.is_risky());
+        assert!(!MbiRedactionStrategy::LastFour.is_risky());
+        assert!(MbiRedactionStrategy::Skip.is_risky());
+    }
 
     #[test]
     fn test_ssn_strategy_risky() {

--- a/crates/octarine/src/primitives/identifiers/government/sanitization/text.rs
+++ b/crates/octarine/src/primitives/identifiers/government/sanitization/text.rs
@@ -7,13 +7,15 @@ use std::borrow::Cow;
 
 use super::super::super::common::patterns;
 use super::redaction::{
-    redact_driver_license_with_strategy, redact_national_id_with_strategy,
-    redact_passport_with_strategy, redact_tax_id_with_strategy, redact_vehicle_id_with_strategy,
+    redact_driver_license_with_strategy, redact_mbi_with_strategy,
+    redact_national_id_with_strategy, redact_passport_with_strategy, redact_tax_id_with_strategy,
+    redact_vehicle_id_with_strategy,
 };
 use super::ssn::redact_ssn_with_strategy;
 use super::strategy::{
-    DriverLicenseRedactionStrategy, NationalIdRedactionStrategy, PassportRedactionStrategy,
-    SsnRedactionStrategy, TaxIdRedactionStrategy, VehicleIdRedactionStrategy,
+    DriverLicenseRedactionStrategy, MbiRedactionStrategy, NationalIdRedactionStrategy,
+    PassportRedactionStrategy, SsnRedactionStrategy, TaxIdRedactionStrategy,
+    VehicleIdRedactionStrategy,
 };
 
 // ============================================================================
@@ -392,6 +394,57 @@ pub fn redact_uk_nis_in_text_with_strategy(
 }
 
 // ============================================================================
+// MBI Text Redaction
+// ============================================================================
+
+/// Redact all US MBI patterns in text with explicit strategy
+///
+/// Scans for the dashed `XXXX-XXX-XXXX` and bare 11-character forms, revalidates
+/// each candidate through `validate_us_mbi` (so non-MBI look-alike strings are
+/// left untouched), and replaces valid matches. The full match is the MBI —
+/// there is no label capture group.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::sanitization::{
+///     redact_us_mbis_in_text_with_strategy, MbiRedactionStrategy
+/// };
+///
+/// let text = "Medicare MBI: 1EG4-TE5-MK73";
+/// let safe = redact_us_mbis_in_text_with_strategy(text, MbiRedactionStrategy::Token);
+/// assert_eq!(safe, "Medicare MBI: [MBI]");
+/// ```
+#[must_use]
+pub fn redact_us_mbis_in_text_with_strategy(
+    text: &str,
+    strategy: MbiRedactionStrategy,
+) -> Cow<'_, str> {
+    use super::super::validation::validate_us_mbi;
+
+    let mut result = Cow::Borrowed(text);
+
+    // Dashed form first (more distinctive), then the bare 11-character form.
+    for pattern in [&*patterns::mbi::WITH_DASH, &*patterns::mbi::NO_DASH] {
+        if pattern.is_match(&result) {
+            result = Cow::Owned(
+                pattern
+                    .replace_all(&result, |caps: &regex::Captures<'_>| {
+                        let mbi = caps.get(0).map_or("", |m| m.as_str());
+                        if validate_us_mbi(mbi).is_err() {
+                            return mbi.to_string();
+                        }
+                        redact_mbi_with_strategy(mbi, strategy)
+                    })
+                    .into_owned(),
+            );
+        }
+    }
+
+    result
+}
+
+// ============================================================================
 // Vehicle ID Text Redaction
 // ============================================================================
 
@@ -500,14 +553,18 @@ pub fn redact_all_government_ids_in_text_with_policy(
     // Convert policy to individual strategies
     let ssn_strategy = policy.to_ssn_strategy();
     let tax_id_strategy = policy.to_tax_id_strategy();
+    let mbi_strategy = policy.to_mbi_strategy();
     let driver_license_strategy = policy.to_driver_license_strategy();
     let passport_strategy = policy.to_passport_strategy();
     let national_id_strategy = policy.to_national_id_strategy();
     let vehicle_id_strategy = policy.to_vehicle_id_strategy();
 
-    // Apply redaction in order
+    // Apply redaction in order. MBIs are redacted before driver licenses so the
+    // loose generic driver-license pattern (`[A-Z0-9]{6,15}`) cannot partially
+    // consume an 11-character MBI first.
     let result = redact_ssns_in_text_with_strategy(text, ssn_strategy);
     let result = redact_tax_ids_in_text_with_strategy(&result, tax_id_strategy);
+    let result = redact_us_mbis_in_text_with_strategy(&result, mbi_strategy);
     let result = redact_driver_licenses_in_text_with_strategy(&result, driver_license_strategy);
     let result = redact_passports_in_text_with_strategy(&result, passport_strategy);
     // UK NINOs first — label-preserving and prefix/suffix validated — so that
@@ -612,6 +669,34 @@ mod tests {
     }
 
     // ========================================================================
+    // MBI Text Tests
+    // ========================================================================
+
+    #[test]
+    fn test_redact_us_mbis_in_text_token() {
+        let text = "Medicare MBI: 1EG4-TE5-MK73";
+        let result = redact_us_mbis_in_text_with_strategy(text, MbiRedactionStrategy::Token);
+        assert_eq!(result, "Medicare MBI: [MBI]");
+    }
+
+    #[test]
+    fn test_redact_us_mbis_in_text_bare_and_last_four() {
+        let text = "Beneficiary 1EG4TE5MK73 enrolled";
+        let token = redact_us_mbis_in_text_with_strategy(text, MbiRedactionStrategy::Token);
+        assert_eq!(token, "Beneficiary [MBI] enrolled");
+        let last4 = redact_us_mbis_in_text_with_strategy(text, MbiRedactionStrategy::LastFour);
+        assert_eq!(last4, "Beneficiary *******MK73 enrolled");
+    }
+
+    #[test]
+    fn test_redact_us_mbis_in_text_skips_invalid() {
+        // Excluded-letter look-alike must pass through untouched.
+        let text = "Reference 1AB2C3D4EF5 stays";
+        let result = redact_us_mbis_in_text_with_strategy(text, MbiRedactionStrategy::Token);
+        assert_eq!(result, "Reference 1AB2C3D4EF5 stays");
+    }
+
+    // ========================================================================
     // Combined Redaction Tests
     // ========================================================================
 
@@ -627,6 +712,28 @@ mod tests {
         assert!(result.contains("[SSN]"));
         assert!(result.contains("[VEHICLE_ID]"));
         assert!(result.contains("[TAX_ID]"));
+    }
+
+    #[test]
+    fn test_redact_all_government_ids_includes_mbi() {
+        use crate::primitives::identifiers::GovernmentTextPolicy;
+
+        // Regression guard: the aggregate redactor must actually scrub MBIs, not
+        // just detect them (issue #428 — otherwise Medicare PHI leaks through the
+        // auto-redaction path).
+        let text = "Patient MBI 1EG4-TE5-MK73 on file";
+        let result = redact_all_government_ids_in_text_with_policy(
+            text,
+            Some(GovernmentTextPolicy::Complete),
+        );
+        assert!(
+            result.contains("[MBI]"),
+            "MBI must be redacted, got: {result}"
+        );
+        assert!(
+            !result.contains("1EG4-TE5-MK73"),
+            "raw MBI must not survive: {result}"
+        );
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
@@ -63,6 +63,7 @@ mod sweden;
 mod thailand;
 mod turkey;
 mod uk;
+mod us_mbi;
 mod vin;
 
 // Re-export cache utilities
@@ -76,6 +77,9 @@ pub use ein::{is_test_ein, is_valid_ein_prefix, validate_ein};
 
 // Re-export ITIN functions
 pub use itin::{is_test_itin, is_valid_itin_group, validate_itin};
+
+// Re-export US MBI functions
+pub use us_mbi::{is_test_us_mbi, is_valid_mbi_letter, validate_us_mbi};
 
 // Re-export driver's license functions
 pub use driver_license::{is_test_driver_license, validate_driver_license};

--- a/crates/octarine/src/primitives/identifiers/government/validation/us_mbi.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/us_mbi.rs
@@ -1,0 +1,245 @@
+//! US Medicare Beneficiary Identifier (MBI) validation.
+//!
+//! Pure validation for the CMS-issued MBI that replaced SSN-based Health
+//! Insurance Claim Numbers (HICNs) on Medicare cards in 2018.
+//!
+//! # MBI Format
+//!
+//! An MBI is exactly 11 characters with a fixed positional structure
+//! (`C A AN N A AN N A A N N`):
+//!
+//! ```text
+//! Pos:     1  2   3  4  5   6  7  8  9 10 11
+//!   C / N  (pos 1,4,7,10,11) = numeric 0-9
+//!   A      (pos 2,5,8,9)     = letter from ACDEFGHJKMNPQRTUVWXY
+//!   AN     (pos 3,6)         = numeric OR that same restricted letter set
+//! ```
+//!
+//! The letter alphabet **excludes `S, L, O, I, B, Z`** to avoid visual
+//! confusion with digits. The dashed display form is `XXXX-XXX-XXXX`.
+//!
+//! The positional + excluded-letter rule is the load-bearing constraint that
+//! separates a real MBI from "any 11-character alphanumeric string". Without
+//! it, arbitrary identifiers get misclassified as Medicare PHI.
+//!
+//! # Authoritative References
+//!
+//! - CMS "Understanding the New Medicare Beneficiary Identifier (MBI)"
+//! - Presidio `us_mbi_recognizer.py` (cross-reference for the same rule)
+
+use crate::primitives::Problem;
+
+/// The valid MBI letter alphabet: A-Z excluding `S, L, O, I, B, Z`.
+const VALID_LETTERS: [char; 20] = [
+    'A', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P', 'Q', 'R', 'T', 'U', 'V', 'W', 'X',
+    'Y',
+];
+
+/// Position kind within the fixed 11-character MBI layout.
+#[derive(Clone, Copy)]
+enum PosKind {
+    /// Numeric only (`0-9`).
+    Numeric,
+    /// Letter from [`VALID_LETTERS`].
+    Alpha,
+    /// Numeric or a valid letter.
+    Alphanumeric,
+}
+
+/// The 11 position kinds in order (`C A AN N A AN N A A N N`).
+const LAYOUT: [PosKind; 11] = [
+    PosKind::Numeric,      // 1
+    PosKind::Alpha,        // 2
+    PosKind::Alphanumeric, // 3
+    PosKind::Numeric,      // 4
+    PosKind::Alpha,        // 5
+    PosKind::Alphanumeric, // 6
+    PosKind::Numeric,      // 7
+    PosKind::Alpha,        // 8
+    PosKind::Alpha,        // 9
+    PosKind::Numeric,      // 10
+    PosKind::Numeric,      // 11
+];
+
+/// Check whether a character is a valid MBI letter (excluded set removed).
+#[must_use]
+pub fn is_valid_mbi_letter(c: char) -> bool {
+    VALID_LETTERS.contains(&c)
+}
+
+/// Validate a US Medicare Beneficiary Identifier (MBI).
+///
+/// Accepts either the bare 11-character form or the dashed `XXXX-XXX-XXXX`
+/// display form. Enforces the full CMS positional layout and the restricted
+/// letter alphabet. Returns `Ok(())` only for values CMS could have assigned.
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` for any of:
+///
+/// - Wrong character count (not 11 after removing dashes)
+/// - A dashed value whose dashes are not in the `XXXX-XXX-XXXX` positions
+/// - A numeric position holding a non-digit
+/// - An alphabetic position holding a non-letter or an excluded letter
+///   (`S, L, O, I, B, Z`)
+/// - An alphanumeric position holding neither a digit nor a valid letter
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::government::validation;
+///
+/// assert!(validation::validate_us_mbi("1EG4TE5MK73").is_ok());
+/// assert!(validation::validate_us_mbi("1EG4-TE5-MK73").is_ok());
+/// assert!(validation::validate_us_mbi("1AB2C3D4EF5").is_err()); // B excluded, F must be numeric
+/// ```
+pub fn validate_us_mbi(value: &str) -> Result<(), Problem> {
+    // Accept the dashed display form only in its exact positions; any other
+    // dash placement is rejected rather than silently stripped (which would
+    // otherwise accept malformed groupings).
+    let uppercased = value.to_ascii_uppercase();
+    let cleaned: String = if uppercased.contains('-') {
+        let parts: Vec<&str> = uppercased.split('-').collect();
+        let well_formed = parts.len() == 3
+            && parts.first().is_some_and(|p| p.len() == 4)
+            && parts.get(1).is_some_and(|p| p.len() == 3)
+            && parts.get(2).is_some_and(|p| p.len() == 4);
+        if !well_formed {
+            return Err(Problem::Validation(
+                "MBI dashed form must be XXXX-XXX-XXXX".into(),
+            ));
+        }
+        parts.concat()
+    } else {
+        uppercased
+    };
+
+    if cleaned.chars().count() != 11 {
+        return Err(Problem::Validation(
+            "MBI must be 11 characters (excluding dashes)".into(),
+        ));
+    }
+
+    for (idx, (c, kind)) in cleaned.chars().zip(LAYOUT.iter()).enumerate() {
+        let position = idx.saturating_add(1);
+        match kind {
+            PosKind::Numeric => {
+                if !c.is_ascii_digit() {
+                    return Err(Problem::Validation(format!(
+                        "MBI position {position} must be numeric, got '{c}'"
+                    )));
+                }
+            }
+            PosKind::Alpha => {
+                if !is_valid_mbi_letter(c) {
+                    return Err(Problem::Validation(format!(
+                        "MBI position {position} must be a letter excluding S,L,O,I,B,Z, got '{c}'"
+                    )));
+                }
+            }
+            PosKind::Alphanumeric => {
+                if !c.is_ascii_digit() && !is_valid_mbi_letter(c) {
+                    return Err(Problem::Validation(format!(
+                        "MBI position {position} must be a digit or a letter excluding S,L,O,I,B,Z, got '{c}'"
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Check whether an MBI is an obvious test/placeholder pattern.
+///
+/// CMS does not publish reserved MBI test ranges, so this is conservative:
+/// only flags values whose numeric and alphabetic positions are each a single
+/// repeated character (e.g. `1A1A1A1A1A1`-style synthetic strings). Returns
+/// `false` for anything that is not a structurally valid MBI.
+#[must_use]
+pub fn is_test_us_mbi(value: &str) -> bool {
+    if validate_us_mbi(value).is_err() {
+        return false;
+    }
+    let cleaned: String = value
+        .chars()
+        .filter(|c| *c != '-')
+        .map(|c| c.to_ascii_uppercase())
+        .collect();
+
+    let digits: Vec<char> = cleaned.chars().filter(char::is_ascii_digit).collect();
+    let letters: Vec<char> = cleaned.chars().filter(|c| !c.is_ascii_digit()).collect();
+
+    let all_same = |chars: &[char]| -> bool {
+        chars
+            .first()
+            .is_some_and(|first| chars.iter().all(|c| c == first))
+    };
+
+    all_same(&digits) && all_same(&letters)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn test_validate_us_mbi_accepts_valid() {
+        // CMS-shaped valid example (Presidio's documented sample).
+        assert!(validate_us_mbi("1EG4TE5MK73").is_ok());
+        assert!(validate_us_mbi("1EG4-TE5-MK73").is_ok());
+        // Lowercase is normalized.
+        assert!(validate_us_mbi("1eg4te5mk73").is_ok());
+    }
+
+    #[test]
+    fn test_validate_us_mbi_rejects_excluded_letters() {
+        // The issue's fixture "1AB2C3D4EF5" is INVALID: 'B' (pos 3) is an
+        // excluded letter, and even ignoring that 'F' (pos 10) must be numeric.
+        assert!(validate_us_mbi("1AB2C3D4EF5").is_err());
+        // Each excluded letter placed in an alpha position is rejected.
+        for bad in ['S', 'L', 'O', 'I', 'B', 'Z'] {
+            let candidate = format!("1{bad}G4TE5MK73");
+            assert!(
+                validate_us_mbi(&candidate).is_err(),
+                "excluded letter {bad} at pos 2 must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_us_mbi_rejects_wrong_layout() {
+        // Starts with a letter (position 1 must be numeric).
+        assert!(validate_us_mbi("AEG4TE5MK73").is_err());
+        // Position 2 numeric where a letter is required.
+        assert!(validate_us_mbi("11G4TE5MK73").is_err());
+        // Position 10/11 letters where digits are required.
+        assert!(validate_us_mbi("1EG4TE5MKAA").is_err());
+    }
+
+    #[test]
+    fn test_validate_us_mbi_rejects_bad_length_and_dashes() {
+        assert!(validate_us_mbi("1EG4TE5MK7").is_err()); // 10 chars
+        assert!(validate_us_mbi("1EG4TE5MK733").is_err()); // 12 chars
+        assert!(validate_us_mbi("1EG-4TE5-MK73").is_err()); // wrong dash grouping
+        assert!(validate_us_mbi("").is_err());
+    }
+
+    #[test]
+    fn test_is_valid_mbi_letter() {
+        assert!(is_valid_mbi_letter('A'));
+        assert!(is_valid_mbi_letter('Y'));
+        for excluded in ['S', 'L', 'O', 'I', 'B', 'Z'] {
+            assert!(!is_valid_mbi_letter(excluded));
+        }
+    }
+
+    #[test]
+    fn test_is_test_us_mbi() {
+        // Not a valid MBI → never a test pattern.
+        assert!(!is_test_us_mbi("not-an-mbi"));
+        // A real-looking MBI with varied digits/letters is not flagged.
+        assert!(!is_test_us_mbi("1EG4TE5MK73"));
+    }
+}

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -67,6 +67,7 @@ pub enum IdentifierType {
     Passport,
     Ein,   // Employer Identification Number (XX-XXXXXXX, IRS campus prefix)
     Itin, // US Individual Taxpayer Identification Number (area 9XX, IRS middle group 50-65/70-88/90-92/94-99)
+    Mbi, // US Medicare Beneficiary Identifier (11-char CMS layout C A AN N A AN N A A N N, letters exclude S/L/O/I/B/Z)
     TaxId, // Generic TIN — EIN and ITIN have their own variants
     NationalId,
     KoreaRrn,           // South Korea Resident Registration Number (citizens, gender 1-4)


### PR DESCRIPTION
## Summary

Adds full support for the **US Medicare Beneficiary Identifier (MBI)** — the primary Medicare ID on every claim, prescription, and EHR field since it replaced SSN-based HICNs in 2018. Closes Presidio-parity gap **CRIT-6**.

Implemented as a complete identifier in the `government` domain, mirroring **ITIN** (structure) and **UkNhs** (a health identifier that is HIPAA-protected but structurally a government ID):

- **Detection + validation** enforcing the CMS 11-char layout `C A AN N A AN N A A N N` and the letter alphabet `ACDEFGHJKMNPQRTUVWXY` (excludes `S, L, O, I, B, Z`). Accepts bare and dashed `XXXX-XXX-XXXX` forms.
- **PII bridge** — `IdentifierType::Mbi` + `PiiType::Mbi` wired across all three registries (types, `From` mapping, scanner) with **HIPAA + high-risk** classification.
- **Builders + shortcuts** — primitives `GovernmentIdentifierBuilder`, Layer 3 `GovernmentBuilder` (instrumented), and free-function shortcuts.
- **Redaction** — `MbiRedactionStrategy`, `redact_mbi_with_strategy`, `redact_us_mbis_in_text_with_strategy`, `TextRedactionPolicy::to_mbi_strategy`, and wiring into `redact_all_government_ids_in_text_with_policy` so MBIs are **actually scrubbed** by the auto-redaction path, not merely detected.

### Correctness note

The issue's example fixtures (`1AB2C3D4EF5` / `1AB2-C3D-4EF5`) are **structurally invalid** under the CMS rule the issue cites: `B` is an excluded letter (pos 3) and `F` must be numeric (pos 10). Tests use the corrected valid example `1EG4TE5MK73` / `1EG4-TE5-MK73` (Presidio's documented sample) and treat the issue's strings as reject-cases — which satisfies the issue's real intent ("excluded-letter rejected", "wrong layout rejected").

### Scope note — redaction gap

An `audit-octarine-pii-sync` pass found the aggregate text redactor scrubs only ~8 of ~72 detected government IDs — MBI (and UkNhs, Korea, India, etc.) were detected + classified but never redacted (silent PHI passthrough). MBI is fixed here; the **systemic gap for the other country IDs is tracked in #672**.

## Test plan

- Detection/validation/builder/shortcut/redaction unit tests (accept valid bare + dashed; reject excluded-letter, wrong-layout, bad-length).
- End-to-end regression tests proving `redact_all_government_ids_in_text_with_policy` and the production redactor scrub `1EG4-TE5-MK73` → `[MBI]`.
- Gates green: 46 MBI tests, 922 government, 170 pii, `just clippy`, `just arch-check`, `just doc`, doctests.
- `audit-octarine-pii-sync` re-verified the bridge + redaction path CLEAN end-to-end.

Closes #428