### PR TITLE
refactor(architecture): import Problem/Result from canonical crate::observe in Layer 3

### DIFF
--- a/crates/octarine/src/auth/csrf/protection.rs
+++ b/crates/octarine/src/auth/csrf/protection.rs
@@ -3,10 +3,10 @@
 //! Provides CSRF protection operations with audit logging.
 
 use crate::observe;
+use crate::observe::Problem;
 use crate::primitives::auth::csrf::{
     CsrfConfig, CsrfToken, generate_csrf_token, tokens_match, validate_csrf_token,
 };
-use crate::primitives::types::Problem;
 
 // ============================================================================
 // CSRF Protection

--- a/crates/octarine/src/auth/lockout/manager.rs
+++ b/crates/octarine/src/auth/lockout/manager.rs
@@ -5,10 +5,10 @@
 use std::sync::Arc;
 
 use crate::observe;
+use crate::observe::Problem;
 use crate::primitives::auth::lockout::{
     LockoutConfig, LockoutDecision, LockoutStatus, calculate_backoff_duration, evaluate_lockout,
 };
-use crate::primitives::types::Problem;
 
 use super::store::LockoutStore;
 

--- a/crates/octarine/src/auth/lockout/store.rs
+++ b/crates/octarine/src/auth/lockout/store.rs
@@ -6,8 +6,8 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 use std::time::Duration;
 
+use crate::observe::Problem;
 use crate::primitives::auth::lockout::LockoutStatus;
-use crate::primitives::types::Problem;
 
 // ============================================================================
 // Lockout Store Trait

--- a/crates/octarine/src/auth/mfa/manager.rs
+++ b/crates/octarine/src/auth/mfa/manager.rs
@@ -3,11 +3,11 @@
 //! Provides MFA operations with audit logging.
 
 use crate::observe;
+use crate::observe::Problem;
 use crate::primitives::auth::mfa::{
     RecoveryCodes, TotpCode, TotpConfig, TotpSecret, generate_recovery_codes, generate_totp_code,
     generate_totp_secret, get_otpauth_uri, validate_totp_code,
 };
-use crate::primitives::types::Problem;
 
 // ============================================================================
 // MFA Enrollment Result

--- a/crates/octarine/src/auth/password/hibp.rs
+++ b/crates/octarine/src/auth/password/hibp.rs
@@ -37,7 +37,7 @@ use std::time::{Duration, Instant};
 use sha1::{Digest, Sha1};
 
 use crate::observe;
-use crate::primitives::types::Problem;
+use crate::observe::Problem;
 
 // ============================================================================
 // Configuration

--- a/crates/octarine/src/auth/password/mod.rs
+++ b/crates/octarine/src/auth/password/mod.rs
@@ -26,8 +26,8 @@ mod hibp;
 use std::time::Instant;
 
 use crate::observe;
+use crate::observe::Problem;
 use crate::primitives::auth::password as prim;
-use crate::primitives::types::Problem;
 
 // Re-export types from primitives
 pub use prim::{PasswordPolicy, PasswordPolicyBuilder, PasswordPolicyViolation, PasswordStrength};

--- a/crates/octarine/src/auth/remember/manager.rs
+++ b/crates/octarine/src/auth/remember/manager.rs
@@ -4,11 +4,11 @@
 
 use crate::crypto::secrets::{Secret, SecretString};
 use crate::observe;
+use crate::observe::Problem;
 use crate::primitives::auth::remember::{
     RememberConfig, RememberToken, RememberTokenPair, generate_remember_token, parse_cookie_value,
     validate_remember_token,
 };
-use crate::primitives::types::Problem;
 
 use super::store::RememberTokenStore;
 

--- a/crates/octarine/src/auth/remember/store.rs
+++ b/crates/octarine/src/auth/remember/store.rs
@@ -5,8 +5,8 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 
+use crate::observe::Problem;
 use crate::primitives::auth::remember::RememberToken;
-use crate::primitives::types::Problem;
 
 // ============================================================================
 // Remember Token Store Trait

--- a/crates/octarine/src/auth/reset/manager.rs
+++ b/crates/octarine/src/auth/reset/manager.rs
@@ -3,10 +3,10 @@
 //! Provides password reset operations with audit logging for ASVS V2.5 compliance.
 
 use crate::observe;
+use crate::observe::Problem;
 use crate::primitives::auth::reset::{
     ResetConfig, ResetToken, generate_reset_token, validate_rate_limit, validate_reset_token,
 };
-use crate::primitives::types::Problem;
 
 use super::store::ResetTokenStore;
 

