### PR TITLE
fix(identifiers): drop inverted Luhn exclusion from bank account heuristic

### DIFF
--- a/crates/octarine/src/identifiers/builder/financial.rs
+++ b/crates/octarine/src/identifiers/builder/financial.rs
@@ -820,6 +820,34 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_bank_account_with_context() {
+        use super::super::super::types::DetectionConfidence;
+
+        let builder = FinancialBuilder::silent();
+
+        // No context → Low confidence (verifies the wrapper forwards args and
+        // returns the primitive's DetectionResult).
+        let low = builder
+            .detect_bank_account_with_context("4532015112830366", None)
+            .expect("Luhn-valid 16-digit string should be a candidate account");
+        assert_eq!(low.identifier_type, IdentifierType::BankAccount);
+        assert_eq!(low.confidence, DetectionConfidence::Low);
+
+        // Keyword context → Medium confidence (context arg is forwarded, not dropped).
+        let medium = builder
+            .detect_bank_account_with_context("12345678", Some("bank account number"))
+            .expect("8-digit string with context should be a candidate account");
+        assert_eq!(medium.confidence, DetectionConfidence::Medium);
+
+        // Bad length → None.
+        assert!(
+            builder
+                .detect_bank_account_with_context("1234567", Some("bank account"))
+                .is_none()
+        );
+    }
+
+    #[test]
     fn test_redact_credit_card_with_strategy() {
         let builder = FinancialBuilder::silent();
 

--- a/crates/octarine/src/identifiers/builder/financial.rs
+++ b/crates/octarine/src/identifiers/builder/financial.rs
@@ -157,6 +157,37 @@ impl FinancialBuilder {
         self.inner.is_bank_account(value)
     }
 
+    /// Detect a bank account with context-aware confidence scoring
+    ///
+    /// Returns [`DetectionConfidence::Low`] for a bare 8-17 digit string and
+    /// [`DetectionConfidence::Medium`] when a bank-account keyword appears in
+    /// `context`. Returns `None` when the length rules out an account number.
+    ///
+    /// [`DetectionConfidence::Low`]: crate::identifiers::DetectionConfidence::Low
+    /// [`DetectionConfidence::Medium`]: crate::identifiers::DetectionConfidence::Medium
+    #[must_use]
+    pub fn detect_bank_account_with_context(
+        &self,
+        value: &str,
+        context: Option<&str>,
+    ) -> Option<DetectionResult> {
+        let start = Instant::now();
+        let result = self.inner.detect_bank_account_with_context(value, context);
+
+        if self.emit_events {
+            record(
+                metric_names::detect_ms(),
+                start.elapsed().as_micros() as f64 / 1000.0,
+            );
+
+            if result.is_some() {
+                increment_by(metric_names::detected(), 1);
+            }
+        }
+
+        result
+    }
+
     /// Check if value is a valid IBAN (format + MOD-97 checksum)
     #[must_use]
     pub fn is_iban(&self, value: &str) -> bool {

--- a/crates/octarine/src/primitives/identifiers/financial/builder.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/builder.rs
@@ -71,6 +71,20 @@ impl FinancialIdentifierBuilder {
         detection::is_bank_account(value)
     }
 
+    /// Detect a bank account with context-aware confidence scoring
+    ///
+    /// Returns [`DetectionConfidence::Low`] for a bare 8-17 digit string and
+    /// [`DetectionConfidence::Medium`] when a bank-account keyword appears in
+    /// `context`. Returns `None` when the length rules out an account number.
+    #[must_use]
+    pub fn detect_bank_account_with_context(
+        &self,
+        value: &str,
+        context: Option<&str>,
+    ) -> Option<DetectionResult> {
+        detection::detect_bank_account_with_context(value, context)
+    }
+
     /// Check if value is a valid IBAN (format + MOD-97 checksum)
     #[must_use]
     pub fn is_iban(&self, value: &str) -> bool {

--- a/crates/octarine/src/primitives/identifiers/financial/detection/bank_account.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/detection/bank_account.rs
@@ -59,7 +59,9 @@ pub fn detect_bank_account_with_context(
     value: &str,
     context: Option<&str>,
 ) -> Option<DetectionResult> {
-    if !is_bank_account_likely(value) {
+    // Length guard mirrors the ReDoS protection on the text-scan functions in
+    // this module — keep unbounded attacker input from allocating/scanning.
+    if value.len() > MAX_INPUT_LENGTH || !is_bank_account_likely(value) {
         return None;
     }
 
@@ -174,9 +176,19 @@ fn is_bank_account_likely(value: &str) -> bool {
 /// Check whether any bank-account context keyword appears in `context`.
 ///
 /// Scans every language's keyword table (case-insensitive) so a caller need not
-/// specify the language of the surrounding text.
+/// specify the language of the surrounding text. Only English currently defines
+/// `BankAccount` keywords; the other language tables resolve to empty slices
+/// until they are backfilled, so non-English context is effectively unmatched
+/// today. The scan is bounded to `MAX_INPUT_LENGTH` bytes to cap the cost of a
+/// large `context` blob.
 fn has_bank_account_context(context: &str) -> bool {
-    let context_lower = context.to_lowercase();
+    // Bound the scan to MAX_INPUT_LENGTH chars (char-based, so always on a UTF-8
+    // boundary) before lowercasing, capping the cost of a large context blob.
+    let context_lower: String = context
+        .chars()
+        .take(MAX_INPUT_LENGTH)
+        .flat_map(char::to_lowercase)
+        .collect();
     KeywordLanguage::all().any(|language| {
         context_keywords(&IdentifierType::BankAccount, language)
             .iter()
@@ -244,6 +256,15 @@ mod tests {
         let result = detect_bank_account_with_context("12345678", Some("bank account number"))
             .expect("8-digit string with context should be a candidate account");
         assert_eq!(result.confidence, DetectionConfidence::Medium);
+    }
+
+    #[test]
+    fn test_detect_bank_account_with_context_low_with_irrelevant_context() {
+        // Some(context) but no bank-account keyword → still Low (distinct code
+        // path from the None case via `is_some_and`).
+        let result = detect_bank_account_with_context("12345678", Some("just some unrelated text"))
+            .expect("8-digit string should be a candidate account");
+        assert_eq!(result.confidence, DetectionConfidence::Low);
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/financial/detection/bank_account.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/detection/bank_account.rs
@@ -277,6 +277,14 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_bank_account_with_context_redos_guard() {
+        // Oversized value → None via the MAX_INPUT_LENGTH short-circuit, before
+        // the digit-count heuristic runs.
+        let oversized = "1".repeat(MAX_INPUT_LENGTH + 1);
+        assert!(detect_bank_account_with_context(&oversized, None).is_none());
+    }
+
+    #[test]
     fn test_empty_input() {
         assert!(!is_bank_account(""));
         assert!(detect_bank_account_with_context("", None).is_none());

--- a/crates/octarine/src/primitives/identifiers/financial/detection/bank_account.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/detection/bank_account.rs
@@ -5,10 +5,11 @@
 //! - IBAN pattern detection
 //! - Payment token patterns (Stripe, PayPal)
 
-use super::super::super::common::patterns;
-use super::super::super::types::{IdentifierMatch, IdentifierType};
-
-use super::credit_card::is_luhn_checksum_valid;
+use super::super::super::common::{KeywordLanguage, patterns};
+use super::super::super::confidence::context_keywords;
+use super::super::super::types::{
+    DetectionConfidence, DetectionResult, IdentifierMatch, IdentifierType,
+};
 
 // ============================================================================
 // Constants
@@ -25,6 +26,55 @@ const MAX_INPUT_LENGTH: usize = 10_000;
 #[must_use]
 pub fn is_bank_account(value: &str) -> bool {
     is_bank_account_likely(value)
+}
+
+/// Detect a bank account with context-aware confidence scoring.
+///
+/// Bank account numbers have no self-validating checksum, so a bare 8-17 digit
+/// string is inherently ambiguous. This detector returns a confidence level and
+/// lets the caller decide how to act on it:
+///
+/// - No surrounding context → [`DetectionConfidence::Low`] (heuristic length match only)
+/// - A bank-account context keyword nearby → [`DetectionConfidence::Medium`]
+///
+/// Unlike the previous heuristic, this does **not** exclude Luhn-valid strings:
+/// real account numbers routinely satisfy the Luhn checksum by chance, so
+/// excluding them produced a measurable false-reject rate. Credit-card
+/// disambiguation is handled upstream by trying [`detect_credit_card_with_context`]
+/// first (see `find_financial_identifier`).
+///
+/// [`detect_credit_card_with_context`]: super::credit_card::detect_credit_card_with_context
+///
+/// # Arguments
+///
+/// * `value` - The candidate account number (digits, optionally formatted)
+/// * `context` - Optional surrounding text to scan for bank-account keywords
+///
+/// # Returns
+///
+/// `Some(DetectionResult)` when `value` is a plausible account number (8-17
+/// digits), or `None` when the length rules it out.
+#[must_use]
+pub fn detect_bank_account_with_context(
+    value: &str,
+    context: Option<&str>,
+) -> Option<DetectionResult> {
+    if !is_bank_account_likely(value) {
+        return None;
+    }
+
+    let has_context = context.is_some_and(has_bank_account_context);
+    let confidence = if has_context {
+        DetectionConfidence::Medium
+    } else {
+        DetectionConfidence::Low
+    };
+
+    Some(DetectionResult {
+        identifier_type: IdentifierType::BankAccount,
+        confidence,
+        is_sensitive: true,
+    })
 }
 
 /// Find all payment tokens in text
@@ -110,19 +160,34 @@ pub fn detect_bank_accounts_in_text(text: &str) -> Vec<IdentifierMatch> {
 // ============================================================================
 
 /// Check if value is likely a bank account (heuristic)
+///
+/// Bank accounts are typically 8-17 digits. We deliberately do **not** exclude
+/// Luhn-valid strings: real account numbers frequently pass the Luhn checksum by
+/// chance, so excluding them produced false rejects. Credit-card disambiguation
+/// is the caller's responsibility (try credit-card detection first).
 fn is_bank_account_likely(value: &str) -> bool {
-    let digits_only = value
-        .chars()
-        .filter(|c| c.is_ascii_digit())
-        .collect::<String>();
+    let digit_count = value.chars().filter(|c| c.is_ascii_digit()).count();
 
-    // Bank accounts are typically 8-17 digits and NOT credit cards
-    digits_only.len() >= 8 && digits_only.len() <= 17 && !is_luhn_checksum_valid(&digits_only)
+    (8..=17).contains(&digit_count)
+}
+
+/// Check whether any bank-account context keyword appears in `context`.
+///
+/// Scans every language's keyword table (case-insensitive) so a caller need not
+/// specify the language of the surrounding text.
+fn has_bank_account_context(context: &str) -> bool {
+    let context_lower = context.to_lowercase();
+    KeywordLanguage::all().any(|language| {
+        context_keywords(&IdentifierType::BankAccount, language)
+            .iter()
+            .any(|kw| context_lower.contains(kw))
+    })
 }
 
 #[cfg(test)]
 mod tests {
     #![allow(clippy::panic, clippy::expect_used)]
+    use super::super::credit_card::is_luhn_checksum_valid;
     use super::*;
 
     #[test]
@@ -147,14 +212,53 @@ mod tests {
 
     #[test]
     fn test_is_bank_account() {
-        // Bank account-like: 8-17 digits that don't pass Luhn
-        assert!(is_bank_account("12345678")); // 8 digits, fails Luhn
-        assert!(!is_bank_account("1234567")); // Too short
+        // Bank account-like: any 8-17 digit string, regardless of Luhn
+        assert!(is_bank_account("12345678")); // 8 digits
+        assert!(is_bank_account("12345678901234567")); // 17 digits (max)
+        assert!(!is_bank_account("1234567")); // Too short (7 digits)
+        assert!(!is_bank_account("123456789012345678")); // Too long (18 digits)
+    }
+
+    #[test]
+    fn test_is_bank_account_accepts_luhn_valid() {
+        // Regression for the inverted-Luhn false-reject (issue #426).
+        // "4532015112830366" is a 16-digit string that passes the Luhn checksum;
+        // the old heuristic wrongly rejected such strings as bank accounts.
+        assert!(is_luhn_checksum_valid("4532015112830366"));
+        assert!(is_bank_account("4532015112830366"));
+    }
+
+    #[test]
+    fn test_detect_bank_account_with_context_low_without_context() {
+        // No surrounding context → Low confidence, not a hard reject.
+        let result = detect_bank_account_with_context("4532015112830366", None)
+            .expect("Luhn-valid 16-digit string should still be a candidate account");
+        assert_eq!(result.identifier_type, IdentifierType::BankAccount);
+        assert_eq!(result.confidence, DetectionConfidence::Low);
+        assert!(result.is_sensitive);
+    }
+
+    #[test]
+    fn test_detect_bank_account_with_context_medium_with_keyword() {
+        // A bank-account context keyword nearby → Medium confidence.
+        let result = detect_bank_account_with_context("12345678", Some("bank account number"))
+            .expect("8-digit string with context should be a candidate account");
+        assert_eq!(result.confidence, DetectionConfidence::Medium);
+    }
+
+    #[test]
+    fn test_detect_bank_account_with_context_rejects_bad_length() {
+        // Too short / too long → None regardless of context.
+        assert!(detect_bank_account_with_context("1234567", Some("bank account")).is_none());
+        assert!(
+            detect_bank_account_with_context("123456789012345678", Some("bank account")).is_none()
+        );
     }
 
     #[test]
     fn test_empty_input() {
         assert!(!is_bank_account(""));
+        assert!(detect_bank_account_with_context("", None).is_none());
         assert_eq!(detect_bank_accounts_in_text("").len(), 0);
         assert_eq!(detect_payment_tokens_in_text("").len(), 0);
     }

--- a/crates/octarine/src/primitives/identifiers/financial/detection/common.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/detection/common.rs
@@ -5,7 +5,7 @@
 use super::super::super::common::{luhn, patterns};
 use super::super::super::types::{IdentifierMatch, IdentifierType};
 
-use super::bank_account::{detect_bank_accounts_in_text, is_bank_account};
+use super::bank_account::{detect_bank_account_with_context, detect_bank_accounts_in_text};
 use super::credit_card::{
     detect_credit_card_with_context, detect_credit_cards_in_text, is_suspicious_pattern_present,
 };
@@ -49,9 +49,12 @@ pub fn find_financial_identifier(value: &str) -> Option<IdentifierType> {
         return Some(result.identifier_type);
     }
 
-    // Basic bank account detection (heuristic)
-    if is_bank_account(value) {
-        return Some(IdentifierType::BankAccount);
+    // Bank account detection (heuristic, confidence-aware). No surrounding text
+    // is available here, so this resolves to a Low-confidence length match —
+    // the confidence-aware path lets callers with context distinguish a bare
+    // Luhn-coincidence number from a keyword-confirmed one.
+    if let Some(result) = detect_bank_account_with_context(value, None) {
+        return Some(result.identifier_type);
     }
 
     None

--- a/crates/octarine/src/primitives/identifiers/financial/detection/common.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/detection/common.rs
@@ -229,6 +229,14 @@ mod tests {
             find_financial_identifier("121000358"),
             Some(IdentifierType::RoutingNumber)
         );
+
+        // Bank account — an 8-digit string that is neither a credit-card
+        // length/Luhn match nor a routing number falls through to the
+        // confidence-aware bank-account branch.
+        assert_eq!(
+            find_financial_identifier("12345678"),
+            Some(IdentifierType::BankAccount)
+        );
     }
 
     #[test]

--- a/crates/octarine/src/primitives/identifiers/financial/detection/mod.rs
+++ b/crates/octarine/src/primitives/identifiers/financial/detection/mod.rs
@@ -43,7 +43,9 @@ pub use credit_card::{
 pub use routing::{detect_routing_number, detect_routing_numbers_in_text, is_routing_number};
 
 // Re-export bank account functions
-pub use bank_account::{detect_bank_accounts_in_text, is_bank_account};
+pub use bank_account::{
+    detect_bank_account_with_context, detect_bank_accounts_in_text, is_bank_account,
+};
 
 // Re-export payment token functions (in bank_account module for now)
 pub use bank_account::detect_payment_tokens_in_text;


### PR DESCRIPTION
## Summary

`is_bank_account_likely` rejected any 8-17 digit string that passed the Luhn
checksum. Real bank account numbers routinely Luhn-validate by chance, so this
produced a measurable false-reject rate. (Because the shared `is_luhn_checksum_valid`
enforces a min-length of 13, the false-reject actually only bit **13-17 digit**
Luhn-valid strings — 8-12 digit accounts always passed. Fix and intent unchanged.)

- Drop the `!is_luhn_checksum_valid(...)` exclusion — the heuristic is now a pure
  8-17 digit length check.
- Add `detect_bank_account_with_context(value, context) -> Option<DetectionResult>`,
  mirroring the sibling `detect_credit_card_with_context`: `Low` confidence with no
  context, `Medium` when a bank-account keyword (`context_keywords(&IdentifierType::BankAccount)`)
  appears nearby. Callers decide how to act on an inherently checksum-less identifier.
- Wire `find_financial_identifier` through the new detector so the confidence-aware
  path is the pipeline's bank-account decision point, not dead code.
- Plumb the detector through the primitive + Layer 3 builders (with observe
  instrumentation) and the detection re-export.
- Guard the detector against unbounded input (`MAX_INPUT_LENGTH`), matching the
  ReDoS protection on the sibling text-scan functions.

## Test plan

- `just test` (validated locally on the working 1.97.0 toolchain — the pinned
  1.95.0 is broken in this env, missing the cargo component).
- New regression + coverage: Luhn-valid string now accepted; Low/Medium/None
  context paths; irrelevant-context stays Low; aggregate `find_financial_identifier`
  routes an 8-digit string to `BankAccount`; oversized-input ReDoS guard; builder
  wrapper forwards args.
- `cargo clippy` (all-features) and strict `rustdoc` clean on the changed files.

## Pre-PR review

Ran the adversarial review harness (2 cycles). Cycle 1 raised one HIGH blocking
finding — the new detector was unwired from the pipeline — which is fixed here
(`find_financial_identifier` now routes through it). Cycle 2 is **clean** (0
blocking). Remaining low/medium deferrables are filed as follow-ups (linked below).

## Deferred follow-ups (out of scope for the false-reject fix)

- Whether `find_financial_identifier` should gate the bank-account branch on
  `confidence != Low` (as the credit-card branch does) — a directional
  false-*accept* tightening the issue did not request.
- `is_bank_account()` / `redact_bank_account_with_strategy` input-length guard parity.
- Backfill non-English `BankAccount` keyword tables (only `en` defined today).
- `pci_data_found` compliance-metric parity + instrumentation symmetry with
  `detect_credit_card_with_context`.
- Shortcut-convention decision for `_with_context` detectors + the
  `Option<T>` → `find_*` naming edge case (shared with the existing
  `detect_credit_card_with_context`).

Closes #426