### PR TITLE
feat(identifiers): US CLIA number (medical lab cert)

### DIFF
--- a/crates/octarine/src/identifiers/builder/medical.rs
+++ b/crates/octarine/src/identifiers/builder/medical.rs
@@ -142,6 +142,12 @@ impl MedicalBuilder {
         self.inner.is_dea_number(value)
     }
 
+    /// Check if value is a US CLIA lab certificate number (shape + state code)
+    #[must_use]
+    pub fn is_us_clia(&self, value: &str) -> bool {
+        self.inner.is_us_clia(value)
+    }
+
     /// Check if text contains any medical identifier
     #[must_use]
     pub fn is_medical_identifier_present(&self, text: &str) -> bool {
@@ -186,6 +192,25 @@ impl MedicalBuilder {
     #[must_use]
     pub fn find_dea_numbers_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
         self.inner.find_dea_numbers_in_text(text)
+    }
+
+    /// Find all US CLIA lab certificate numbers in text (context-required)
+    #[must_use]
+    pub fn find_us_clias_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        let start = Instant::now();
+        let matches = self.inner.find_us_clias_in_text(text);
+
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+            if !matches.is_empty() {
+                increment_by(metric_names::detected(), matches.len() as u64);
+            }
+        }
+
+        matches
     }
 
     /// Find all medical identifiers in text
@@ -274,6 +299,25 @@ impl MedicalBuilder {
     /// Returns `Problem` if the NPI is invalid or a known test pattern
     pub fn validate_npi_no_test(&self, npi: &str) -> Result<(), Problem> {
         self.inner.validate_npi_no_test(npi)
+    }
+
+    /// Validate US CLIA lab certificate number format
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the CLIA shape or state code is invalid
+    pub fn validate_us_clia(&self, clia: &str) -> Result<(), Problem> {
+        let start = Instant::now();
+        let result = self.inner.validate_us_clia(clia);
+
+        if self.emit_events {
+            record(
+                metric_names::validate_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
+
+        result
     }
 
     // =========================================================================
@@ -378,6 +422,24 @@ impl MedicalBuilder {
         policy: MedicalTextPolicy,
     ) -> Cow<'a, str> {
         self.inner.redact_medical_codes_in_text(text, policy)
+    }
+
+    /// Redact US CLIA lab certificate numbers in text using text redaction policy
+    #[must_use]
+    pub fn redact_us_clias_in_text<'a>(
+        &self,
+        text: &'a str,
+        policy: MedicalTextPolicy,
+    ) -> Cow<'a, str> {
+        self.inner.redact_us_clias_in_text(text, policy)
+    }
+
+    /// Redact US CLIA lab certificate numbers in text using the Complete policy
+    #[must_use]
+    pub fn redact_us_clia(&self, text: &str) -> String {
+        self.inner
+            .redact_us_clias_in_text(text, MedicalTextPolicy::Complete)
+            .into_owned()
     }
 
     /// Redact all medical identifiers in text using Complete policy
@@ -531,5 +593,24 @@ mod tests {
     fn test_mrn_detection() {
         let builder = MedicalBuilder::silent();
         assert!(builder.is_mrn("MRN: 12345678"));
+    }
+
+    #[test]
+    fn test_clia_detection_and_validation() {
+        let builder = MedicalBuilder::silent();
+        assert!(builder.is_us_clia("05D0123456"));
+        assert!(!builder.is_us_clia("67D1234567")); // invalid state code
+        assert!(builder.validate_us_clia("05D0123456").is_ok());
+        assert!(builder.validate_us_clia("5DD0123456").is_err());
+    }
+
+    #[test]
+    fn test_clia_redaction_and_scan() {
+        let builder = MedicalBuilder::silent();
+        let text = "Laboratory ID 05D0123456 on the report";
+        let redacted = builder.redact_us_clia(text);
+        assert!(redacted.contains("[CLIA_NUMBER]"));
+        assert!(!redacted.contains("05D0123456"));
+        assert_eq!(builder.find_us_clias_in_text(text).len(), 1);
     }
 }

--- a/crates/octarine/src/identifiers/shortcuts/medical.rs
+++ b/crates/octarine/src/identifiers/shortcuts/medical.rs
@@ -43,6 +43,12 @@ pub fn is_medical_code(value: &str) -> bool {
     MedicalBuilder::new().is_medical_code(value)
 }
 
+/// Check if value is a US CLIA lab certificate number (shape + state code)
+#[must_use]
+pub fn is_us_clia(value: &str) -> bool {
+    MedicalBuilder::new().is_us_clia(value)
+}
+
 /// Validate a medical record number format
 ///
 /// # Errors
@@ -61,10 +67,25 @@ pub fn validate_npi(npi: &str) -> Result<(), Problem> {
     MedicalBuilder::new().validate_npi(npi)
 }
 
