### PR TITLE
chore(deps): upgrade x25519-dalek 2.x → 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,22 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1381,7 +1396,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "serde",
  "sha2 0.10.9",
@@ -1529,6 +1544,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "figment"
@@ -4839,7 +4860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5945,13 +5966,13 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
- "curve25519-dalek",
- "rand_core 0.6.4",
- "serde",
+ "curve25519-dalek 5.0.0",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/crates/octarine/Cargo.toml
+++ b/crates/octarine/Cargo.toml
@@ -67,7 +67,7 @@ hex = "0.4"
 zeroize = { version = "1.8", features = ["derive"] }
 chacha20poly1305 = "0.11.0"
 aes-gcm = "0.11.0"
-argon2 = "0.5"
+argon2 = { version = "0.5", features = ["std"] }
 
 # Cryptocurrency address validation (BTC base58check, Bech32/Bech32m, ETH EIP-55)
 bs58 = { version = "0.5", features = ["check"] }
@@ -125,7 +125,7 @@ rand_core = "0.10"
 getrandom = { version = "0.4", features = ["sys_rng"] }
 
 # Classical elliptic curve cryptography
-x25519-dalek = { version = "2.0", features = ["static_secrets", "getrandom", "zeroize"] }
+x25519-dalek = { version = "3.0", features = ["static_secrets", "getrandom", "zeroize"] }
 
 # Database support (optional)
 sqlx = { version = "0.9", optional = true, default-features = false, features = [

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,14 @@ skip = [
   { crate = "rand_core:0.6.4", reason = "RustCrypto rand_core-0.6 ecosystem (elliptic-curve/rsa/signature) — re-evaluate 2026-12-01" },
   { crate = "rand_core:0.9.5", reason = "follows rand 0.9.5 blockers — re-evaluate 2026-12-01" },
 
+  # ── curve25519-dalek 4/5 split ── introduced by x25519-dalek 3.0 (#687),
+  # which pulls curve25519-dalek 5.0.0. ed25519-dalek 2.2.0 ← jsonwebtoken
+  # 10.4.0 (latest) still pins curve25519-dalek 4.x; fiat-crypto is the
+  # curve25519-dalek field backend and duplicates alongside it. Clears when
+  # jsonwebtoken's ed25519-dalek moves to curve25519-dalek 5.
+  { crate = "curve25519-dalek:4.1.3", reason = "ed25519-dalek 2.2.0 ← jsonwebtoken 10.4.0 (latest) still on curve25519-dalek 4.x; x25519-dalek 3.0 pulls 5.x — re-evaluate 2026-12-01" },
+  { crate = "fiat-crypto:0.2.9", reason = "field backend of curve25519-dalek 4.x (above) — re-evaluate 2026-12-01" },
+
   # ── toml / figment stack ── single blocker: figment 0.10.19 (latest) pins
   # toml ^0.8, which drags toml_edit 0.22 + winnow 0.7 + toml_datetime 0.6.
   { crate = "toml_datetime:0.6.11", reason = "figment 0.10.19 pins toml 0.8 — re-evaluate 2026-12-01" },


### PR DESCRIPTION
## Summary

Upgrades `x25519-dalek` 2.0.1 → **3.0.0** (Dependabot #685, deferred from #686 as a breaking major and tracked as #687).

3.0.0 is a major release **only** because the `digest` traits are part of x25519-dalek's public API and were updated — there are no other user-facing API changes. octarine's hybrid-encryption code (`primitives/crypto/encryption/hybrid/*`) uses only the stable, non-digest surface (`StaticSecret`, `EphemeralSecret`, `PublicKey`, `.diffie_hellman()`, `::random()`, `.as_bytes()`), and those types are internal (`pub(crate)`), so **no source changes and no change to octarine's public API**.

## Changes

- **`crates/octarine/Cargo.toml`**: `x25519-dalek` `2.0` → `3.0` (same feature set: `static_secrets`, `getrandom`, `zeroize` — all still exist in 3.0).
- **`Cargo.lock`**: pulls `curve25519-dalek 5.0.0` + `fiat-crypto 0.3.0`.
- **`deny.toml`**: documented `[bans]` skips for the two new duplicates. x25519-dalek 3.0 pulls curve25519-dalek 5.x while `ed25519-dalek 2.2.0 ← jsonwebtoken 10.4.0` (latest stable) stays on 4.x → one `curve25519-dalek` 4/5 duplicate, with `fiat-crypto` (its field backend) travelling alongside. Documented per the #686 pattern (exact old version pinned, blocker named, re-evaluate 2026-12-01), not silenced.
- **`crates/octarine/Cargo.toml` (argon2)**: added the `std` feature. The bump exposed a **latent feature-unification bug** — `password.rs`'s `SaltString::generate(&mut OsRng)` needs `rand_core 0.6`'s `getrandom` feature, which x25519-dalek 2.x *incidentally* enabled on the shared `rand_core 0.6.4`. x25519-dalek 3.0 moved to `rand_core 0.10`, so it vanished. Enabling `argon2/std` (→ `password-hash/std` → `rand_core/std` → `getrandom`) makes that dependency explicit instead of accidental.

## Test plan

- `just clippy` — clean
- `just deps-deny` — `advisories ok, bans ok, licenses ok, sources ok`; **0 duplicate + 0 unmatched-skip** warnings
- `just test-mod hybrid` (26 unit) + `just test-filter hybrid` (33 incl. integration round-trip/isolation/corruption) — pass
- `just test` (full nextest + doctests) — **0 failures**

Closes #687