### PR TITLE
feat(identifiers): add Spanish Passport (ES_PASSPORT)

### DIFF
--- a/crates/octarine/src/identifiers/builder/government/europe.rs
+++ b/crates/octarine/src/identifiers/builder/government/europe.rs
@@ -131,6 +131,62 @@ impl GovernmentBuilder {
         self.inner.validate_spain_nie_with_checksum(nie)
     }
 
+    // ---- Spain passport ------------------------------------------------------
+
+    /// Check if value matches a Spanish passport pattern
+    #[must_use]
+    pub fn is_spain_passport(&self, value: &str) -> bool {
+        let start = Instant::now();
+        let result = self.inner.is_spain_passport(value);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result {
+                increment_by(metric_names::detected(), 1);
+                increment_by(metric_names::government_data_found(), 1);
+            }
+        }
+        result
+    }
+
+    /// Find all Spanish passport mentions in text (label-anchored only)
+    #[must_use]
+    pub fn find_spain_passports_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_spain_passports_in_text(text);
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+            }
+        }
+        matches
+    }
+
+    /// Validate Spanish passport format (3 letters + 6 digits, no checksum)
+    pub fn validate_spain_passport(&self, value: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_spain_passport(value);
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if result.is_err() {
+                observe::warn(
+                    "spain_passport_validation_failed",
+                    "Invalid Spain passport format",
+                );
+            }
+        }
+        result
+    }
+
     // ---- Italy Codice Fiscale ------------------------------------------------
 
     /// Check if value matches an Italian Codice Fiscale pattern

--- a/crates/octarine/src/identifiers/shortcuts/government.rs
+++ b/crates/octarine/src/identifiers/shortcuts/government.rs
@@ -700,6 +700,31 @@ pub fn validate_germany_passport_with_checksum(value: &str) -> Result<(), Proble
     GovernmentBuilder::new().validate_germany_passport_with_checksum(value)
 }
 
+// ============================================================================
+// Spain — Passport
+// ============================================================================
+
+/// Check if value is a valid Spanish passport number (3 letters + 6 digits)
+#[must_use]
+pub fn is_spain_passport(value: &str) -> bool {
+    GovernmentBuilder::new().is_spain_passport(value)
+}
+
+/// Find all Spanish passport mentions in text (label-anchored only)
+#[must_use]
+pub fn find_spain_passports(text: &str) -> Vec<IdentifierMatch> {
+    GovernmentBuilder::new().find_spain_passports_in_text(text)
+}
+
+/// Validate a Spanish passport format (3 letters + 6 digits, no checksum)
+///
+/// # Errors
+///
+/// Returns `Problem` if the value is not a valid passport format.
+pub fn validate_spain_passport(value: &str) -> Result<(), Problem> {
+    GovernmentBuilder::new().validate_spain_passport(value)
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
@@ -921,5 +946,17 @@ mod tests {
         // Tampered check digit rejected.
         assert!(validate_germany_passport_with_checksum("T220001294").is_err());
         assert!(!find_germany_passports("Reisepass T220001293").is_empty());
+    }
+
+    #[test]
+    fn test_spain_passport_shortcuts() {
+        assert!(is_spain_passport("ABC123456"));
+        assert!(validate_spain_passport("ABC123456").is_ok());
+        assert!(validate_spain_passport("").is_err());
+        // Wrong shape rejected.
+        assert!(validate_spain_passport("AB1234567").is_err());
+        // Label-gated text scanning — bare shape does not match.
+        assert!(!find_spain_passports("pasaporte ABC123456").is_empty());
+        assert!(find_spain_passports("ABC123456").is_empty());
     }
 }

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -205,6 +205,7 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             | PiiType::ItalyDriverLicense
             | PiiType::SpainNif
             | PiiType::SpainNie
