### PR TITLE
refactor(architecture): sever Layer 1→2 coupling in ProblemExt re-export

### DIFF
--- a/crates/octarine-problem/src/lib.rs
+++ b/crates/octarine-problem/src/lib.rs
@@ -106,6 +106,133 @@ pub enum Problem {
 pub type Result<T> = std::result::Result<T, Problem>;
 
 // =============================================================================
+// Event-free constructors (Layer 0 — no observe dependency)
+// =============================================================================
+
+/// Event-free constructors for [`Problem`].
+///
+/// This is the **Layer 1 (primitives)** constructor surface. It mirrors the
+/// method names of `observe::ProblemExt` so call sites read identically
+/// (`Problem::validation(msg)`), but building a problem through this trait has
+/// **no side effects** — it never dispatches an observability event.
+///
+/// `octarine::primitives` re-exports this trait (aliased as `ProblemExt`) so
+/// pure primitives can construct typed problems without reaching into the
+/// observe layer, keeping the dependency graph unidirectional. Layer 2
+/// (`observe`) has its own same-named trait whose constructors additionally
+/// emit audit events for security- and user-attributable failures; Layer 3
+/// wrappers are where that audit coverage belongs.
+///
+/// Each method returns the same [`Problem`] variant the observe-layer
+/// constructor produces, so the two paths differ only in the event side
+/// effect — the error value is identical.
+pub trait ProblemConstructors: Sized {
+    /// Create a validation error (input doesn't meet requirements)
+    fn validation(msg: impl Into<String>) -> Self;
+
+    /// Create a conversion error (failed to convert between types)
+    fn conversion(msg: impl Into<String>) -> Self;
+
+    /// Create a sanitization error (failed to sanitize input)
+    fn sanitization(msg: impl Into<String>) -> Self;
+
+    /// Create a configuration error (invalid configuration)
+    fn config(msg: impl Into<String>) -> Self;
+
+    /// Create a not found error (resource doesn't exist)
+    fn not_found(what: impl Into<String>) -> Self;
+
+    /// Create an authentication error (failed to authenticate)
+    fn auth(msg: impl Into<String>) -> Self;
+
+    /// Create a permission denied error (insufficient privileges)
+    fn permission_denied(msg: impl Into<String>) -> Self;
+
+    /// Create a security error (security violation detected)
+    ///
+    /// Returns the [`Problem::PermissionDenied`] variant, matching the
+    /// observe-layer `security` constructor.
+    fn security(msg: impl Into<String>) -> Self;
+
+    /// Create a network error (network operation failed)
+    fn network(msg: impl Into<String>) -> Self;
+
+    /// Create a database error (database operation failed)
+    fn database(msg: impl Into<String>) -> Self;
+
+    /// Create a parse error (failed to parse input)
+    fn parse(msg: impl Into<String>) -> Self;
+
+    /// Create a timeout error (operation exceeded time limit)
+    fn timeout(msg: impl Into<String>) -> Self;
+
+    /// Create an operation failed error (generic operation failure)
+    fn operation_failed(msg: impl Into<String>) -> Self;
+
+    /// Create an other/unknown error (catch-all for uncategorized errors)
+    fn other(msg: impl Into<String>) -> Self;
+}
+
+impl ProblemConstructors for Problem {
+    fn validation(msg: impl Into<String>) -> Self {
+        Self::Validation(msg.into())
+    }
+
+    fn conversion(msg: impl Into<String>) -> Self {
+        Self::Conversion(msg.into())
+    }
+
+    fn sanitization(msg: impl Into<String>) -> Self {
+        Self::Sanitization(msg.into())
+    }
+
+    fn config(msg: impl Into<String>) -> Self {
+        Self::Config(msg.into())
+    }
+
+    fn not_found(what: impl Into<String>) -> Self {
+        Self::NotFound(what.into())
+    }
+
+    fn auth(msg: impl Into<String>) -> Self {
+        Self::Auth(msg.into())
+    }
+
+    fn permission_denied(msg: impl Into<String>) -> Self {
+        Self::PermissionDenied(msg.into())
+    }
+
+    fn security(msg: impl Into<String>) -> Self {
+        // Matches observe's `create_security`, which returns PermissionDenied.
+        Self::PermissionDenied(msg.into())
+    }
+
+    fn network(msg: impl Into<String>) -> Self {
+        Self::Network(msg.into())
+    }
+
+    fn database(msg: impl Into<String>) -> Self {
+        Self::Database(msg.into())
+    }
+
+    fn parse(msg: impl Into<String>) -> Self {
+        Self::Parse(msg.into())
+    }
+
+    fn timeout(msg: impl Into<String>) -> Self {
+        Self::Timeout(msg.into())
+    }
+
+    fn operation_failed(msg: impl Into<String>) -> Self {
+        Self::OperationFailed(msg.into())
+    }
+
+    fn other(msg: impl Into<String>) -> Self {
+        Self::Other(msg.into())
+    }
+}
+
+// =============================================================================
 // Primitive helper functions (no observe dependency)
 // =============================================================================
 
@@ -179,5 +306,50 @@ mod tests {
     fn test_result_err() {
         let r: Result<i32> = Err(Problem::NotFound("item".into()));
         assert!(r.is_err());
+    }
+
+    #[test]
+    fn test_constructors_input_variants() {
+        assert!(matches!(Problem::validation("m"), Problem::Validation(_)));
+        assert!(matches!(Problem::conversion("m"), Problem::Conversion(_)));
+        assert!(matches!(
+            Problem::sanitization("m"),
+            Problem::Sanitization(_)
+        ));
+        assert!(matches!(Problem::parse("m"), Problem::Parse(_)));
+    }
+
+    #[test]
+    fn test_constructors_security_variants() {
+        assert!(matches!(Problem::auth("m"), Problem::Auth(_)));
+        assert!(matches!(
+            Problem::permission_denied("m"),
+            Problem::PermissionDenied(_)
+        ));
+        // security maps to PermissionDenied, matching observe's create_security.
+        assert!(matches!(
+            Problem::security("m"),
+            Problem::PermissionDenied(_)
+        ));
+    }
+
+    #[test]
+    fn test_constructors_operational_variants() {
+        assert!(matches!(Problem::config("m"), Problem::Config(_)));
+        assert!(matches!(Problem::not_found("m"), Problem::NotFound(_)));
+        assert!(matches!(Problem::network("m"), Problem::Network(_)));
+        assert!(matches!(Problem::database("m"), Problem::Database(_)));
+        assert!(matches!(Problem::timeout("m"), Problem::Timeout(_)));
+        assert!(matches!(
+            Problem::operation_failed("m"),
+            Problem::OperationFailed(_)
+        ));
+        assert!(matches!(Problem::other("m"), Problem::Other(_)));
+    }
+
+    #[test]
+    fn test_constructors_preserve_message() {
+        let p = Problem::validation("bad input");
+        assert_eq!(p.to_string(), "Validation error: bad input");
     }
 }

--- a/crates/octarine/src/identifiers/builder/environment.rs
+++ b/crates/octarine/src/identifiers/builder/environment.rs
@@ -3,6 +3,7 @@
 //! This is the **public API** (Layer 3) that wraps the primitive builder
 //! with observe instrumentation for compliance-grade audit trails.
 
+use super::emit_security_event;
 use crate::observe::Problem;
 use crate::primitives::identifiers::EnvironmentBuilder as PrimitiveEnvironmentBuilder;
 
@@ -102,8 +103,17 @@ impl EnvironmentBuilder {
     // ========================================================================
 
     /// Validate an environment variable name (returns Result)
+    ///
+    /// When observe events are enabled, an injection-pattern or
+    /// critical-variable-override detection (surfaced by the primitive as
+    /// [`Problem::PermissionDenied`]) is emitted as a CRITICAL security event,
+    /// preserving the audit trail these attack-detection paths require.
     pub fn validate_env_var(&self, name: &str) -> Result<(), Problem> {
-        self.inner.validate_env_var(name)
+        let result = self.inner.validate_env_var(name);
+        if self.emit_events {
+            emit_security_event(&result, "identifiers.environment", name);
+        }
+        result
     }
 }
 

--- a/crates/octarine/src/identifiers/builder/generic.rs
+++ b/crates/octarine/src/identifiers/builder/generic.rs
@@ -3,6 +3,7 @@
 //! This is the **public API** (Layer 3) that wraps the primitive builder
 //! with observe instrumentation for compliance-grade audit trails.
 
+use super::emit_security_event;
 use crate::observe::Problem;
 use crate::primitives::identifiers::GenericBuilder as PrimitiveGenericBuilder;
 
@@ -83,8 +84,17 @@ impl GenericBuilder {
     // ========================================================================
 
     /// Validate a generic identifier (returns Result)
+    ///
+    /// When observe events are enabled, an injection-pattern detection
+    /// (surfaced by the primitive as [`Problem::PermissionDenied`]) is emitted
+    /// as a CRITICAL security event, preserving the audit trail these
+    /// attack-detection paths require for SOC2/PCI-DSS logging.
     pub fn validate_identifier(&self, name: &str) -> Result<(), Problem> {
-        self.inner.validate_identifier(name)
+        let result = self.inner.validate_identifier(name);
+        if self.emit_events {
+            emit_security_event(&result, "identifiers.generic", name);
+        }
+        result
     }
 }
 

--- a/crates/octarine/src/identifiers/builder/layer_isolation.rs
+++ b/crates/octarine/src/identifiers/builder/layer_isolation.rs
@@ -1,0 +1,271 @@
+//! Behavioral regression tests for the Layer 1 ↔ Layer 2 event-dispatch
+//! boundary that issue #409 established.
+//!
+//! The refactor made `crate::primitives::types::ProblemExt` (the Layer-1
+//! constructor trait) resolve to the **event-free**
+//! `octarine_problem::ProblemConstructors` instead of observe's
+//! event-dispatching `ProblemExt`. These tests lock in two guarantees that the
+//! `matches!`-only unit tests in `octarine-problem` cannot express (that crate
+//! has no dependency on `observe`):
+//!
+//! 1. Constructing a `Problem` through the Layer-1 trait dispatches **zero**
+//!    observability events — a future edit that re-points the re-export back at
+//!    `observe::ProblemExt` (reintroducing the #409 leak) fails here.
+//! 2. The Layer-3 identifier builders re-emit the CRITICAL security audit event
+//!    that the primitive side effect used to provide, gated on `emit_events`,
+//!    so injection detection still lands in the audit trail.
+//!
+//! The dispatcher and writer registry are process-global singletons; following
+//! the convention in `tests/observe/writer_dispatch.rs`, every event carries a
+//! unique marker and assertions filter by marker (never absolute counts) so the
+//! suite is robust whether run process-per-test (nextest) or many-per-process.
+//! A shared `MemoryWriter` is wrapped in a named `CaptureWriter` so concurrent
+//! tests register distinct writers against the global registry yet still read
+//! their own captured events back.
+
+#![allow(clippy::panic, clippy::expect_used)]
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::observe::writers::{
+    DispatcherConfig, MemoryWriter, Writer, WriterError, WriterHealthStatus, configure_dispatcher,
+    dispatch, register_writer, unregister_writer,
+};
+use crate::observe::{Event, EventType};
+
+/// Deadline for positive-signal polls — matches the 5s the observe integration
+/// suite uses to absorb dispatcher scheduling jitter under parallel CI load.
+const POLL_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Configure the global dispatcher for fast flushes exactly once per test
+/// binary (mirrors `tests/observe/mod.rs::ensure_test_dispatcher`).
+fn ensure_test_dispatcher() {
+    static INIT: OnceLock<()> = OnceLock::new();
+    INIT.get_or_init(|| {
+        let _ = configure_dispatcher(DispatcherConfig::testing());
+    });
+}
+
+/// Poll `probe` up to `deadline`, checking every 10ms. Avoids fixed sleeps so
+/// the test stays resilient under CI scheduling jitter.
+fn poll_until<F: FnMut() -> bool>(deadline: Duration, mut probe: F) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < deadline {
+        if probe() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    probe()
+}
+
+fn count_with_marker(writer: &MemoryWriter, marker: &str) -> usize {
+    writer
+        .all_events()
+        .iter()
+        .filter(|e| e.message.contains(marker))
+        .count()
+}
+
+/// Named proxy around a shared `MemoryWriter` so multiple concurrent tests can
+/// register distinct capture writers against the global registry (the built-in
+/// `MemoryWriter::name()` is a fixed `"memory"`).
+struct CaptureWriter {
+    inner: Arc<MemoryWriter>,
+    name: &'static str,
+}
+
+#[async_trait]
+impl Writer for CaptureWriter {
+    async fn write(&self, event: &Event) -> Result<(), WriterError> {
+        self.inner.write(event).await
+    }
+
+    async fn flush(&self) -> Result<(), WriterError> {
+        self.inner.flush().await
+    }
+
+    fn health_check(&self) -> WriterHealthStatus {
+        self.inner.health_check()
+    }
+
+    fn name(&self) -> &'static str {
+        self.name
+    }
+}
+
+fn register_capture(name: &'static str) -> Arc<MemoryWriter> {
+    let inner = Arc::new(MemoryWriter::with_capacity(64));
+    register_writer(Box::new(CaptureWriter {
+        inner: Arc::clone(&inner),
+        name,
+    }));
+    inner
+}
+
+/// Layer 1 constructors must not dispatch events. Building a `Problem` through
+/// `crate::primitives::types::ProblemExt` (the event-free re-export) is expected
+/// to produce nothing on the wire — this is the core #409 guarantee.
+#[test]
+fn layer1_problem_constructors_dispatch_no_events() {
+    use crate::primitives::types::ProblemExt;
+
+    ensure_test_dispatcher();
+
+    let name = "layer_isolation_l1_silent";
+    let marker = "L1_NOEVENT_409_a71c";
+    let capture = register_capture(name);
+
+    // Construct via the Layer-1 trait. The message carries the marker so a leak
+    // would be visible in the captured events.
+    let _validation = <crate::observe::Problem as ProblemExt>::validation(marker);
+    let _security = <crate::observe::Problem as ProblemExt>::security(marker);
+    let _permission = <crate::observe::Problem as ProblemExt>::permission_denied(marker);
+
+    // Dispatch a separate probe event and wait for it, so we confirm the
+    // dispatcher actually flushed rather than merely timing out on silence.
+    let probe_name = "layer_isolation_l1_probe";
+    let probe_marker = "L1_PROBE_409_a71c";
+    let probe = register_capture(probe_name);
+    dispatch(Event::new(EventType::Info, probe_marker));
+    let flushed = poll_until(POLL_DEADLINE, || {
+        count_with_marker(&probe, probe_marker) >= 1
+    });
+
+    let leaked = count_with_marker(&capture, marker);
+    unregister_writer(name);
+    unregister_writer(probe_name);
+
+    assert!(
+        flushed,
+        "probe writer should confirm the dispatcher flushed"
+    );
+    assert_eq!(
+        leaked, 0,
+        "Layer-1 ProblemExt constructors must dispatch zero events (issue #409 leak)"
+    );
+}
+
+/// The Layer-3 `MetricsBuilder` must re-emit a CRITICAL security event when the
+/// primitive raises a security-class failure — restoring the audit trail the
+/// Layer-1 side effect used to provide. `silent()` must stay silent.
+///
+/// The label-count (cardinality) check is used as the trigger because it
+/// returns `Problem::security` unconditionally on breach, with no character or
+/// ordering gate in front of it — an unambiguously reachable security path.
+/// Unbounded label cardinality is itself a denial-of-service vector, so the
+/// CRITICAL classification is warranted.
+#[test]
+fn layer3_metrics_builder_emits_security_event_on_cardinality_breach() {
+    use crate::identifiers::MetricsBuilder;
+
+    ensure_test_dispatcher();
+
+    let name = "layer_isolation_l3_metrics";
+    let capture = register_capture(name);
+
+    // A distinctive over-limit count (default max is 20). The count appears in
+    // the emitted message ("... N labels ... (input: N)"), so it doubles as the
+    // per-test marker.
+    let over_limit = 409_777; // labels — unique, unmistakably over 20
+    let err = MetricsBuilder::new().validate_label_count(over_limit);
+    assert!(err.is_err(), "cardinality breach must fail validation");
+
+    let emitted = poll_until(POLL_DEADLINE, || count_with_marker(&capture, "409777") >= 1);
+
+    // A silent builder must not emit anything for the same breach.
+    let silent_over_limit = 409_888;
+    let _ = MetricsBuilder::silent().validate_label_count(silent_over_limit);
+    let silent_count = count_with_marker(&capture, "409888");
+
+    unregister_writer(name);
+
+    assert!(
+        emitted,
+        "L3 MetricsBuilder must emit a security event on cardinality breach"
+    );
+    assert_eq!(
+        silent_count, 0,
+        "silent() MetricsBuilder must not emit events"
+    );
+}
+
+/// The Layer-3 `EnvironmentBuilder` must emit a CRITICAL security event when a
+/// caller attempts to override a critical system variable (e.g. `PATH`), which
+/// the primitive surfaces via `Problem::security` → `PermissionDenied`. This is
+/// a genuinely reachable security path (valid chars, valid start char) and one
+/// of the more sensitive: overriding `PATH`/`LD_PRELOAD` is a classic attack.
+#[test]
+fn layer3_environment_builder_emits_security_event_on_critical_override() {
+    use crate::identifiers::EnvironmentBuilder;
+
+    ensure_test_dispatcher();
+
+    let name = "layer_isolation_l3_env";
+    let capture = register_capture(name);
+
+    // PATH is a critical system variable; the primitive returns
+    // Problem::security("Cannot override critical system variable 'PATH'").
+    let err = EnvironmentBuilder::new().validate_env_var("PATH");
+    assert!(err.is_err(), "overriding a critical var must fail");
+
+    // The emitted message embeds the var name; "critical system variable" is a
+    // stable marker unique to this security path.
+    let emitted = poll_until(POLL_DEADLINE, || {
+        count_with_marker(&capture, "Cannot override critical system variable 'PATH'") >= 1
+    });
+
+    let silent_env = EnvironmentBuilder::silent();
+    let _ = silent_env.validate_env_var("LD_PRELOAD");
+    let silent_count = count_with_marker(&capture, "LD_PRELOAD");
+
+    unregister_writer(name);
+
+    assert!(
+        emitted,
+        "L3 EnvironmentBuilder must emit a security event on critical-var override"
+    );
+    assert_eq!(
+        silent_count, 0,
+        "silent() EnvironmentBuilder must not emit events"
+    );
+}
+
+/// A benign validation failure (bad characters, not an injection) must NOT be
+/// escalated to a security event — only `Problem::PermissionDenied` failures
+/// are. Guards against over-emitting on the far more common Warning path.
+#[test]
+fn layer3_generic_builder_no_security_event_on_benign_failure() {
+    use crate::identifiers::GenericBuilder;
+
+    ensure_test_dispatcher();
+
+    let name = "layer_isolation_l3_benign";
+    let capture = register_capture(name);
+
+    // Leading digit -> "must start with letter or underscore" (Validation),
+    // not a security detection. The token would surface if wrongly escalated.
+    let token = "9invalid_L3BENIGN_409_c5d1";
+    let err = GenericBuilder::new().validate_identifier(token);
+    assert!(err.is_err(), "bad identifier must fail validation");
+
+    // Dispatch a probe so we do not just time out on legitimate silence.
+    let probe_marker = "L3BENIGN_PROBE_409_c5d1";
+    dispatch(Event::new(EventType::Info, probe_marker));
+    let flushed = poll_until(POLL_DEADLINE, || {
+        count_with_marker(&capture, probe_marker) >= 1
+    });
+
+    let escalated = count_with_marker(&capture, "_L3BENIGN_409_c5d1");
+    unregister_writer(name);
+
+    assert!(flushed, "probe event should confirm the dispatcher flushed");
+    assert_eq!(
+        escalated, 0,
+        "benign (non-security) validation failures must not emit a security event"
+    );
+}

