### PR TITLE
docs(docs): fix stale references to removed/renamed paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ overview and [docs/architecture/](docs/architecture/) for the three-layer
 design.
 
 This file is deliberately minimal — it covers dev setup and the SemVer policy.
-Branching and the full PR workflow are documented in the project skills under
-`.claude/skills/git-workflow/`. Commit format is enforced automatically — see
-[Commit Format](#commit-format) below.
+The three-layer design and module layout live in
+[docs/architecture/](docs/architecture/). Commit format is enforced
+automatically — see [Commit Format](#commit-format) below.
 
 ## Commit Format
 

--- a/docs/architecture/security/identifiers.md
+++ b/docs/architecture/security/identifiers.md
@@ -4,7 +4,9 @@
 >
 > **Audience**: Developers extending the identifier system or understanding design decisions.
 >
-> **Location**: `src/security/data/{detection,validation,sanitization}/identifiers/`
+> **Location**: `src/primitives/identifiers/` (Layer 1 detection,
+> validation, sanitization) and `src/identifiers/` (Layer 3
+> observability-instrumented API)
 
 ______________________________________________________________________
 
@@ -880,7 +882,7 @@ ______________________________________________________________________
 ### Internal Documentation
 
 - `docs/architecture/refactor-plan.md`: Refactor status summary (v0.3.0-beta.1)
-- `src/security/data/MODULE_QUALITY_SCORECARD.md`: Quality metrics framework
+- `docs/module-quality.md`: Quality metrics framework
 - `CLAUDE.md`: Zero-trust security philosophy
 - `docs/security/patterns/detection-validation-sanitization.md`: Layer separation philosophy
 

--- a/docs/module-quality.md
+++ b/docs/module-quality.md
@@ -743,7 +743,7 @@ ______________________________________________________________________
 
 ```text
 Please evaluate the {module_name} module using the Module Quality Scorecard
-at /workspace/octarine/src/security/data/MODULE_QUALITY_SCORECARD.md
+at docs/module-quality.md
 
 Provide:
 1. Completed scorecard with point values and justification for each category

--- a/docs/observe/compliance.md
+++ b/docs/observe/compliance.md
@@ -21,8 +21,11 @@ The observe module captures user identity and access context:
 
 ```rust
 use octarine::observe::{set_tenant, TenantContext, TenantId, info};
+use octarine::runtime::r#async::set_user_id;
 
-// Set user context at authentication boundary
+// Set user and tenant context at the authentication boundary
+set_user_id("user-123");
+
 let tenant_id = TenantId::new("acme-corp").expect("valid");
 let ctx = TenantContext {
     tenant_id,
@@ -40,7 +43,7 @@ info("resource_access", "User accessed customer record");
 
 | Requirement | Feature |
 |-------------|---------|
-| User identification | `TenantContext.user_id` captured in events |
+| User identification | `EventContext.user_id` captured in events |
 | Access logging | Every event includes context metadata |
 | Session tracking | Correlation ID propagation |
 | Multi-tenant isolation | Thread-local tenant context |


### PR DESCRIPTION
## Summary

Fixes four stale documentation references flagged by the docs audit (finding IDs docs-006–docs-009), plus one identical dangling reference found in the same pass. All pointed at paths/APIs that no longer exist after the v0.3.0 refactor.

- **`docs/observe/compliance.md`** — SOC2 CC6.1 control table cited `TenantContext.user_id`, which doesn't exist (`TenantContext` has only `tenant_id`/`tenant_name`/`tenant_tier`). Corrected to `EventContext.user_id`. The adjacent code example was also misleading — it set only tenant context yet claimed events "include user identity" — so it now calls `set_user_id(...)` to actually demonstrate the capture.
- **`docs/architecture/security/identifiers.md`** — Location header pointed at the removed `src/security/data/{...}/identifiers/` tree; now points at the post-refactor `src/primitives/identifiers/` (Layer 1) and `src/identifiers/` (Layer 3). Dangling `MODULE_QUALITY_SCORECARD.md` reference relinked to `docs/module-quality.md`.
- **`docs/module-quality.md`** — same dangling `MODULE_QUALITY_SCORECARD.md` path in the review-prompt block, fixed to repo-relative `docs/module-quality.md`.
- **`CONTRIBUTING.md`** — removed the broken `.claude/skills/git-workflow/` reference (no such skill exists) in favor of `docs/architecture/`.

## Test plan

- `just doc` passes clean (rustdoc `-D warnings`); no doc-graph regressions.
- `grep -rn "MODULE_QUALITY_SCORECARD\|skills/git-workflow\|TenantContext.user_id" docs/ CONTRIBUTING.md` returns nothing for the targeted references.
- `set_user_id` import path (`octarine::runtime::r#async::set_user_id`) verified against the re-export in `runtime/async/mod.rs`.
- Docs-only change — no Rust source touched.

Closes #402