+/// Validate a US CLIA lab certificate number format
+///
+/// # Errors
+///
+/// Returns `Problem` if the CLIA shape or state code is invalid.
+pub fn validate_us_clia(clia: &str) -> Result<(), Problem> {
+    MedicalBuilder::new().validate_us_clia(clia)
+}
+
 /// Find all medical record numbers in text
 #[must_use]
 pub fn find_medical_records(text: &str) -> Vec<IdentifierMatch> {
     MedicalBuilder::new().find_mrns_in_text(text)
+}
+
+/// Find all US CLIA lab certificate numbers in text (context-required)
+#[must_use]
+pub fn find_us_clias(text: &str) -> Vec<IdentifierMatch> {
+    MedicalBuilder::new().find_us_clias_in_text(text)
 }
 
 /// Redact all medical identifiers in text
@@ -109,5 +130,18 @@ mod tests {
         assert!(validate_npi("1245319599").is_ok()); // valid checksum
         assert!(validate_npi("1234567890").is_err()); // invalid checksum
         assert!(validate_npi("not-an-npi").is_err());
+    }
+
+    #[test]
+    fn test_clia_shortcuts() {
+        assert!(is_us_clia("05D0123456")); // California prefix
+        assert!(!is_us_clia("67D1234567")); // invalid state code
+        assert!(!is_us_clia("5DD0123456")); // D in wrong position
+
+        assert!(validate_us_clia("05D0123456").is_ok());
+        assert!(validate_us_clia("00D0000000").is_err()); // invalid state code
+
+        let matches = find_us_clias("Laboratory ID 05D0123456 on file");
+        assert_eq!(matches.len(), 1);
     }
 }

--- a/crates/octarine/src/observe/pii/redactor/medical.rs
+++ b/crates/octarine/src/observe/pii/redactor/medical.rs
@@ -81,6 +81,18 @@ pub(super) fn redact_dea_numbers(text: &str, profile: RedactionProfile) -> Strin
     }
 }
 
