### PR TITLE
docs(claude-md): sync skills and CLAUDE.md with current code state

### DIFF
--- a/.claude/skills/octarine-architecture/SKILL.md
+++ b/.claude/skills/octarine-architecture/SKILL.md
@@ -16,7 +16,7 @@ code goes, diagnosing a visibility issue, or reviewing naming.
 | **L1** | `primitives/` | `pub(crate)` | External crates, `Problem` type only | `observe::*`, any L3 module |
 | **L1** | `testing/` | `pub` + `#[cfg(feature)]` | Everything | — |
 | **L2** | `observe/` | `pub` | `primitives/` | Any L3 module, `testing/` |
-| **L3** | `identifiers/`, `data/`, `runtime/`, `crypto/`, `security/` | `pub` | `primitives/` + `observe/` | `testing/` (except `#[cfg(test)]`) |
+| **L3** | `data/`, `security/`, `identifiers/`, `runtime/`, `crypto/`, `io/`, `auth/`, `http/` | `pub` | `primitives/` + `observe/` | `testing/` (except `#[cfg(test)]`) |
 
 Primitives must NEVER call `observe::info/warn/debug/fail`, `increment_by()`, or `record()`.
 

--- a/.claude/skills/octarine-identifier-checklist/SKILL.md
+++ b/.claude/skills/octarine-identifier-checklist/SKILL.md
@@ -42,8 +42,9 @@ Every identifier type requires ALL applicable steps.
 7. **Validation methods** — same file (or `builder/` subdirectory for large domains)
 8. **Sanitization methods** — same file
    - All builder methods DELEGATE to implementation — no business logic
-   - 15/18 domains use single `builder.rs`. Only personal, network, location
-     use `builder/` subdirectory with split files.
+   - 13/18 domains use single `builder.rs`. Five use a `builder/`
+     subdirectory with split files: government, location, network, personal,
+     token.
 
 ### Layer 3: Public API (pub)
 
@@ -55,8 +56,8 @@ Every identifier type requires ALL applicable steps.
     - `pub fn validate_{type}(v: &str) -> Result<(), Problem> { ... }`
 
 11. **Type registration** — two separate files:
-    - Add `IdentifierType::{Type}` variant in `primitives/identifiers/types.rs`
-    - Add `PiiType::{Type}` variant in `observe/pii/types.rs` (if PII)
+    - Add `IdentifierType::{Type}` variant in `primitives/identifiers/types/core.rs`
+    - Add `PiiType::{Type}` variant in `observe/pii/types/mod.rs` (if PII)
     - Register in PII scanner (`observe/pii/scanner/`) if the type is PII
 
 ### Verification