+            | PiiType::SpainPassport
             | PiiType::UkNi
             | PiiType::UkNhs
             | PiiType::UkPassport

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -258,6 +258,10 @@ pub(super) fn scan_government(text: &str, pii_types: &mut Vec<PiiType>) {
             PiiType::SpainNie,
         ),
         (
+            GovernmentIdentifierBuilder::find_spain_passports_in_text,
+            PiiType::SpainPassport,
+        ),
+        (
             GovernmentIdentifierBuilder::find_uk_nis_in_text,
             PiiType::UkNi,
         ),

--- a/crates/octarine/src/observe/pii/types/classification.rs
+++ b/crates/octarine/src/observe/pii/types/classification.rs
@@ -28,7 +28,7 @@ impl PiiType {
             Self::TurkeyTckn | Self::TurkeyLicensePlate |
             Self::SingaporeNric | Self::FinlandHetu | Self::PolandPesel | Self::ItalyFiscalCode |
             Self::ItalyVat | Self::ItalyPassport | Self::ItalyIdentityCard | Self::ItalyDriverLicense |
-            Self::SpainNif | Self::SpainNie | Self::UkNi |
+            Self::SpainNif | Self::SpainNie | Self::SpainPassport | Self::UkNi |
             Self::UkNhs | Self::UkPassport | Self::UkDrivingLicence |
             Self::SwedenPersonnummer | Self::SwedenOrgnummer |
             Self::GermanyTaxId | Self::GermanyIdCard | Self::GermanyPassport |
@@ -76,7 +76,7 @@ impl PiiType {
             // PIPA/Privacy Act 1988/DPDPA/PDPA — not GDPR)
             Self::FinlandHetu | Self::PolandPesel | Self::ItalyFiscalCode |
             Self::ItalyVat | Self::ItalyPassport | Self::ItalyIdentityCard | Self::ItalyDriverLicense |
-            Self::SpainNif | Self::SpainNie | Self::UkNi |
+            Self::SpainNif | Self::SpainNie | Self::SpainPassport | Self::UkNi |
             Self::UkNhs | Self::UkPassport | Self::UkDrivingLicence |
             Self::SwedenPersonnummer | Self::SwedenOrgnummer |
             // German IDs — Steuer-IdNr protected under §§ 139a-139e AO + DSGVO,

--- a/crates/octarine/src/observe/pii/types/core.rs
+++ b/crates/octarine/src/observe/pii/types/core.rs
@@ -68,6 +68,7 @@ impl PiiType {
             Self::ItalyDriverLicense => "italy_driver_license",
             Self::SpainNif => "spain_nif",
             Self::SpainNie => "spain_nie",
+            Self::SpainPassport => "spain_passport",
             Self::UkNi => "uk_ni",
             Self::UkNhs => "uk_nhs",
             Self::UkPassport => "uk_passport",
@@ -229,6 +230,7 @@ impl PiiType {
             | Self::ItalyDriverLicense
             | Self::SpainNif
             | Self::SpainNie
+            | Self::SpainPassport
             | Self::UkNi
             | Self::UkNhs
             | Self::UkPassport

--- a/crates/octarine/src/observe/pii/types/mapping.rs
+++ b/crates/octarine/src/observe/pii/types/mapping.rs
@@ -115,6 +115,7 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::ItalyDriverLicense => Self::ItalyDriverLicense,
             IdentifierType::SpainNif => Self::SpainNif,
             IdentifierType::SpainNie => Self::SpainNie,
+            IdentifierType::SpainPassport => Self::SpainPassport,
             IdentifierType::UkNi => Self::UkNi,
             IdentifierType::UkNhs => Self::UkNhs,
             IdentifierType::UkPassport => Self::UkPassport,

--- a/crates/octarine/src/observe/pii/types/mod.rs
+++ b/crates/octarine/src/observe/pii/types/mod.rs
@@ -167,6 +167,8 @@ pub enum PiiType {
     SpainNif,
     /// Spanish NIE (Numero de Identidad de Extranjero)
     SpainNie,
+    /// Spanish passport (3 letters + 6 digits, no checksum)
+    SpainPassport,
     /// UK National Insurance Number (NINO)
     UkNi,
     /// UK NHS Number (10 digits, mod-11 weighted checksum)

--- a/crates/octarine/src/observe/pii/types/tests.rs
+++ b/crates/octarine/src/observe/pii/types/tests.rs
@@ -211,6 +211,7 @@ fn test_country_specific_government_classifications() {
         PiiType::ItalyDriverLicense,
         PiiType::SpainNif,
         PiiType::SpainNie,
+        PiiType::SpainPassport,
         PiiType::UkNi,
         PiiType::GermanyTaxId,
         PiiType::GermanyIdCard,
@@ -271,6 +272,7 @@ fn test_country_specific_government_classifications() {
     assert_eq!(PiiType::ItalyIdentityCard.name(), "italy_identity_card");
     assert_eq!(PiiType::ItalyDriverLicense.name(), "italy_driver_license");
     assert_eq!(PiiType::SpainNie.name(), "spain_nie");
+    assert_eq!(PiiType::SpainPassport.name(), "spain_passport");
     assert_eq!(PiiType::UkNi.name(), "uk_ni");
     assert_eq!(PiiType::GermanyTaxId.name(), "germany_tax_id");
     assert_eq!(PiiType::GermanyIdCard.name(), "germany_id_card");
@@ -523,6 +525,10 @@ fn from_identifier_type_direct_mappings() {
     );
     assert_eq!(PiiType::from(IdentifierType::SpainNif), PiiType::SpainNif);
     assert_eq!(PiiType::from(IdentifierType::SpainNie), PiiType::SpainNie);
+    assert_eq!(
+        PiiType::from(IdentifierType::SpainPassport),
+        PiiType::SpainPassport
+    );
     assert_eq!(PiiType::from(IdentifierType::UkNi), PiiType::UkNi);
     assert_eq!(
         PiiType::from(IdentifierType::GermanyTaxId),

--- a/crates/octarine/src/primitives/identifiers/common/keywords/es.rs
+++ b/crates/octarine/src/primitives/identifiers/common/keywords/es.rs
@@ -1,12 +1,18 @@
 //! Spanish (`es`) context keywords for identifier confidence scoring.
 //!
-//! Placeholder for the follow-up translation PRs (Step 3 of #432). The file
-//! exists so the per-language layout is complete; keyword data is sourced from
-//! Presidio's MIT-licensed `country_specific/es` files with attribution.
+//! Keyword data is sourced from Presidio's MIT-licensed `country_specific/es`
+//! files with attribution. Keywords are lowercase — the analyzer lowercases the
+//! text window before matching.
 
 use crate::primitives::identifiers::IdentifierType;
 
 /// Spanish (`es`) context keyword table, keyed by identifier type.
-///
-/// Empty until the translation PR populates it.
-pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[];
+pub(super) static KEYWORDS: &[(IdentifierType, &[&str])] = &[(
+    IdentifierType::SpainPassport,
+    &[
+        "pasaporte",
+        "número de pasaporte",
+        "numero de pasaporte",
+        "pasaporte español",
+    ],
+)];

--- a/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/mod.rs
@@ -44,8 +44,8 @@ pub(crate) use personal::{
     italy_driver_license, italy_fiscal_code, italy_identity_card, italy_passport, italy_vat,
     korea_brn, korea_driver_license, korea_frn, korea_passport, korea_rrn, mbi, mexico_curp,
     national_id, nigeria_bvn, nigeria_nin, nigeria_vehicle_reg, passport, personal_name,
-    poland_pesel, singapore_nric, singapore_uen, spain_nie, spain_nif, ssn, student_id,
-    sweden_orgnummer, sweden_personnummer, tax_id, thailand_tnin, turkey_license_plate,
+    poland_pesel, singapore_nric, singapore_uen, spain_nie, spain_nif, spain_passport, ssn,
+    student_id, sweden_orgnummer, sweden_personnummer, tax_id, thailand_tnin, turkey_license_plate,
     turkey_tckn, uk_driving_licence, uk_nhs, uk_ni, uk_passport,
 };
 

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/mod.rs
@@ -40,9 +40,9 @@ pub(crate) use regional_identifiers::{
     birthdate, brazil_cnpj, brazil_cpf, finland_hetu, germany_id_card, germany_passport,
     germany_tax_id, italy_driver_license, italy_fiscal_code, italy_identity_card, italy_passport,
     italy_vat, mexico_curp, nigeria_bvn, nigeria_nin, nigeria_vehicle_reg, personal_name,
-    poland_pesel, singapore_nric, singapore_uen, spain_nie, spain_nif, sweden_orgnummer,
-    sweden_personnummer, thailand_tnin, turkey_license_plate, turkey_tckn, uk_driving_licence,
-    uk_nhs, uk_ni, uk_passport,
+    poland_pesel, singapore_nric, singapore_uen, spain_nie, spain_nif, spain_passport,
+    sweden_orgnummer, sweden_personnummer, thailand_tnin, turkey_license_plate, turkey_tckn,
+    uk_driving_licence, uk_nhs, uk_ni, uk_passport,
 };
 pub(crate) use us_identifiers::{
     driver_license, employee_id, mbi, passport, ssn, student_id, tax_id,

--- a/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/personal/regional_identifiers.rs
@@ -528,6 +528,36 @@ pub(crate) mod spain_nie {
     }
 }
 
+/// Spain passport patterns
+///
+/// Format: 3 letters + 6 digits (`[A-Z]{3}[0-9]{6}`). No checksum — matches
+/// Presidio's `EsPassportRecognizer`.
+pub(crate) mod spain_passport {
+    use super::*;
+
+    /// Passport format: 3 letters + 6 digits
+    pub static STANDARD: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"(?i)\b[A-Z]{3}\d{6}\b").expect("BUG: Invalid regex pattern"));
+
+    /// Passport with explicit label (Spanish + English aliases)
+    pub static LABELED: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\b(?:pasaporte(?:\s+español)?|(?:n[uú]mero[\s-]?de[\s-]?)?pasaporte|passport(?:[\s-]?number|[\s-]?no\.?)?)[\s:#-]*([A-Z]{3}\d{6})\b",
+        )
+        .expect("BUG: Invalid regex pattern")
+    });
+
+    pub fn all() -> Vec<&'static Regex> {
+        vec![&*LABELED, &*STANDARD]
+    }
+
+    /// Label-anchored only — the bare 3-letter + 6-digit shape is too loose
+    /// for unlabeled text scanning.
+    pub fn labeled_only() -> Vec<&'static Regex> {
+        vec![&*LABELED]
+    }
+}
+
 /// Italy Codice Fiscale (fiscal code) patterns
 pub(crate) mod italy_fiscal_code {
     use super::*;

--- a/crates/octarine/src/primitives/identifiers/government/builder/europe.rs
+++ b/crates/octarine/src/primitives/identifiers/government/builder/europe.rs
@@ -114,6 +114,27 @@ impl GovernmentIdentifierBuilder {
         validation::is_test_spain_nie(nie)
     }
 
+    /// Check if value matches Spain passport format
+    #[must_use]
+    pub fn is_spain_passport(&self, value: &str) -> bool {
+        detection::is_spain_passport(value)
+    }
+
+    /// Find all Spain passports in text (label-anchored)
+    #[must_use]
+    pub fn find_spain_passports_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_spain_passports_in_text(text)
+    }
+
+    /// Validate Spain passport format (3 letters + 6 digits, no checksum)
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the passport format is invalid
+    pub fn validate_spain_passport(&self, value: &str) -> Result<(), Problem> {
+        validation::validate_spain_passport(value)
+    }
+
     /// Check if value matches Italy Codice Fiscale format
     #[must_use]
     pub fn is_italy_fiscal_code(&self, value: &str) -> bool {

--- a/crates/octarine/src/primitives/identifiers/government/detection/europe.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/europe.rs
@@ -112,6 +112,44 @@ pub fn find_spain_nies_in_text(text: &str) -> Vec<IdentifierMatch> {
     deduplicate_matches(matches)
 }
 
+/// Check if a value matches Spain passport format
+#[must_use]
+pub fn is_spain_passport(value: &str) -> bool {
+    if exceeds_safe_length(value, MAX_IDENTIFIER_LENGTH) {
+        return false;
+    }
+    patterns::spain_passport::all()
+        .iter()
+        .any(|p| p.is_match(value))
+}
+
+/// Find all Spain passport patterns in text
+///
+/// Label-anchored only: the bare 3-letter + 6-digit shape is too loose to
+/// scan for in unlabeled text without excessive false positives.
+#[must_use]
+pub fn find_spain_passports_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for pattern in patterns::spain_passport::labeled_only() {
+        for capture in pattern.captures_iter(text) {
+            let full_match = get_full_match(&capture);
+            matches.push(IdentifierMatch::high_confidence(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::SpainPassport,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
 /// Check if a value matches Italy Codice Fiscale format
 #[must_use]
 pub fn is_italy_fiscal_code(value: &str) -> bool {
@@ -558,6 +596,47 @@ mod tests {
     #[test]
     fn test_find_uk_driving_licences_dvla_label_accepted() {
         let matches = find_uk_driving_licences_in_text("DVLA MORGA753116SM9IJ");
+        assert_eq!(matches.len(), 1);
+    }
+
+    // ----- Spain Passport -----
+
+    #[test]
+    fn test_is_spain_passport_accepts_valid_shape() {
+        assert!(is_spain_passport("ABC123456"));
+        assert!(is_spain_passport("XYZ987654"));
+        // Case-insensitive.
+        assert!(is_spain_passport("abc123456"));
+    }
+
+    #[test]
+    fn test_is_spain_passport_rejects_wrong_shape() {
+        assert!(!is_spain_passport("AB1234567")); // 2 letters + 7 digits
+        assert!(!is_spain_passport("ABCD12345")); // 4 letters + 5 digits
+        assert!(!is_spain_passport("ABC12345")); // only 5 digits
+        assert!(!is_spain_passport("123456789")); // all digits
+    }
+
+    #[test]
+    fn test_find_spain_passports_in_text_requires_label() {
+        let matches = find_spain_passports_in_text("pasaporte ABC123456 emitido en Madrid");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches.first().expect("one match").identifier_type,
+            IdentifierType::SpainPassport
+        );
+    }
+
+    #[test]
+    fn test_find_spain_passports_in_text_no_label_no_match() {
+        // Bare 3-letter + 6-digit run without a label should not be picked up.
+        let matches = find_spain_passports_in_text("Reference code ABC123456 attached.");
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_find_spain_passports_in_text_english_label() {
+        let matches = find_spain_passports_in_text("Passport number: XYZ987654");
         assert_eq!(matches.len(), 1);
     }
 }

--- a/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/detection/mod.rs
@@ -82,10 +82,11 @@ pub use europe::{
     find_finland_hetus_in_text, find_italy_driver_licenses_in_text,
     find_italy_fiscal_codes_in_text, find_italy_identity_cards_in_text,
     find_italy_passports_in_text, find_italy_vats_in_text, find_poland_pesels_in_text,
-    find_spain_nies_in_text, find_spain_nifs_in_text, find_uk_driving_licences_in_text,
-    find_uk_nhs_in_text, find_uk_passports_in_text, is_finland_hetu, is_italy_driver_license,
-    is_italy_fiscal_code, is_italy_identity_card, is_italy_passport, is_italy_vat, is_poland_pesel,
-    is_spain_nie, is_spain_nif, is_uk_driving_licence, is_uk_nhs, is_uk_passport,
+    find_spain_nies_in_text, find_spain_nifs_in_text, find_spain_passports_in_text,
+    find_uk_driving_licences_in_text, find_uk_nhs_in_text, find_uk_passports_in_text,
+    is_finland_hetu, is_italy_driver_license, is_italy_fiscal_code, is_italy_identity_card,
+    is_italy_passport, is_italy_vat, is_poland_pesel, is_spain_nie, is_spain_nif,
+    is_spain_passport, is_uk_driving_licence, is_uk_nhs, is_uk_passport,
 };
 pub use germany::{
     find_germany_id_cards_in_text, find_germany_passports_in_text, find_germany_tax_ids_in_text,
@@ -238,6 +239,8 @@ pub fn detect_government_identifier(value: &str) -> Option<IdentifierType> {
         Some(IdentifierType::SpainNif)
     } else if is_spain_nie(value) {
         Some(IdentifierType::SpainNie)
+    } else if is_spain_passport(value) {
+        Some(IdentifierType::SpainPassport)
     } else if is_uk_ni(value) {
         Some(IdentifierType::UkNi)
     } else if is_national_id(value) {
@@ -326,6 +329,7 @@ pub fn find_all_government_ids_in_text(text: &str) -> Vec<IdentifierMatch> {
     all_matches.extend(find_italy_driver_licenses_in_text(text));
     all_matches.extend(find_spain_nifs_in_text(text));
     all_matches.extend(find_spain_nies_in_text(text));
+    all_matches.extend(find_spain_passports_in_text(text));
     all_matches.extend(find_uk_nis_in_text(text));
     all_matches.extend(find_uk_nhs_in_text(text));
     all_matches.extend(find_uk_passports_in_text(text));

--- a/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/mod.rs
@@ -130,7 +130,7 @@ pub use italy::{
 // Re-export Spain functions
 pub use spain::{
     is_test_spain_nie, is_test_spain_nif, validate_spain_nie, validate_spain_nie_with_checksum,
-    validate_spain_nif, validate_spain_nif_with_checksum,
+    validate_spain_nif, validate_spain_nif_with_checksum, validate_spain_passport,
 };
 
 // Re-export Sweden functions

--- a/crates/octarine/src/primitives/identifiers/government/validation/spain.rs
+++ b/crates/octarine/src/primitives/identifiers/government/validation/spain.rs
@@ -239,6 +239,35 @@ pub fn is_test_spain_nie(value: &str) -> bool {
 }
 
 // ============================================================================
+// Passport Validation
+// ============================================================================
+
+/// Validate Spain passport format (3 letters + 6 digits, no checksum)
+///
+/// The Spanish passport number has no check digit — validation is purely
+/// structural. Calls detection first (DRY: validators depend on detectors).
+///
+/// # Errors
+///
+/// Returns `Problem::Validation` if the value is not a valid passport format.
+pub fn validate_spain_passport(value: &str) -> Result<(), Problem> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(Problem::Validation(
+            "Spain passport cannot be empty".to_string(),
+        ));
+    }
+
+    if !super::super::detection::is_spain_passport(trimmed) {
+        return Err(Problem::Validation(
+            "Spain passport must be 3 letters followed by 6 digits".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -472,6 +501,34 @@ mod tests {
     fn test_is_test_nie_wrong_length() {
         assert!(!is_test_spain_nie("12345"));
         assert!(!is_test_spain_nie(""));
+    }
+
+    // ===== Passport format validation =====
+
+    #[test]
+    fn test_validate_passport_valid() {
+        assert!(validate_spain_passport("AAA123456").is_ok());
+        assert!(validate_spain_passport("XYZ987654").is_ok());
+    }
+
+    #[test]
+    fn test_validate_passport_case_insensitive() {
+        assert!(validate_spain_passport("aaa123456").is_ok());
+    }
+
+    #[test]
+    fn test_validate_passport_empty() {
+        assert!(validate_spain_passport("").is_err());
+        assert!(validate_spain_passport("   ").is_err());
+    }
+
+    #[test]
+    fn test_validate_passport_wrong_shape() {
+        assert!(validate_spain_passport("AA1234567").is_err()); // 2 letters + 7 digits
+        assert!(validate_spain_passport("AAAA12345").is_err()); // 4 letters + 5 digits
+        assert!(validate_spain_passport("AAA12345").is_err()); // only 5 digits
+        assert!(validate_spain_passport("123456789").is_err()); // all digits
+        assert!(validate_spain_passport("ABC12345X").is_err()); // trailing letter
     }
 
     // ===== Check letters verification =====

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -478,6 +478,10 @@ impl StreamingScanner {
                 GovernmentIdentifierBuilder::find_spain_nies_in_text,
             ),
             (
+                |t| matches!(t, IdentifierType::SpainPassport),
+                GovernmentIdentifierBuilder::find_spain_passports_in_text,
+            ),
+            (
                 |t| matches!(t, IdentifierType::UkNi),
                 GovernmentIdentifierBuilder::find_uk_nis_in_text,
             ),

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -105,6 +105,7 @@ pub enum IdentifierType {
     ItalyDriverLicense, // Italian Patente di Guida (standard + U1 Carta Conducente)
     SpainNif,           // Spanish NIF (Numero de Identificacion Fiscal)
     SpainNie,           // Spanish NIE (Numero de Identidad de Extranjero)
+    SpainPassport,      // Spanish passport (3 letters + 6 digits, no checksum)
     UkNi,               // UK National Insurance Number (NINO)
     UkNhs,              // UK NHS Number (10 digits, mod-11 weighted checksum)
     UkPassport,         // UK Passport (2 letters + 7 digits)


### PR DESCRIPTION
## Summary

Adds `IdentifierType::SpainPassport` end-to-end, closing the Presidio parity gap **HIGH-12** (Spain portion). Octarine had `SpainNif` and `SpainNie` but no passport; Presidio ships `EsPassportRecognizer` with regex `\b[A-Z]{3}[0-9]{6}\b`.

The Spanish passport number is **3 letters + 6 digits with no checksum**, so validation is purely structural (unlike NIF/NIE's mod-23 or the German passport's ICAO Doc 9303 check digit). Coverage mirrors the German suite (#669):

- **Type + patterns** — `IdentifierType::SpainPassport`; `spain_passport` regex module (`STANDARD` + label-anchored `LABELED` with Spanish/English aliases).
- **Detection + validation** — `is_spain_passport` / `find_spain_passports_in_text` (label-anchored) in `detection/europe.rs`; format-only `validate_spain_passport` (calls detection first, per DRY) in `validation/spain.rs`.
- **Builders + shortcuts** — primitives builder, Layer 3 builder (with observe instrumentation), and `is_/find_/validate_spain_passport` shortcuts.
- **PII bridge (all three registries)** — `PiiType::SpainPassport`, `name()`, `government` domain, high-risk + GDPR classification, `From<IdentifierType>` mapping, scanner domain, redactor arm, and streaming finder.
- **Spanish context keywords** — populates the previously-empty `es.rs` table (`pasaporte`, `número de pasaporte`, …).

### Notes
- Detection lives in `detection/europe.rs` alongside the existing Spain NIF/NIE (not a new `detection/spain.rs` as the issue body literally suggested) — following the established convention rather than fragmenting Spain across two files.
- The aggregate text redactor gap (`redact_all_government_ids_in_text_with_policy` uses generic finders) is out of scope here and tracked in #672; SpainPassport routes through generic government redaction exactly like SpainNif/SpainNie/Germany.

## Test plan
- New unit tests: 5 detection (`detection/europe.rs`), 5 validation (`validation/spain.rs`), 1 shortcut (`shortcuts/government.rs`), plus PII registry assertions (`name()`, `From` mapping, high-risk list).
- `just fmt`, `just clippy` (strict lints), `just arch-check`, `just doc` — all clean.
- `just test` — full suite green (the sole failure was the known pre-existing flaky `test_cache_cleanup`, which passes in isolation and is unrelated to this change).

Closes #437