+/// Redact US CLIA lab certificate numbers based on profile
+pub(super) fn redact_us_clias(text: &str, profile: RedactionProfile) -> String {
+    match profile {
+        RedactionProfile::ProductionStrict | RedactionProfile::ProductionLenient => {
+            let builder = MedicalIdentifierBuilder::new();
+            let policy = policy_from_profile(profile);
+            builder.redact_us_clias_in_text(text, policy).into_owned()
+        }
+        RedactionProfile::Development | RedactionProfile::Testing => text.to_string(),
+    }
+}
+
 /// Redact prescriptions based on profile
 pub(super) fn redact_prescriptions(text: &str, profile: RedactionProfile) -> String {
     match profile {
@@ -216,6 +228,30 @@ mod tests {
     fn test_redact_dea_numbers_no_pii() {
         let text = "Pharmacy compliance review complete";
         let result = redact_dea_numbers(text, RedactionProfile::ProductionStrict);
+        assert_eq!(result, text);
+    }
+
+    // ===== CLIA Numbers =====
+
+    #[test]
+    fn test_redact_us_clias_strict() {
+        let text = "Laboratory ID 05D0123456 on the report";
+        let result = redact_us_clias(text, RedactionProfile::ProductionStrict);
+        assert!(result.contains("[CLIA_NUMBER]"));
+        assert!(!result.contains("05D0123456"));
+    }
+
+    #[test]
+    fn test_redact_us_clias_testing_unchanged() {
+        let text = "Laboratory ID 05D0123456 on the report";
+        let result = redact_us_clias(text, RedactionProfile::Testing);
+        assert_eq!(result, text);
+    }
+
+    #[test]
+    fn test_redact_us_clias_no_pii() {
+        let text = "Lab results reviewed and filed";
+        let result = redact_us_clias(text, RedactionProfile::ProductionStrict);
         assert_eq!(result, text);
     }
 

--- a/crates/octarine/src/observe/pii/redactor/mod.rs
+++ b/crates/octarine/src/observe/pii/redactor/mod.rs
@@ -258,6 +258,7 @@ pub fn redact_pii_with_profile(text: &str, profile: RedactionProfile) -> String 
             PiiType::IcdCode => redact_medical_codes(&result, profile),
             PiiType::PrescriptionNumber => redact_prescriptions(&result, profile),
             PiiType::DeaNumber => redact_dea_numbers(&result, profile),
+            PiiType::UsClia => redact_us_clias(&result, profile),
             // Biometric
             PiiType::FingerprintId => redact_fingerprints(&result, profile),
             PiiType::FaceId => redact_facial_data(&result, profile),

--- a/crates/octarine/src/observe/pii/scanner/domains.rs
+++ b/crates/octarine/src/observe/pii/scanner/domains.rs
@@ -326,6 +326,9 @@ pub(super) fn scan_medical(text: &str, pii_types: &mut Vec<PiiType>) {
         if !medical.find_dea_numbers_in_text(text).is_empty() {
             pii_types.push(PiiType::DeaNumber);
         }
+        if !medical.find_us_clias_in_text(text).is_empty() {
+            pii_types.push(PiiType::UsClia);
+        }
     }
 }
 

--- a/crates/octarine/src/observe/pii/types/classification.rs
+++ b/crates/octarine/src/observe/pii/types/classification.rs
@@ -33,7 +33,7 @@ impl PiiType {
             Self::SwedenPersonnummer | Self::SwedenOrgnummer |
             Self::GermanyTaxId | Self::GermanyIdCard | Self::GermanyPassport |
             // Medical (HIPAA)
-            Self::Mrn | Self::Npi | Self::InsuranceNumber | Self::DeaNumber | Self::IcdCode | Self::PrescriptionNumber |
+            Self::Mrn | Self::Npi | Self::InsuranceNumber | Self::DeaNumber | Self::IcdCode | Self::PrescriptionNumber | Self::UsClia |
             // Biometric (irreplaceable)
             Self::FingerprintId | Self::FaceId | Self::VoiceId | Self::IrisId | Self::DnaId | Self::BiometricTemplate |
             // GDPR Article 9 special-category data — racial origin (nationality),
@@ -119,6 +119,7 @@ impl PiiType {
                 | Self::IcdCode
                 | Self::PrescriptionNumber
                 | Self::DeaNumber
+                | Self::UsClia // CLIA lab certificate — HIPAA-relevant when linked to patient data
                 | Self::Ssn // SSN is also PHI in medical context
                 | Self::Itin // ITIN is also PHI in medical context (IRS-issued tax ID for patients)
                 | Self::Mbi // MBI is Medicare PHI — it appears on every claim/prescription/EHR field (mirrors UkNhs HIPAA-equivalent treatment)

--- a/crates/octarine/src/observe/pii/types/core.rs
+++ b/crates/octarine/src/observe/pii/types/core.rs
@@ -84,6 +84,7 @@ impl PiiType {
             Self::IcdCode => "icd_code",
             Self::PrescriptionNumber => "prescription_number",
             Self::DeaNumber => "dea_number",
+            Self::UsClia => "us_clia",
             // Biometric
             Self::FingerprintId => "fingerprint_id",
             Self::FaceId => "face_id",
@@ -243,7 +244,8 @@ impl PiiType {
             | Self::InsuranceNumber
             | Self::IcdCode
             | Self::PrescriptionNumber
-            | Self::DeaNumber => "medical",
+            | Self::DeaNumber
+            | Self::UsClia => "medical",
             Self::FingerprintId
             | Self::FaceId
             | Self::VoiceId

--- a/crates/octarine/src/observe/pii/types/mapping.rs
+++ b/crates/octarine/src/observe/pii/types/mapping.rs
@@ -144,6 +144,7 @@ impl From<IdentifierType> for PiiType {
             IdentifierType::ProviderID => Self::Npi,
             IdentifierType::MedicalCode => Self::IcdCode,
             IdentifierType::MedicalLicense => Self::DeaNumber,
+            IdentifierType::UsClia => Self::UsClia,
 
             // Biometric
             IdentifierType::Fingerprint => Self::FingerprintId,

--- a/crates/octarine/src/observe/pii/types/mod.rs
+++ b/crates/octarine/src/observe/pii/types/mod.rs
@@ -201,6 +201,8 @@ pub enum PiiType {
     PrescriptionNumber,
     /// DEA (Drug Enforcement Administration) number
     DeaNumber,
+    /// US CLIA (Clinical Laboratory Improvement Amendments) lab certificate number
+    UsClia,
 
     // =========================================================================
     // Biometric Domain

--- a/crates/octarine/src/primitives/identifiers/common/patterns/medical.rs
+++ b/crates/octarine/src/primitives/identifiers/common/patterns/medical.rs
@@ -105,6 +105,32 @@ pub static DEA_UNLABELED: Lazy<Regex> =
 pub static DEA_EXACT: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[A-Za-z]{2}\d{7}$").expect("BUG: Invalid regex pattern"));
 
+/// CLIA (Clinical Laboratory Improvement Amendments) number - EXACT
+/// Format: 2-digit SSA state code + literal `D` + 7 digits (10 chars total).
+/// Case-insensitive on the `D`. State-code whitelist enforced in detection.
+/// Reference: https://www.cms.gov/medicare/quality/clinical-laboratory-improvement-amendments
+pub static CLIA_EXACT: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^\d{2}D\d{7}$").expect("BUG: Invalid regex pattern"));
+
+/// CLIA number - LABELED / CONTEXT
+/// Requires a positive context keyword (`CLIA`, `lab cert(ificate)`,
+/// `laboratory ID`, `lab number`, `lab id`) before the 10-char CLIA token.
+/// CLIA has no checksum, so a bare `NNDNNNNNNN` is too weak to surface
+/// unlabeled — context is required to avoid false positives. The token is
+/// captured in group 1.
+pub static CLIA_LABELED: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)\b(?:CLIA|lab(?:oratory)?[\s-]*(?:cert(?:ificate)?|id|number|no|#))[\s:#-]*(\d{2}D\d{7})\b",
+    )
+    .expect("BUG: Invalid regex pattern")
+});
+
+/// Patterns matching context-labeled CLIA lab certificate numbers
+/// (`CLIA: 05D0123456`, `Laboratory ID 05D0123456`).
+pub fn clia() -> Vec<&'static Regex> {
+    vec![&*CLIA_LABELED]
+}
+
 /// Patterns matching DEA (Drug Enforcement Administration) registration numbers,
 /// both labeled (`DEA: AB1234567`) and unlabeled (raw `AB1234567`).
 pub fn dea_numbers() -> Vec<&'static Regex> {
@@ -137,7 +163,7 @@ pub fn medical_codes() -> Vec<&'static Regex> {
 }
 
 /// All medical patterns from this module — MRN, insurance (Medicare/policy/group),
-/// prescription, NPI, ICD-10, CPT, and DEA (labeled + unlabeled).
+/// prescription, NPI, ICD-10, CPT, DEA (labeled + unlabeled), and CLIA (labeled).
 pub fn all() -> Vec<&'static Regex> {
     vec![
         &*MRN_LABELED,
@@ -150,5 +176,6 @@ pub fn all() -> Vec<&'static Regex> {
         &*CPT,
         &*DEA_LABELED,
         &*DEA_UNLABELED,
+        &*CLIA_LABELED,
     ]
 }

--- a/crates/octarine/src/primitives/identifiers/medical/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/medical/builder.rs
@@ -107,6 +107,12 @@ impl MedicalIdentifierBuilder {
         detection::is_dea_number(value)
     }
 
+    /// Check if value is a US CLIA lab certificate number (shape + state code)
+    #[must_use]
+    pub fn is_us_clia(&self, value: &str) -> bool {
+        detection::is_us_clia(value)
+    }
+
     /// Check if text contains any medical identifier
     #[must_use]
     pub fn is_medical_identifier_present(&self, text: &str) -> bool {
@@ -151,6 +157,12 @@ impl MedicalIdentifierBuilder {
     #[must_use]
     pub fn find_dea_numbers_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
         detection::find_dea_numbers_in_text(text)
+    }
+
+    /// Find all US CLIA lab certificate numbers in text (context-required)
+    #[must_use]
+    pub fn find_us_clias_in_text(&self, text: &str) -> Vec<IdentifierMatch> {
+        detection::find_us_clias_in_text(text)
     }
 
     /// Find all medical identifiers in text
@@ -206,6 +218,15 @@ impl MedicalIdentifierBuilder {
     /// Returns `Problem` if the NPI is invalid or a known test pattern
     pub fn validate_npi_no_test(&self, npi: &str) -> Result<(), Problem> {
         validation::validate_npi_no_test(npi)
+    }
+
+    /// Validate US CLIA lab certificate number format
+    ///
+    /// # Errors
+    ///
+    /// Returns `Problem` if the CLIA shape or state code is invalid
+    pub fn validate_us_clia(&self, clia: &str) -> Result<(), Problem> {
+        validation::validate_us_clia(clia)
     }
 
     // =========================================================================
@@ -400,6 +421,16 @@ impl MedicalIdentifierBuilder {
         policy: TextRedactionPolicy,
     ) -> Cow<'a, str> {
         sanitization::redact_dea_numbers_in_text(text, policy)
+    }
+
+    /// Redact US CLIA lab certificate numbers in text using text redaction policy
+    #[must_use]
+    pub fn redact_us_clias_in_text<'a>(
+        &self,
+        text: &'a str,
+        policy: TextRedactionPolicy,
+    ) -> Cow<'a, str> {
+        sanitization::redact_us_clias_in_text(text, policy)
     }
 
     /// Redact all medical identifiers in text using Complete policy

--- a/crates/octarine/src/primitives/identifiers/medical/detection.rs
+++ b/crates/octarine/src/primitives/identifiers/medical/detection.rs
@@ -192,6 +192,11 @@ pub fn detect_medical_identifier(value: &str) -> Option<IdentifierType> {
     if is_dea_number(value) {
         return Some(IdentifierType::MedicalLicense);
     }
+    // CLIA before MRN — CLIA has a precise NNDNNNNNNN shape + state-code check,
+    // while unlabeled MRN is very broad and would otherwise swallow a CLIA.
+    if is_us_clia(value) {
+        return Some(IdentifierType::UsClia);
+    }
     if is_medical_record_number(value) {
         return Some(IdentifierType::MedicalRecordNumber);
     }
@@ -512,6 +517,7 @@ pub fn find_all_medical_in_text(text: &str) -> Vec<IdentifierMatch> {
     all_matches.extend(find_provider_ids_in_text(text));
     all_matches.extend(find_medical_codes_in_text(text));
     all_matches.extend(find_dea_numbers_in_text(text));
+    all_matches.extend(find_us_clias_in_text(text));
 
     deduplicate_matches(all_matches)
 }
@@ -658,6 +664,95 @@ pub fn find_dea_numbers_in_text(text: &str) -> Vec<IdentifierMatch> {
                 full_match.as_str().to_string(),
                 IdentifierType::MedicalLicense,
                 DetectionConfidence::Medium,
+            ));
+        }
+    }
+
+    deduplicate_matches(matches)
+}
+
+// ============================================================================
+// CLIA Number Detection
+// ============================================================================
+
+/// Valid CLIA state-code prefixes (first two digits of a CLIA number).
+///
+/// CLIA numbers embed the SSA state code as their first two digits. The set is
+/// the SSA `GEO_SSA_STATE_TB` table: `01`–`53` (50 states, DC=09, Puerto
+/// Rico=40, Virgin Islands=48) plus the SSA territory / foreign-possession
+/// codes `54`–`66`, `97`, `98`, `99`.
+const CLIA_STATE_CODES: &[&str] = &[
+    "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16",
+    "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32",
+    "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48",
+    "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62", "63", "64",
+    "65", "66", "97", "98", "99",
+];
+
+/// Check if a 2-character prefix is a valid CLIA/SSA state code
+fn is_valid_clia_state_code(prefix: &str) -> bool {
+    CLIA_STATE_CODES.contains(&prefix)
+}
+
+/// Check if a value is a US CLIA (Clinical Laboratory Improvement Amendments) number
+///
+/// CLIA numbers are 10 characters: a 2-digit SSA state code, the literal letter
+/// `D` (case-insensitive), and 7 digits (`NNDNNNNNNN`). There is no publicly
+/// documented check-digit algorithm, so detection enforces the shape plus the
+/// state-code whitelist only.
+///
+/// # Examples
+///
+/// ```ignore
+/// use crate::primitives::identifiers::medical::detection;
+///
+/// assert!(detection::is_us_clia("05D0123456"));  // California prefix
+/// assert!(detection::is_us_clia("05d0123456"));  // case-insensitive D
+/// assert!(!detection::is_us_clia("5DD0123456"));  // D in wrong position
+/// assert!(!detection::is_us_clia("67D1234567"));  // 67 is not a valid state code
+/// ```
+#[must_use]
+pub fn is_us_clia(value: &str) -> bool {
+    let trimmed = value.trim();
+
+    // Shape check first (exact 10-char NNDNNNNNNN, case-insensitive D)
+    if !patterns::medical::CLIA_EXACT.is_match(trimmed) {
+        return false;
+    }
+
+    // First two characters are the state code (guaranteed ASCII digits by regex)
+    match trimmed.get(0..2) {
+        Some(prefix) => is_valid_clia_state_code(prefix),
+        None => false,
+    }
+}
+
+/// Find all US CLIA numbers in text
+///
+/// Scans text for CLIA numbers that appear alongside a positive context keyword
+/// (`CLIA`, `lab cert`, `laboratory ID`, `lab number`, …). Each candidate is
+/// validated with [`is_us_clia`] (shape + state code) before being reported.
+/// CLIA has no checksum, so requiring context avoids false positives on bare
+/// 10-character strings.
+#[must_use]
+pub fn find_us_clias_in_text(text: &str) -> Vec<IdentifierMatch> {
+    if exceeds_safe_length(text, MAX_INPUT_LENGTH) {
+        return Vec::new();
+    }
+
+    let mut matches = Vec::new();
+
+    for capture in patterns::medical::CLIA_LABELED.captures_iter(text) {
+        let full_match = get_full_match(&capture);
+        // The CLIA token itself is captured in group 1; validate it directly.
+        let clia_value = capture.get(1).map_or(full_match.as_str(), |m| m.as_str());
+        if is_us_clia(clia_value) {
+            matches.push(IdentifierMatch::new(
+                full_match.start(),
+                full_match.end(),
+                full_match.as_str().to_string(),
+                IdentifierType::UsClia,
+                DetectionConfidence::High,
             ));
         }
     }
@@ -1121,6 +1216,87 @@ mod tests {
         assert_eq!(
             detect_medical_identifier("AB1234563"),
             Some(IdentifierType::MedicalLicense)
+        );
+    }
+
+    // ===== CLIA Number Tests =====
+
+    #[test]
+    fn test_is_us_clia_valid() {
+        assert!(is_us_clia("05D0123456")); // California prefix
+        assert!(is_us_clia("01D0000001")); // Alabama prefix
+        assert!(is_us_clia("45D9876543")); // Texas prefix
+        assert!(is_us_clia("48D1234567")); // Virgin Islands (territory)
+        // Case-insensitive D
+        assert!(is_us_clia("05d0123456"));
+        // Whitespace trimmed
+        assert!(is_us_clia("  05D0123456  "));
+    }
+
+    #[test]
+    fn test_is_us_clia_invalid_letter_position() {
+        // D must be at position 3 (index 2), not elsewhere
+        assert!(!is_us_clia("5DD0123456"));
+        assert!(!is_us_clia("0DD0123456"));
+        assert!(!is_us_clia("05E0123456")); // wrong letter
+        assert!(!is_us_clia("0510123456")); // digit where D belongs
+    }
+
+    #[test]
+    fn test_is_us_clia_invalid_state_code() {
+        // 67 is outside the SSA state-code set
+        assert!(!is_us_clia("67D1234567"));
+        // 00 is not a valid state code
+        assert!(!is_us_clia("00D0000000"));
+        // 96 sits in the gap between 66 and 97
+        assert!(!is_us_clia("96D1234567"));
+    }
+
+    #[test]
+    fn test_is_us_clia_length_band_edges() {
+        assert!(!is_us_clia("05D012345")); // 9 chars — too short
+        assert!(!is_us_clia("05D01234567")); // 11 chars — too long
+        assert!(!is_us_clia("")); // empty
+        assert!(!is_us_clia("05D")); // truncated
+    }
+
+    #[test]
+    fn test_find_us_clias_in_text_context_boost() {
+        let text = "Laboratory ID 05D0123456 was on the report";
+        let matches = find_us_clias_in_text(text);
+        assert_eq!(matches.len(), 1);
+        let first = matches.first().expect("Should detect CLIA");
+        assert_eq!(first.identifier_type, IdentifierType::UsClia);
+        assert_eq!(first.confidence, DetectionConfidence::High);
+
+        // Explicit CLIA: prefix
+        let text2 = "CLIA: 45D9876543 on file";
+        assert_eq!(find_us_clias_in_text(text2).len(), 1);
+
+        // "lab certificate" context
+        let text3 = "lab certificate 01D0000001 issued";
+        assert_eq!(find_us_clias_in_text(text3).len(), 1);
+    }
+
+    #[test]
+    fn test_find_us_clias_requires_context() {
+        // A bare CLIA-shaped token with no lab/CLIA context is not surfaced
+        let text = "The value 05D0123456 appears here";
+        assert_eq!(find_us_clias_in_text(text).len(), 0);
+    }
+
+    #[test]
+    fn test_find_us_clias_rejects_invalid_state_code() {
+        // Context present, but the state code is invalid → not reported
+        let text = "CLIA: 67D1234567 is malformed";
+        assert_eq!(find_us_clias_in_text(text).len(), 0);
+    }
+
+    #[test]
+    fn test_detect_medical_identifier_clia() {
+        assert_eq!(
+            detect_medical_identifier("05D0123456"),
+            Some(IdentifierType::UsClia)
         );
     }
 }