--- a/.claude/skills/octarine-observe-integration/SKILL.md
+++ b/.claude/skills/octarine-observe-integration/SKILL.md
@@ -77,11 +77,9 @@ pub fn validate(&self, input: &str) -> Result<(), Problem> {
 **Never use** `event::warn()` in new Layer 3 builders — use `observe::warn()`
 for consistent operation context capture in audit trails.
 
-**Migration note**: Several existing builders still use `event::warn()`:
-`crypto/validation/builder.rs`, `data/text/builder.rs`,
-`identifiers/builder/{government,biometric}.rs`,
-`security/{queries,network}/builder.rs`. When modifying one of these builders,
-migrate existing `event::` calls to `observe::` at the same time.
+**Migration note**: One existing builder still uses `event::warn()`:
+`crypto/validation/builder.rs`. When modifying it, migrate the existing
+`event::` calls to `observe::` at the same time.
 
 ## When to Use
 

--- a/.claude/skills/octarine-pii-bridge/SKILL.md
+++ b/.claude/skills/octarine-pii-bridge/SKILL.md
@@ -16,8 +16,8 @@ implementation process; this skill covers only the cross-registry sync steps.
 
 | Registry | File | Purpose |
 |----------|------|---------|
-| `IdentifierType` | `primitives/identifiers/types.rs` | Primitives-level enum (source of truth) |
-| `PiiType` | `observe/pii/types.rs` | PII classification enum |
+| `IdentifierType` | `primitives/identifiers/types/core.rs` | Primitives-level enum (source of truth) |
+| `PiiType` | `observe/pii/types/mod.rs` | PII classification enum |
 | Scanner domains | `observe/pii/scanner/domains.rs` | Detection dispatch per domain |
 
 **All three MUST be updated together.**
@@ -28,14 +28,14 @@ When adding a new identifier type `{Type}` to domain `{domain}`:
 
 ### 1. IdentifierType (primitives — source of truth)
 
-File: `crates/octarine/src/primitives/identifiers/types.rs`
+File: `crates/octarine/src/primitives/identifiers/types/core.rs`
 
 Add variant to the `IdentifierType` enum in the appropriate domain section.
 The Layer 3 file `identifiers/types/core.rs` is a re-export — do not edit it.
 
 ### 2. PiiType (observe layer)
 
-File: `crates/octarine/src/observe/pii/types.rs`
+File: `crates/octarine/src/observe/pii/types/mod.rs`
 
 ```rust
 pub enum PiiType {
@@ -53,8 +53,9 @@ Update classification methods:
 - `is_hipaa_protected()` — if HIPAA-relevant (medical/health data)
 - `is_secret()` — if it's a secret/credential
 
-Read the actual `is_*_protected()` methods in `observe/pii/types.rs` for
-current classifications before deciding which to update.
+Read the actual `is_*_protected()` methods in `observe/pii/types/` (see
+`classification.rs` and `mod.rs`) for current classifications before deciding
+which to update.
 
 ### 3. Scanner Domain Function
 
@@ -77,9 +78,10 @@ pub(super) fn scan_{domain}(text: &str, pii_types: &mut Vec<PiiType>) {
 After updating all three registries:
 
 ```bash
-# Verify the new variant appears in all three files
-grep "{Type}" crates/octarine/src/primitives/identifiers/types.rs
-grep "{Type}" crates/octarine/src/observe/pii/types.rs
+# Verify the new variant appears in all three registries
+# (types.rs was split into a types/ directory; scan the whole directory)
+grep -r "{Type}" crates/octarine/src/primitives/identifiers/types/
+grep -r "{Type}" crates/octarine/src/observe/pii/types/
 grep "{type}\|{Type}" crates/octarine/src/observe/pii/scanner/domains.rs
 
 # Run PII and identifier tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ crates/octarine/src/
 │   │   ├── personal/# SSN, email, phone, names
 │   │   ├── financial/# Credit cards, bank accounts
 │   │   └── ...     # credentials, medical, government, etc.
+│   ├── http/       # HTTP primitives (headers, request IDs, routing, security)
 │   ├── io/         # File operations
 │   ├── runtime/    # Async utilities
 │   ├── types/      # Common types (Problem, Result)
@@ -169,7 +170,7 @@ This separation ensures:
 detection::is_traversal_present(path)  // "file..txt" -> true (sensitive)
 
 // VALIDATION - Strict (precise, no false positives)
-validation::validate_no_traversal(path)?;  // Uses Path::components()
+validation::validate_no_traversal_strict(path)?;  // Uses Path::components()
 
 // SANITIZATION - Transform dangerous input
 sanitization::sanitize_path(path)?;  // Removes threats
@@ -360,7 +361,7 @@ so transient runner contention does not block PRs. See
 1. Add detection function in `primitives/{concern}/{domain}/detection.rs`
 1. Add validation function in `primitives/{concern}/{domain}/validation.rs` (calls detection)
 1. Add sanitization if needed in `primitives/{concern}/{domain}/sanitization.rs`
-1. Wrap in Layer 3 (`data/`) with observe instrumentation
+1. Wrap in the corresponding Layer 3 module (`data/`, `security/`, or `identifiers/`) with observe instrumentation
 1. Add to builder API
 1. Add shortcut function
 


### PR DESCRIPTION
## Summary

Fixes seven documentation-drift items flagged by the ai-config audit (#407). Every claim was verified against current source before editing — this is a docs-only change (5 markdown files, no Rust touched).

| File | Drift fixed |
| ---- | ----------- |
| `octarine-pii-bridge/SKILL.md` | `types.rs` → `types/{core,mod}.rs` (both are now directories); verification grep commands updated to scan the directories |
| `octarine-architecture/SKILL.md` | Layer 3 table listed 5 of 8 modules — added `auth/`, `http/`, `io/`, now matching CLAUDE.md's golden-rule list |
| `octarine-identifier-checklist/SKILL.md` | "15/18 domains use single `builder.rs`" → correct "13/18; five use `builder/` subdir (government, location, network, personal, token)"; also fixed stale `types.rs` refs in step 11 |
| `octarine-observe-integration/SKILL.md` | Migration note listed 6 `event::warn()` users; only `crypto/validation/builder.rs` actually remains — trimmed to just that one |
| `CLAUDE.md` | `validate_no_traversal(path)?` → `validate_no_traversal_strict` (the `?`-compatible `Result` variant — the `bool` variant won't compile); "Wrap in Layer 3 (`data/`)" → "corresponding Layer 3 module"; added `primitives/http/` to the module tree |

## Test plan

- Docs-only change — no code paths affected.
- Each drift claim cross-checked against the tree: `types/` and `pii/types/` are directories; `primitives/http/` exists (5 files); five identifier domains use `builder/` subdirs; `crypto/validation/builder.rs` is the sole `event::warn()` user; `validate_no_traversal_strict` returns `Result<(), Problem>`.
- Post-edit grep sweep confirms no residual `identifiers/types.rs` / `pii/types.rs` / stale-list references remain.

Closes #407