--- a/crates/octarine/src/auth/reset/store.rs
+++ b/crates/octarine/src/auth/reset/store.rs
@@ -7,8 +7,8 @@ use std::sync::RwLock;
 use std::time::{Duration, Instant};
 use zeroize::Zeroize;
 
+use crate::observe::Problem;
 use crate::primitives::auth::reset::ResetToken;
-use crate::primitives::types::Problem;
 
 // ============================================================================
 // Reset Token Store Trait

--- a/crates/octarine/src/auth/session/manager.rs
+++ b/crates/octarine/src/auth/session/manager.rs
@@ -5,8 +5,8 @@
 use std::sync::Arc;
 
 use crate::observe;
+use crate::observe::Problem;
 use crate::primitives::auth::session::{Session, SessionBinding, SessionConfig, SessionId};
-use crate::primitives::types::Problem;
 
 use super::store::SessionStore;
 

--- a/crates/octarine/src/auth/session/store.rs
+++ b/crates/octarine/src/auth/session/store.rs
@@ -5,8 +5,8 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 
+use crate::observe::Problem;
 use crate::primitives::auth::session::{Session, SessionId};
-use crate::primitives::types::Problem;
 
 // ============================================================================
 // Session Store Trait

--- a/crates/octarine/src/crypto/validation/shortcuts.rs
+++ b/crates/octarine/src/crypto/validation/shortcuts.rs
@@ -3,7 +3,7 @@
 //! Convenience functions for common crypto validation operations.
 
 use super::{CryptoPolicy, KeyType, SignatureAlgorithm};
-use crate::primitives::types::Problem;
+use crate::observe::Problem;
 
 #[cfg(feature = "crypto-validation")]
 use super::CryptoAuditResult;

--- a/crates/octarine/src/data/formats/builder.rs
+++ b/crates/octarine/src/data/formats/builder.rs
@@ -7,10 +7,10 @@ use std::time::Instant;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 
+use crate::observe::Result;
 use crate::observe::metrics::record;
 use crate::observe::{debug, warn};
 use crate::primitives::data::formats::{FormatBuilder as PrimBuilder, FormatType, XmlDocument};