--- a/crates/octarine/src/primitives/identifiers/medical/sanitization/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/medical/sanitization/mod.rs
@@ -46,5 +46,5 @@ pub use individual::{
 pub use text::{
     redact_all_medical_in_text, redact_dea_numbers_in_text, redact_insurance_in_text,
     redact_medical_codes_in_text, redact_mrn_in_text, redact_prescriptions_in_text,
-    redact_provider_ids_in_text,
+    redact_provider_ids_in_text, redact_us_clias_in_text,
 };

--- a/crates/octarine/src/primitives/identifiers/medical/sanitization/text.rs
+++ b/crates/octarine/src/primitives/identifiers/medical/sanitization/text.rs
@@ -355,11 +355,45 @@ pub fn redact_dea_numbers_in_text(text: &str, policy: TextRedactionPolicy) -> Co
     Cow::Owned(result)
 }
 
+/// Redact all US CLIA lab-certificate numbers in text using text redaction policy
+///
+/// Scans text for context-labeled CLIA numbers (validated shape + state code)
+/// and replaces the matched span. CLIA has no partial-reveal strategy, so every
+/// non-`Skip` policy replaces with a token (`Anonymous` uses `[REDACTED]`).
+#[must_use]
+pub fn redact_us_clias_in_text(text: &str, policy: TextRedactionPolicy) -> Cow<'_, str> {
+    if matches!(policy, TextRedactionPolicy::Skip) {
+        return Cow::Borrowed(text);
+    }
+
+    use super::super::detection;
+    let matches = detection::find_us_clias_in_text(text);
+
+    if matches.is_empty() {
+        return Cow::Borrowed(text);
+    }
+
+    let token = match policy {
+        TextRedactionPolicy::Complete | TextRedactionPolicy::Partial => "[CLIA_NUMBER]",
+        TextRedactionPolicy::Anonymous => "[REDACTED]",
+        TextRedactionPolicy::Skip => return Cow::Borrowed(text),
+    };
+
+    let mut result = text.to_string();
+    // Replace in reverse order to keep earlier match offsets valid.
+    for m in matches.iter().rev() {
+        result.replace_range(m.start..m.end, token);
+    }
+
+    Cow::Owned(result)
+}
+
 /// Redact every medical identifier type in `text` using the given policy.
 ///
 /// Composes all per-identifier text redactors (MRN, insurance, prescription,