--- a/crates/octarine/src/identifiers/builder/metrics.rs
+++ b/crates/octarine/src/identifiers/builder/metrics.rs
@@ -3,6 +3,7 @@
 //! This is the **public API** (Layer 3) that wraps the primitive builder
 //! with observe instrumentation for compliance-grade audit trails.
 
+use super::emit_security_event;
 use crate::observe::Problem;
 use crate::primitives::identifiers::{MetricViolation, MetricsBuilder as PrimitiveMetricsBuilder};
 
@@ -130,23 +131,56 @@ impl MetricsBuilder {
     // ========================================================================
 
     /// Validate a metric name (returns Result)
+    ///
+    /// When observe events are enabled, an injection-pattern detection
+    /// (surfaced by the primitive as [`Problem::PermissionDenied`]) is emitted
+    /// as a CRITICAL security event, preserving the attack-detection audit trail.
     pub fn validate_name(&self, name: &str) -> Result<(), Problem> {
-        self.inner.validate_name(name)
+        let result = self.inner.validate_name(name);
+        if self.emit_events {
+            emit_security_event(&result, "identifiers.metrics.name", name);
+        }
+        result
     }
 
     /// Validate a label key (returns Result)
     pub fn validate_label_key(&self, key: &str) -> Result<(), Problem> {
-        self.inner.validate_label_key(key)
+        let result = self.inner.validate_label_key(key);
+        if self.emit_events {
+            emit_security_event(&result, "identifiers.metrics.label_key", key);
+        }
+        result
     }
 
     /// Validate a label value (returns Result)
+    ///
+    /// When observe events are enabled, a severe-injection detection (surfaced
+    /// by the primitive as [`Problem::PermissionDenied`]) is emitted as a
+    /// CRITICAL security event.
     pub fn validate_label_value(&self, value: &str) -> Result<(), Problem> {
-        self.inner.validate_label_value(value)
+        let result = self.inner.validate_label_value(value);
+        if self.emit_events {
+            emit_security_event(&result, "identifiers.metrics.label_value", value);
+        }
+        result
     }
 
     /// Validate label count (returns Result)
+    ///
+    /// When observe events are enabled, a cardinality-limit breach (surfaced by
+    /// the primitive as [`Problem::PermissionDenied`]) is emitted as a CRITICAL
+    /// security event — unbounded label cardinality is a denial-of-service
+    /// vector.
     pub fn validate_label_count(&self, count: usize) -> Result<(), Problem> {
-        self.inner.validate_label_count(count)
+        let result = self.inner.validate_label_count(count);
+        if self.emit_events {
+            emit_security_event(
+                &result,
+                "identifiers.metrics.label_count",
+                &count.to_string(),
+            );
+        }
+        result
     }
 
     // ========================================================================
@@ -176,18 +210,38 @@ impl MetricsBuilder {
     // ========================================================================
 
     /// Sanitize a metric name, returning an error if invalid
+    ///
+    /// When observe events are enabled, an injection pattern that is rejected
+    /// rather than silently sanitized (surfaced by the primitive as
+    /// [`Problem::PermissionDenied`]) is emitted as a CRITICAL security event.
     pub fn sanitize_name(&self, name: &str) -> Result<String, Problem> {
-        self.inner.sanitize_name(name)
+        let result = self.inner.sanitize_name(name);
+        if self.emit_events {
+            emit_security_event(&result, "identifiers.metrics.sanitize_name", name);
+        }
+        result
     }
 
     /// Sanitize a label key, returning an error if invalid
     pub fn sanitize_label_key(&self, key: &str) -> Result<String, Problem> {
-        self.inner.sanitize_label_key(key)
+        let result = self.inner.sanitize_label_key(key);
+        if self.emit_events {
+            emit_security_event(&result, "identifiers.metrics.sanitize_label_key", key);
+        }
+        result
     }
 
     /// Sanitize a label value, returning an error if invalid
+    ///
+    /// When observe events are enabled, a severe-injection pattern that is
+    /// rejected rather than sanitized (surfaced by the primitive as
+    /// [`Problem::PermissionDenied`]) is emitted as a CRITICAL security event.
     pub fn sanitize_label_value(&self, value: &str) -> Result<String, Problem> {
-        self.inner.sanitize_label_value(value)
+        let result = self.inner.sanitize_label_value(value);
+        if self.emit_events {
+            emit_security_event(&result, "identifiers.metrics.sanitize_label_value", value);
+        }
+        result
     }
 }
 

--- a/crates/octarine/src/identifiers/builder/mod.rs
+++ b/crates/octarine/src/identifiers/builder/mod.rs
@@ -83,6 +83,9 @@ mod organizational;
 mod personal;
 mod token;
 
+#[cfg(test)]
+mod layer_isolation;
+
 // Re-export all domain builders
 pub use biometric::BiometricBuilder;
 pub use confidence::ConfidenceBuilder;
@@ -112,6 +115,24 @@ use crate::primitives::identifiers::StreamingScanner;
 use crate::primitives::identifiers::confidence::ConfidenceBuilder as PrimitiveConfidenceBuilder;
 
 use super::types::{IdentifierMatch, IdentifierType};
+
+use crate::observe::Problem;
+
+/// Emit a CRITICAL security event when a validation/sanitization failure is a
+/// security detection (an injection or override attempt), which the primitive
+/// signals via [`Problem::PermissionDenied`]. Benign failures (empty, too long,
+/// bad chars) surface as [`Problem::Validation`] and are intentionally not
+/// escalated here.
+///
+/// This restores the audit trail that Layer-1 constructors previously emitted
+/// as a side effect, now that Layer 1 uses the event-free constructor trait
+/// (issue #409). Audit coverage belongs in these Layer-3 wrappers, gated on the
+/// builder's `emit_events` flag by the caller.
+pub(super) fn emit_security_event<T>(result: &Result<T, Problem>, operation: &str, input: &str) {
+    if let Err(Problem::PermissionDenied(reason)) = result {
+        observe::critical(operation, format!("{reason} (input: {input})"));
+    }
+}
 
 crate::define_metrics! {
     detect_ms => "data.identifiers.unified.detect_ms",

--- a/crates/octarine/src/primitives/types/mod.rs
+++ b/crates/octarine/src/primitives/types/mod.rs
@@ -57,7 +57,11 @@ pub(crate) use dates::{
 pub use network::PortRange;
 pub use octarine_problem::{Problem, Result};
 
-// Re-export the observability-enabled constructors trait so call sites that
-// import `Problem` from `primitives::types` can also pick up
-// `Problem::validation(..)`, `Problem::network(..)`, etc.
-pub use crate::observe::ProblemExt;
+// Re-export the event-free constructors trait from Layer 0 (octarine-problem)
+// under the familiar `ProblemExt` name, so call sites that import `Problem` from
+// `primitives::types` can also pick up `Problem::validation(..)`,
+// `Problem::network(..)`, etc. Layer 1 must NOT reach observe's same-named
+// `ProblemExt`, whose constructors dispatch observability events as a side
+// effect (that audit coverage belongs in the Layer 3 wrappers). Layer 2/3 code
+// continues to import the event-dispatching trait from `crate::observe`.
+pub use octarine_problem::ProblemConstructors as ProblemExt;


### PR DESCRIPTION
## Summary

Fixes the `octarine-layers` audit finding (#409): `primitives/types/mod.rs`
re-exported `crate::observe::ProblemExt`, pulling a **Layer 2** trait into the
**Layer 1** surface — a unidirectional-dependency violation.

The trait wasn't merely re-exported. **36 Layer-1 files make 330 calls** to
`Problem::validation()`/`security()`/etc. through it, and several observe
constructors **dispatch audit events as a side effect** of construction — so
Layer 1 was emitting Layer 2 events. The two naive fixes both fail:

- *Delete the re-export, import from observe directly* → impossible; Layer 1
  can't import from observe.
- *Add same-named inherent constructors on `Problem`* → dangerous; verified that
  an inherent assoc-fn **silently shadows** an in-scope trait method, which
  would strip audit events from all 455 Layer 2/3 call sites (only an
  unused-import warning, no error).

### What this does

1. **Adds an event-free `ProblemConstructors` trait** to the Layer 0
   `octarine-problem` micro-crate and re-exports it from `primitives::types` as
   `ProblemExt`. All 36 primitive files + 330 call sites compile **unchanged**
   but now resolve to the event-free Layer-0 trait. observe's event-dispatching
   `ProblemExt` is untouched for Layer 2/3. `crate::primitives` is `pub(crate)`,
   so there's **no public-API/SemVer impact**.

2. **Restores the Layer-3 audit trail** that the removed side effect provided.
   Pre-PR review caught (and I verified) that three identifier builders —
   `generic`, `environment`, `metrics` — relied on the primitive `security()`
   side effect for CRITICAL injection/critical-var/cardinality audit events;
   their `emit_events` flag was dead. A shared `emit_security_event` helper now
   emits `observe::critical` (gated on `emit_events`) whenever the primitive
   returns a security-class `PermissionDenied`, mirroring the `security::*`
   builders. Benign `Validation` failures are intentionally not escalated.

3. **Adds `layer_isolation` regression tests** locking in the contract:
   Layer-1 constructors dispatch **zero** events; Layer-3 re-emits CRITICAL on
   cardinality breach + critical-var override; benign failures don't over-emit.

## Test plan

- `just arch-check` — the `octarine-layers-001` violation is resolved (exit 0)
- `just clippy` — clean
- `just doc` — clean (rustdoc `-D warnings`)
- `just test` — 8459 pass, +4 new regression tests. (Two pre-existing timing
  flakes — `auth::timing::test_constant_time_response_async_fast` and
  `collections::cache::lru::test_cache_cleanup` — fail only under this
  container's clock/parallel load, fail identically on a rebuilt clean baseline,
  and neither file references `Problem`/`ProblemExt`; CI's `ci` profile retries
  timing tests.)
- `grep` confirms zero `observe::ProblemExt` remains in `primitives/`.

## Follow-up

The lower-severity `validation`/`conversion` **Warning**-event gaps across the
same L3 builders (they lost their Warning-level side effect too) are deferred to
a follow-up issue — see the escalation discussion on #409.

Closes #409