-use crate::primitives::types::Result;
 
 crate::define_metrics! {
     parse_ms => "data.formats.parse_ms",

--- a/crates/octarine/src/data/formats/shortcuts.rs
+++ b/crates/octarine/src/data/formats/shortcuts.rs
@@ -5,8 +5,8 @@
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 
+use crate::observe::Result;
 use crate::primitives::data::formats::{FormatType, XmlDocument};
-use crate::primitives::types::Result;
 
 use super::FormatBuilder;
 

--- a/crates/octarine/src/io/formats/builder.rs
+++ b/crates/octarine/src/io/formats/builder.rs
@@ -4,12 +4,12 @@
 
 use std::path::Path;
 
+use crate::observe::Result;
 use crate::observe::{debug, warn};
 use crate::primitives::data::formats::FormatType;
 use crate::primitives::io::formats::{
     FormatIoBuilder as PrimBuilder, FormatReadOptions, FormatWriteOptions, ReadResult,
 };
-use crate::primitives::types::Result;
 
 /// Builder for format-aware I/O operations with observability
 ///

--- a/crates/octarine/src/io/formats/shortcuts.rs
+++ b/crates/octarine/src/io/formats/shortcuts.rs
@@ -4,8 +4,8 @@
 
 use std::path::Path;
 
+use crate::observe::Result;
 use crate::primitives::data::formats::FormatType;
-use crate::primitives::types::Result;
 
 use super::{FormatIoBuilder, ReadResult};
 

--- a/crates/octarine/src/observe/metrics/export/prometheus.rs
+++ b/crates/octarine/src/observe/metrics/export/prometheus.rs
@@ -5,8 +5,8 @@
 use std::fmt::Write;
 
 use super::DefaultLabels;
+use crate::observe::Problem;
 use crate::observe::metrics::{CounterSnapshot, GaugeSnapshot, HistogramSnapshot, MetricSnapshot};
-use crate::primitives::types::Problem;
 
 /// Result type for Prometheus rendering operations.
 pub type Result<T> = std::result::Result<T, Problem>;

--- a/crates/octarine/src/runtime/formats/json.rs
+++ b/crates/octarine/src/runtime/formats/json.rs
@@ -6,10 +6,10 @@ use std::path::Path;
 
 use serde_json::Value as JsonValue;
 
+use crate::observe::Result;
 use crate::observe::{debug, info};
 use crate::primitives::data::formats::FormatBuilder;
 use crate::primitives::security::formats::{FormatSecurityBuilder, JsonPolicy};
-use crate::primitives::types::Result;
 
 /// Secure JSON reader with policy enforcement
 ///

--- a/crates/octarine/src/runtime/formats/xml.rs
+++ b/crates/octarine/src/runtime/formats/xml.rs
@@ -4,10 +4,10 @@
 
 use std::path::Path;
 
+use crate::observe::Result;
 use crate::observe::{debug, info};
 use crate::primitives::data::formats::{FormatBuilder, XmlDocument};
 use crate::primitives::security::formats::{FormatSecurityBuilder, XmlPolicy};
-use crate::primitives::types::Result;
 
 /// Secure XML reader with XXE prevention
 ///

--- a/crates/octarine/src/runtime/formats/yaml.rs
+++ b/crates/octarine/src/runtime/formats/yaml.rs
@@ -6,10 +6,10 @@ use std::path::Path;
 
 use serde_yaml::Value as YamlValue;
 
+use crate::observe::Result;
 use crate::observe::{debug, info};
 use crate::primitives::data::formats::FormatBuilder;
 use crate::primitives::security::formats::{FormatSecurityBuilder, YamlPolicy};
-use crate::primitives::types::Result;
 
 /// Secure YAML reader with code execution prevention
 ///

--- a/crates/octarine/src/security/formats/builder.rs
+++ b/crates/octarine/src/security/formats/builder.rs
@@ -4,13 +4,13 @@
 
 use std::time::Instant;
 
+use crate::observe::Result;
 use crate::observe::metrics::{increment_by, record};
 use crate::observe::{debug, warn};
 use crate::primitives::data::formats::FormatType;
 use crate::primitives::security::formats::{
     FormatSecurityBuilder as PrimBuilder, FormatThreat, JsonPolicy, XmlPolicy, YamlPolicy,
 };
-use crate::primitives::types::Result;
 
 crate::define_metrics! {
     validate_ms => "security.formats.validate_ms",

--- a/crates/octarine/src/security/formats/shortcuts.rs
+++ b/crates/octarine/src/security/formats/shortcuts.rs
@@ -2,8 +2,8 @@
 //!
 //! Convenience functions for common format security operations.
 
+use crate::observe::Result;
 use crate::primitives::data::formats::FormatType;
-use crate::primitives::types::Result;
 
 use super::{FormatSecurityBuilder, FormatThreat, JsonPolicy, XmlPolicy, YamlPolicy};
 

--- a/crates/octarine/src/security/queries/builder.rs
+++ b/crates/octarine/src/security/queries/builder.rs
@@ -5,12 +5,12 @@
 use std::time::Instant;
 
 use crate::observe;
+use crate::observe::Problem;
 use crate::observe::metrics::{increment_by, record};
 use crate::primitives::security::queries::{
     GraphqlAnalysis, GraphqlConfig, GraphqlSchema, QuerySecurityBuilder as PrimitiveBuilder,
     QueryThreat, QueryType,
 };
-use crate::primitives::types::Problem;
 
 crate::define_metrics! {
     validate_ms => "security.queries.validate_ms",

--- a/crates/octarine/src/security/queries/shortcuts.rs
+++ b/crates/octarine/src/security/queries/shortcuts.rs
@@ -4,7 +4,7 @@
 //! These wrap the QueryBuilder for simple use cases.
 
 use super::{GraphqlAnalysis, QueryBuilder, QueryThreat, QueryType};
-use crate::primitives::types::Problem;
+use crate::observe::Problem;
 
 // ============================================================================
 // SQL Shortcuts


### PR DESCRIPTION
## Summary

- Rewrites the `Problem`/`Result` import path in **25 Layer 3 files** from
  `crate::primitives::types` (Layer 1) to the canonical `crate::observe`
  (Layer 2 re-export), resolving audit finding `octarine-visibility-002`.
- Layer 3 must depend only on `observe`, which re-exports the Layer 1 type
  definitions via `observe/problem/types.rs` → `observe/mod.rs`. Importing
  directly from `primitives::types` tightened coupling to the internal layer
  and bypassed that chain.
- Matches the established pattern in `security/paths/shortcuts.rs` and siblings.
- **Deliberately excluded**: `observe/problem/types.rs` — it is the single
  canonical re-export source and must keep importing from `primitives::types`.
  All `primitives/**` files also legitimately use the Layer 1 path.

Files touched span `auth/`, `crypto/`, `data/`, `io/`, `observe/metrics/`,
`runtime/`, and `security/` — one import line each, no logic changes.

## Test plan

- `just fmt-check` — clean (one import group reordered by `just fmt`)
- `just clippy` — clean, all features (proves every rewritten path resolves
  through the observe re-export)
- `just test` — nextest + doctests, full workspace, 0 failures
- `git diff --stat` — 25 files, 25 insertions / 25 deletions, nothing under
  `src/primitives/`, re-export source untouched

Closes #403