-/// NPI/provider, ICD-10/CPT codes, DEA numbers) in a single pass so callers
-/// get a fully sanitized `String` without managing the order themselves.
+/// NPI/provider, ICD-10/CPT codes, DEA numbers, CLIA numbers) in a single pass
+/// so callers get a fully sanitized `String` without managing the order
+/// themselves.
 ///
 /// # Arguments
 ///
@@ -378,6 +412,7 @@ pub fn redact_all_medical_in_text(text: &str, policy: TextRedactionPolicy) -> St
     let result = redact_provider_ids_in_text(&result, policy);
     let result = redact_medical_codes_in_text(&result, policy);
     let result = redact_dea_numbers_in_text(&result, policy);
+    let result = redact_us_clias_in_text(&result, policy);
 
     result.into_owned()
 }
@@ -470,6 +505,32 @@ mod tests {
         assert!(result.contains("[INSURANCE_INFO]"));
         assert!(result.contains("[PRESCRIPTION]"));
         assert!(result.contains("[PROVIDER_ID]"));
+    }
+
+    #[test]
+    fn test_redact_us_clias_in_text() {
+        let text = "Laboratory ID 05D0123456 on the report";
+        let result = redact_us_clias_in_text(text, TextRedactionPolicy::Complete);
+        assert!(result.contains("[CLIA_NUMBER]"));
+        assert!(!result.contains("05D0123456"));
+    }
+
+    #[test]
+    fn test_redact_all_medical_scrubs_clia() {
+        // CLIA must be scrubbed by the aggregate redactor, not just detected.
+        let text = "CLIA: 45D9876543 and Patient MRN: 12345678";
+        let result = redact_all_medical_in_text(text, TextRedactionPolicy::Complete);
+        assert!(result.contains("[CLIA_NUMBER]"));
+        assert!(!result.contains("45D9876543"));
+        assert!(result.contains("[MEDICAL_RECORD]"));
+    }
+
+    #[test]
+    fn test_redact_us_clias_anonymous() {
+        let text = "CLIA: 05D0123456";
+        let result = redact_us_clias_in_text(text, TextRedactionPolicy::Anonymous);
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains("05D0123456"));
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/medical/validation.rs
+++ b/crates/octarine/src/primitives/identifiers/medical/validation.rs
@@ -295,6 +295,37 @@ pub fn validate_npi_no_test(npi: &str) -> Result<(), Problem> {
 }
 
 // ============================================================================
