### PR TITLE
docs(docs): fix code examples referencing non-existent APIs

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -34,34 +34,34 @@ Principles and patterns for designing clean, secure, and ergonomic APIs in octar
 ### Builder Pattern
 
 ```rust
-let sanitizer = PathSanitizer::builder()
-    .remove_traversal()
-    .normalize()
-    .strict_mode()
-    .build();
+use octarine::security::paths::SecurityBuilder;
+
+let sanitizer = SecurityBuilder::new();
+let safe = sanitizer.sanitize("../file")?;
 ```
 
 ### Dual Functions
 
 ```rust
-// Strict - returns Result
-let path = sanitize_path_strict("../file")?;
+use octarine::security::paths::{sanitize_path, strip_traversal};
 
-// Lenient - always succeeds
-let path = sanitize_path("../file");
+// Strict - returns Result<String, Problem>
+let path = sanitize_path("../file")?;
+
+// Lenient - always succeeds, strips traversal in place
+let path = strip_traversal("../file");
 ```
 
 ### Shortcuts for Common Cases
 
 ```rust
-// Direct function for simple cases
-let safe = sanitize_path(user_input);
+use octarine::security::paths::{sanitize_path, SecurityBuilder};
 
-// Builder for complex cases
-let safe = PathSanitizer::builder()
-    .custom_config()
-    .build()
-    .sanitize(user_input)?;
+// Direct function for simple cases (returns Result<String, Problem>)
+let safe = sanitize_path(user_input)?;
+
+// Builder when you need to toggle observe events
+let safe = SecurityBuilder::silent().sanitize(user_input)?;
 ```
 
 ## Public API Surface

--- a/docs/architecture/layer-architecture.md
+++ b/docs/architecture/layer-architecture.md
@@ -406,10 +406,10 @@ Each concern represents a fundamentally different question:
 identifiers::network::is_ipv4("192.168.1.1")  // true - it's an IP address
 
 // THREATS (security/): Is this data DANGEROUS?
-security::network::is_ssrf_target("192.168.1.1")  // true - internal IP, SSRF risk
+security::network::is_potential_ssrf("192.168.1.1")  // true - internal IP, SSRF risk
 
 // FORMAT (data/): How should this be NORMALIZED?
-data::network::normalize_url("HTTP://Example.COM/path")  // "http://example.com/path"
+data::network::normalize_url_path("/api/v1/../v2/users")  // Cow: "/api/v2/users"
 ```
 
 ### Cross-Domain Application

--- a/docs/module-quality.md
+++ b/docs/module-quality.md
@@ -410,7 +410,7 @@ Check mod.rs for module documentation:
 //!
 //! // Detect UUID
 //! let result = network::detect_network_identifier("550e8400-...");
-//! assert_eq!(result, Some(IdentifierType::UUID));
+//! assert_eq!(result, Some(IdentifierType::Uuid));
 //! ```
 //!
 //! # Security Considerations
@@ -460,10 +460,10 @@ Sample 10-15 public functions across the module. Each function MUST have:
 ///
 /// # Returns
 ///
-/// * `Some(IdentifierType::UUID)` - If the value matches UUID format
-/// * `Some(IdentifierType::IPAddress)` - If the value is IPv4 or IPv6
-/// * `Some(IdentifierType::MACAddress)` - If the value is a MAC address
-/// * `Some(IdentifierType::URL)` - If the value has a protocol scheme
+/// * `Some(IdentifierType::Uuid)` - If the value matches UUID format
+/// * `Some(IdentifierType::IpAddress)` - If the value is IPv4 or IPv6
+/// * `Some(IdentifierType::MacAddress)` - If the value is a MAC address
+/// * `Some(IdentifierType::Url)` - If the value has a protocol scheme
 /// * `None` - If no network identifier pattern is detected
 ///
 /// # Examples
@@ -471,11 +471,11 @@ Sample 10-15 public functions across the module. Each function MUST have:
 /// ```ignore
 /// // UUID detection
 /// let result = detect_network_identifier("550e8400-...");
-/// assert_eq!(result, Some(IdentifierType::UUID));
+/// assert_eq!(result, Some(IdentifierType::Uuid));
 ///
 /// // IPv4 detection
 /// let result = detect_network_identifier("192.168.1.1");
-/// assert_eq!(result, Some(IdentifierType::IPAddress));
+/// assert_eq!(result, Some(IdentifierType::IpAddress));
 ///
 /// // Non-network identifier
 /// let result = detect_network_identifier("not-an-id");
@@ -519,8 +519,8 @@ ones.
 //!
 //! ```ignore
 //! // Example showing correct usage for developers
-//! use super::detect_ipv4;
-//! assert!(detect_ipv4("192.168.1.1"));
+//! use super::is_ipv4;
+//! assert!(is_ipv4("192.168.1.1"));
 //! ```
 
 // ❌ WRONG - No examples because it's internal