+// CLIA Number Validation
+// ============================================================================
+
+/// Validate US CLIA (Clinical Laboratory Improvement Amendments) number
+///
+/// Validates the CMS lab-certificate format: a 2-digit SSA state code, the
+/// literal letter `D`, and 7 digits (`NNDNNNNNNN`, 10 chars, case-insensitive
+/// `D`).
+///
+/// Format requirements:
+/// - Must match CLIA detection (exact shape + state-code whitelist)
+/// - CLIA has no publicly documented checksum, so shape + state code is the
+///   full validation
+///
+/// # Errors
+///
+/// Returns `Problem::validation` if:
+/// - Does not match the `NNDNNNNNNN` shape
+/// - The first two digits are not a valid SSA/CLIA state code
+pub fn validate_us_clia(clia: &str) -> Result<(), Problem> {
+    // Use detection layer first (DRY principle + type safety)
+    if !detection::is_us_clia(clia) {
+        return Err(Problem::Validation(
+            "Invalid CLIA number: expected NNDNNNNNNN with a valid state code".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 
@@ -516,5 +547,32 @@ mod tests {
         assert!(validate_insurance_number("  INS-123456789  ").is_ok());
         assert!(validate_prescription_number("  RX-123456  ").is_ok());
         assert!(validate_npi("  1245319599  ").is_ok());
+    }
+
+    // ===== CLIA Tests =====
+
+    #[test]
+    fn test_clia_valid() {
+        assert!(validate_us_clia("05D0123456").is_ok()); // California
+        assert!(validate_us_clia("01D0000001").is_ok()); // Alabama
+        assert!(validate_us_clia("45D9876543").is_ok()); // Texas
+        assert!(validate_us_clia("05d0123456").is_ok()); // case-insensitive D
+        assert!(validate_us_clia("  05D0123456  ").is_ok()); // trimmed
+    }
+
+    #[test]
+    fn test_clia_invalid_shape() {
+        assert!(validate_us_clia("5DD0123456").is_err()); // D in wrong position
+        assert!(validate_us_clia("05E0123456").is_err()); // wrong letter
+        assert!(validate_us_clia("05D012345").is_err()); // too short
+        assert!(validate_us_clia("05D01234567").is_err()); // too long
+        assert!(validate_us_clia("").is_err()); // empty
+    }
+
+    #[test]
+    fn test_clia_invalid_state_code() {
+        assert!(validate_us_clia("67D1234567").is_err()); // outside SSA set
+        assert!(validate_us_clia("00D0000000").is_err()); // 00 not valid
+        assert!(validate_us_clia("96D1234567").is_err()); // gap between 66 and 97
     }
 }

--- a/crates/octarine/src/primitives/identifiers/streaming.rs
+++ b/crates/octarine/src/primitives/identifiers/streaming.rs
@@ -537,7 +537,8 @@ impl StreamingScanner {
             | IdentifierType::Prescription
             | IdentifierType::ProviderID
             | IdentifierType::MedicalCode
-            | IdentifierType::MedicalLicense => {
+            | IdentifierType::MedicalLicense
+            | IdentifierType::UsClia => {
                 let medical = MedicalIdentifierBuilder::new();
                 Some(self.push_matching(medical.find_all_in_text(text), id_type))
             }

--- a/crates/octarine/src/primitives/identifiers/types/core.rs
+++ b/crates/octarine/src/primitives/identifiers/types/core.rs
@@ -134,6 +134,7 @@ pub enum IdentifierType {
     ProviderID,          // NPI (National Provider Identifier)
     MedicalCode,         // ICD-10, CPT codes
     MedicalLicense,      // DEA numbers, state medical board licenses
+    UsClia, // US CLIA lab certificate (NNDNNNNNNN — SSA state code + literal D + 7 digits)
 
     // Biometric identifiers (GDPR Article 9, BIPA)
     Fingerprint,       // Fingerprint hashes/identifiers


### PR DESCRIPTION
## Summary

Adds full support for **US CLIA (Clinical Laboratory Improvement Amendments) certificate numbers** — the CMS-issued 10-character `NNDNNNNNNN` lab-certificate ID (2-digit SSA state code, literal `D`, 7 digits) found on every US lab requisition, lab result, Medicare lab claim, and DICOM SR report. HIPAA-relevant when linked to patient data. Closes a Presidio-parity gap (mirrors open PR [microsoft/presidio#2029](https://github.com/microsoft/presidio/pull/2029)).

Follows the existing **flat medical-domain** file layout (modeled on the DEA identifier for primitives, and on the MBI commit #673 for the three-registry PII bridge) — **not** the `detection/{type}.rs` subdirectory the issue body assumed, which doesn't match the medical domain.

### What changed

- **Detection** (`primitives/identifiers/medical/detection.rs`) — `is_us_clia` (exact `\d{2}D\d{7}` shape + SSA state-code whitelist `01`–`53` plus territory codes `54`–`66`/`97`–`99`; CLIA has no checksum) and `find_us_clias_in_text` requiring a positive context keyword (`CLIA`, `lab cert`, `laboratory ID`, `lab number`). Registered **before** MRN in `detect_medical_identifier` so the broad unlabeled-MRN pattern can't swallow a CLIA.
- **Validation** — `validate_us_clia` (calls detection first, DRY).
- **Redaction** — `redact_us_clias_in_text` (`[CLIA_NUMBER]` token) wired into **both** the primitive `redact_all_medical_in_text` **and** the `observe/pii` redactor dispatch, so CLIA is actually scrubbed by the auto-redaction path — not just detected.
- **Types / PII bridge** — `IdentifierType::UsClia` + `PiiType::UsClia` across all three registries (types, `From` mapping, scanner `scan_medical`), classified `is_hipaa_protected` + `is_high_risk`.
- **Layer 3** — `MedicalBuilder` methods (observe-instrumented) + top-level shortcuts (`is_us_clia`, `validate_us_clia`, `find_us_clias`).

### Note on issue fixtures

The issue lists `99D0000000` as an "invalid state-code prefix" example, but `99` **is** a valid SSA territory code. Tests use genuine out-of-range prefixes (`00`/`67`/`96`) as the reject-cases — the same fixture-correction approach the MBI commit took.

## Test plan

- `just test-filter clia` — 20/20 new CLIA tests pass (detection, validation, sanitization, redactor, builder, shortcuts).
- `just test-mod medical` — 157/157; `just test-mod pii` — 173/173.
- `just clippy` (exit 0, clean), `just fmt-check` (clean), `just arch-check` (clean), `just doc` (strict rustdoc `-D warnings`, exit 0).

Closes #477