--- a/docs/observe/compliance.md
+++ b/docs/observe/compliance.md
@@ -128,7 +128,7 @@ use octarine::observe::writers::{AuditQuery, Queryable};
 let query = AuditQuery::builder()
     .since(audit_period_start)
     .until(audit_period_end)
-    .contains_phi_only(true)
+    .phi_only(true)
     .build();
 
 let result = writer.query(&query).await?;
@@ -366,14 +366,14 @@ async fn generate_compliance_report(
     // PII access events
     let pii_query = AuditQuery::builder()
         .since(since)
-        .contains_pii_only(true)
+        .pii_only(true)
         .build();
     let pii_events = writer.query(&pii_query).await?;
 
     // PHI access events (HIPAA)
     let phi_query = AuditQuery::builder()
         .since(since)
-        .contains_phi_only(true)
+        .phi_only(true)
         .build();
     let phi_events = writer.query(&phi_query).await?;
 

--- a/docs/security/patterns/input-architecture.md
+++ b/docs/security/patterns/input-architecture.md
@@ -73,34 +73,33 @@ Based on OWASP input categories, all input falls into one of nine contexts:
 ### Simple Functions (80% of cases)
 
 ```rust
-use octarine::security::data::paths::sanitize_path;
+use octarine::security::paths::sanitize_path;
 
-// Quick sanitization with defaults
-let safe_path = sanitize_path(user_input);
+// Quick sanitization with defaults (returns Result<String, Problem>)
+let safe_path = sanitize_path(user_input)?;
 ```
 
 ### Builder Pattern (Complex cases)
 
 ```rust
-use octarine::security::data::paths::PathSanitizer;
+use octarine::security::paths::SecurityBuilder;
 
-let sanitizer = PathSanitizer::builder()
-    .remove_traversal()
-    .normalize()
-    .strict_mode()
-    .build();
+let sanitizer = SecurityBuilder::new();
 
+// Full sanitization (removes all detected threats)
 let safe_path = sanitizer.sanitize(user_input)?;
 ```
 
 ### Dual Function Pattern
 
 ```rust
-// Strict version - returns Result
-let path = sanitize_path_strict(user_input)?;
+use octarine::security::paths::{sanitize_path, strip_traversal};
 
-// Lenient version - always succeeds with safe default
-let path = sanitize_path(user_input);
+// Strict version - returns Result (Err on unrecoverable threats)
+let path = sanitize_path(user_input)?;
+
+// Lenient version - always succeeds, strips traversal in place
+let path = strip_traversal(user_input);
 ```
 
 ## Security Boundaries


### PR DESCRIPTION
## Summary

Five user-facing documentation files contained Rust code examples that would **not compile** because they referenced pre-v0.3.0 API names (functions, types, and enum variants that no longer exist). Each replacement was verified against the current source tree before editing.

| File | Fix |
| ---- | --- |
| `docs/security/patterns/input-architecture.md` | `security::data::paths::PathSanitizer` → `security::paths::SecurityBuilder`; `sanitize_path_strict` → `sanitize_path` (Result) / `strip_traversal` (lenient); `sanitize_path` now shown returning `Result<String, Problem>` |
| `docs/api/index.md` | Same `PathSanitizer`/`sanitize_path_strict` corrections; builder shown as `SecurityBuilder::new()`/`::silent()` |
| `docs/architecture/layer-architecture.md` | `is_ssrf_target` → `is_potential_ssrf`; `normalize_url` → `normalize_url_path` (takes a URL path, returns `Cow`) |
| `docs/observe/compliance.md` | `AuditQuery::builder()` `.contains_phi_only`/`.contains_pii_only` → `.phi_only`/`.pii_only` (both blocks) |
| `docs/module-quality.md` | `IdentifierType::UUID/IPAddress/MACAddress/URL` → `Uuid/IpAddress/MacAddress/Url`; `detect_ipv4` → `is_ipv4` |

Addresses all five audit findings (docs-001 through docs-005). Also corrected the sibling `contains_pii_only` in compliance.md (identical bug in the same examples, not separately listed).

## Test plan

- These `.md` files are standalone (not included via `doc(include_str!)`), so there is no compile/doctest step that exercises them — corrections were verified by grepping each replacement name against the source tree:
  - `SecurityBuilder`, `sanitize_path`, `strip_traversal` in `crates/octarine/src/security/paths/`
  - `is_potential_ssrf` in `security/network/shortcuts.rs`; `normalize_url_path` in `data/network/shortcuts.rs`
  - `phi_only`/`pii_only` in `observe/writers/database/query.rs`
  - `Uuid`/`IpAddress`/`MacAddress`/`Url` in `primitives/identifiers/types/core.rs`; `is_ipv4` in `identifiers/shortcuts/network.rs`

Closes #405