### PR TITLE
fix(identifiers): restore Warning audit events for L3 validation failures

### DIFF
--- a/crates/octarine/src/identifiers/builder/database.rs
+++ b/crates/octarine/src/identifiers/builder/database.rs
@@ -5,6 +5,7 @@
 //! This is the **public API** (Layer 3) that wraps the primitive builder
 //! with observe instrumentation for compliance-grade audit trails.
 
+use crate::observe::EmitProblemEvent;
 use crate::observe::Problem;
 use crate::primitives::identifiers::DatabaseBuilder as PrimitiveDatabaseBuilder;
 
@@ -118,8 +119,18 @@ impl DatabaseBuilder {
     // ========================================================================
 
     /// Validate a database identifier (returns Result)
+    ///
+    /// When observe events are enabled, an injection-pattern detection
+    /// (surfaced by the primitive as [`Problem::PermissionDenied`]) is emitted
+    /// as a CRITICAL security event, and a benign validation failure (bad
+    /// characters, reserved keyword, too long) as a WARNING event, preserving
+    /// the audit trail these paths require.
     pub fn validate_identifier(&self, name: &str) -> Result<(), Problem> {
-        self.inner.validate_identifier(name)
+        let result = self.inner.validate_identifier(name);
+        if self.emit_events {
+            result.emit_event("identifiers.database", name);
+        }
+        result
     }
 }
 

--- a/crates/octarine/src/identifiers/builder/environment.rs
+++ b/crates/octarine/src/identifiers/builder/environment.rs
@@ -3,7 +3,7 @@
 //! This is the **public API** (Layer 3) that wraps the primitive builder
 //! with observe instrumentation for compliance-grade audit trails.
 
-use super::emit_security_event;
+use crate::observe::EmitProblemEvent;
 use crate::observe::Problem;
 use crate::primitives::identifiers::EnvironmentBuilder as PrimitiveEnvironmentBuilder;
 
@@ -107,11 +107,12 @@ impl EnvironmentBuilder {
     /// When observe events are enabled, an injection-pattern or
     /// critical-variable-override detection (surfaced by the primitive as
     /// [`Problem::PermissionDenied`]) is emitted as a CRITICAL security event,
-    /// preserving the audit trail these attack-detection paths require.
+    /// and a benign validation failure (bad characters, empty) as a WARNING
+    /// event, preserving the audit trail these paths require.
     pub fn validate_env_var(&self, name: &str) -> Result<(), Problem> {
         let result = self.inner.validate_env_var(name);
         if self.emit_events {
-            emit_security_event(&result, "identifiers.environment", name);
+            result.emit_event("identifiers.environment", name);
         }
         result
     }

--- a/crates/octarine/src/identifiers/builder/generic.rs
+++ b/crates/octarine/src/identifiers/builder/generic.rs
@@ -3,7 +3,7 @@
 //! This is the **public API** (Layer 3) that wraps the primitive builder
 //! with observe instrumentation for compliance-grade audit trails.
 
-use super::emit_security_event;
+use crate::observe::EmitProblemEvent;
 use crate::observe::Problem;
 use crate::primitives::identifiers::GenericBuilder as PrimitiveGenericBuilder;
 
@@ -87,12 +87,13 @@ impl GenericBuilder {
     ///
     /// When observe events are enabled, an injection-pattern detection
     /// (surfaced by the primitive as [`Problem::PermissionDenied`]) is emitted
-    /// as a CRITICAL security event, preserving the audit trail these
-    /// attack-detection paths require for SOC2/PCI-DSS logging.
+    /// as a CRITICAL security event, and a benign validation failure (bad
+    /// characters, reserved names) as a WARNING event, preserving the audit
+    /// trail these paths require for SOC2/PCI-DSS logging.
     pub fn validate_identifier(&self, name: &str) -> Result<(), Problem> {
         let result = self.inner.validate_identifier(name);
         if self.emit_events {
-            emit_security_event(&result, "identifiers.generic", name);
+            result.emit_event("identifiers.generic", name);
         }
         result
     }

--- a/crates/octarine/src/identifiers/builder/layer_isolation.rs
+++ b/crates/octarine/src/identifiers/builder/layer_isolation.rs
@@ -71,6 +71,14 @@ fn count_with_marker(writer: &MemoryWriter, marker: &str) -> usize {
         .count()
 }
 
+fn count_with_marker_of_type(writer: &MemoryWriter, marker: &str, ty: EventType) -> usize {
+    writer
+        .all_events()
+        .iter()
+        .filter(|e| e.event_type == ty && e.message.contains(marker))
+        .count()
+}
+
 /// Named proxy around a shared `MemoryWriter` so multiple concurrent tests can
 /// register distinct capture writers against the global registry (the built-in
 /// `MemoryWriter::name()` is a fixed `"memory"`).
@@ -235,11 +243,14 @@ fn layer3_environment_builder_emits_security_event_on_critical_override() {
     );
 }
 
-/// A benign validation failure (bad characters, not an injection) must NOT be
-/// escalated to a security event — only `Problem::PermissionDenied` failures
-/// are. Guards against over-emitting on the far more common Warning path.
+/// A benign validation failure (bad characters, not an injection) must emit a
+/// WARNING event — restoring the audit trail Layer-1 constructors used to
+/// provide (issue #683) — but must NOT be escalated to a CRITICAL security
+/// event; only `Problem::PermissionDenied` failures are. `silent()` must stay
+/// silent. Guards both the newly-restored Warning path and the security
+/// non-escalation guarantee.
 #[test]
-fn layer3_generic_builder_no_security_event_on_benign_failure() {
+fn layer3_generic_builder_emits_warning_on_benign_failure() {
     use crate::identifiers::GenericBuilder;
 
     ensure_test_dispatcher();
@@ -248,24 +259,36 @@ fn layer3_generic_builder_no_security_event_on_benign_failure() {
     let capture = register_capture(name);
 
     // Leading digit -> "must start with letter or underscore" (Validation),
-    // not a security detection. The token would surface if wrongly escalated.
-    let token = "9invalid_L3BENIGN_409_c5d1";
-    let err = GenericBuilder::new().validate_identifier(token);
+    // not a security detection. The identifier appears in the emitted message.
+    let bad_ident = "9_benign_warn_marker_ident";
+    let err = GenericBuilder::new().validate_identifier(bad_ident);
     assert!(err.is_err(), "bad identifier must fail validation");
 
-    // Dispatch a probe so we do not just time out on legitimate silence.
-    let probe_marker = "L3BENIGN_PROBE_409_c5d1";
-    dispatch(Event::new(EventType::Info, probe_marker));
-    let flushed = poll_until(POLL_DEADLINE, || {
-        count_with_marker(&capture, probe_marker) >= 1
+    // The benign failure must land as a WARNING carrying the input identifier.
+    let warned = poll_until(POLL_DEADLINE, || {
+        count_with_marker_of_type(&capture, bad_ident, EventType::Warning) >= 1
     });
 
-    let escalated = count_with_marker(&capture, "_L3BENIGN_409_c5d1");
+    // A silent builder must not emit anything for the same benign failure.
+    let silent_ident = "9_benign_silent_marker_ident";
+    let _ = GenericBuilder::silent().validate_identifier(silent_ident);
+    let silent_count = count_with_marker(&capture, silent_ident);
+
+    // The benign path must NOT be escalated to a CRITICAL security event, which
+    // dispatches as `EventType::SystemError` (see observe/event/dispatch.rs).
+    let escalated = count_with_marker_of_type(&capture, bad_ident, EventType::SystemError);
     unregister_writer(name);
 
-    assert!(flushed, "probe event should confirm the dispatcher flushed");
+    assert!(
+        warned,
+        "L3 GenericBuilder must emit a WARNING event on a benign validation failure"
+    );
+    assert_eq!(
+        silent_count, 0,
+        "silent() GenericBuilder must not emit events for a benign failure"
+    );
     assert_eq!(
         escalated, 0,
-        "benign (non-security) validation failures must not emit a security event"
+        "benign (non-security) validation failures must not emit a CRITICAL security event"
     );
 }

--- a/crates/octarine/src/identifiers/builder/metrics.rs
+++ b/crates/octarine/src/identifiers/builder/metrics.rs
@@ -3,7 +3,7 @@
 //! This is the **public API** (Layer 3) that wraps the primitive builder
 //! with observe instrumentation for compliance-grade audit trails.
 
-use super::emit_security_event;
+use crate::observe::EmitProblemEvent;
 use crate::observe::Problem;
 use crate::primitives::identifiers::{MetricViolation, MetricsBuilder as PrimitiveMetricsBuilder};
 
@@ -138,7 +138,7 @@ impl MetricsBuilder {
     pub fn validate_name(&self, name: &str) -> Result<(), Problem> {
         let result = self.inner.validate_name(name);
         if self.emit_events {
-            emit_security_event(&result, "identifiers.metrics.name", name);
+            result.emit_event("identifiers.metrics.name", name);
         }
         result
     }
@@ -147,7 +147,7 @@ impl MetricsBuilder {
     pub fn validate_label_key(&self, key: &str) -> Result<(), Problem> {
         let result = self.inner.validate_label_key(key);
         if self.emit_events {
-            emit_security_event(&result, "identifiers.metrics.label_key", key);
+            result.emit_event("identifiers.metrics.label_key", key);
         }
         result
     }
@@ -160,7 +160,7 @@ impl MetricsBuilder {
     pub fn validate_label_value(&self, value: &str) -> Result<(), Problem> {
         let result = self.inner.validate_label_value(value);
         if self.emit_events {
-            emit_security_event(&result, "identifiers.metrics.label_value", value);
+            result.emit_event("identifiers.metrics.label_value", value);
         }
         result
     }
@@ -174,11 +174,7 @@ impl MetricsBuilder {
     pub fn validate_label_count(&self, count: usize) -> Result<(), Problem> {
         let result = self.inner.validate_label_count(count);
         if self.emit_events {
-            emit_security_event(
-                &result,
-                "identifiers.metrics.label_count",
-                &count.to_string(),
-            );
+            result.emit_event("identifiers.metrics.label_count", &count.to_string());
         }
         result
     }
@@ -217,7 +213,7 @@ impl MetricsBuilder {
     pub fn sanitize_name(&self, name: &str) -> Result<String, Problem> {
         let result = self.inner.sanitize_name(name);
         if self.emit_events {
-            emit_security_event(&result, "identifiers.metrics.sanitize_name", name);
+            result.emit_event("identifiers.metrics.sanitize_name", name);
         }
         result
     }
@@ -226,7 +222,7 @@ impl MetricsBuilder {
     pub fn sanitize_label_key(&self, key: &str) -> Result<String, Problem> {
         let result = self.inner.sanitize_label_key(key);
         if self.emit_events {
-            emit_security_event(&result, "identifiers.metrics.sanitize_label_key", key);
+            result.emit_event("identifiers.metrics.sanitize_label_key", key);
         }
         result
     }
@@ -239,7 +235,7 @@ impl MetricsBuilder {
     pub fn sanitize_label_value(&self, value: &str) -> Result<String, Problem> {
         let result = self.inner.sanitize_label_value(value);
         if self.emit_events {
-            emit_security_event(&result, "identifiers.metrics.sanitize_label_value", value);
+            result.emit_event("identifiers.metrics.sanitize_label_value", value);
         }
         result
     }

--- a/crates/octarine/src/identifiers/builder/mod.rs
+++ b/crates/octarine/src/identifiers/builder/mod.rs
@@ -116,24 +116,6 @@ use crate::primitives::identifiers::confidence::ConfidenceBuilder as PrimitiveCo
 
 use super::types::{IdentifierMatch, IdentifierType};
 
-use crate::observe::Problem;
-
-/// Emit a CRITICAL security event when a validation/sanitization failure is a
-/// security detection (an injection or override attempt), which the primitive
-/// signals via [`Problem::PermissionDenied`]. Benign failures (empty, too long,
-/// bad chars) surface as [`Problem::Validation`] and are intentionally not
-/// escalated here.
-///
-/// This restores the audit trail that Layer-1 constructors previously emitted
-/// as a side effect, now that Layer 1 uses the event-free constructor trait
-/// (issue #409). Audit coverage belongs in these Layer-3 wrappers, gated on the
-/// builder's `emit_events` flag by the caller.
-pub(super) fn emit_security_event<T>(result: &Result<T, Problem>, operation: &str, input: &str) {
-    if let Err(Problem::PermissionDenied(reason)) = result {
-        observe::critical(operation, format!("{reason} (input: {input})"));
-    }
-}
-
 crate::define_metrics! {
     detect_ms => "data.identifiers.unified.detect_ms",
     scan_ms => "data.identifiers.unified.scan_ms",

--- a/crates/octarine/src/identifiers/builder/organizational.rs
+++ b/crates/octarine/src/identifiers/builder/organizational.rs
@@ -7,6 +7,7 @@
 
 use std::borrow::Cow;
 
+use crate::observe::EmitProblemEvent;
 use crate::observe::Problem;
 use crate::primitives::identifiers::OrganizationalIdentifierBuilder;
 
@@ -137,29 +138,53 @@ impl OrganizationalBuilder {
 
     /// Validate employee ID format
     ///
+    /// When observe events are enabled, a validation failure is emitted as a
+    /// WARNING event (or CRITICAL if the primitive surfaces a security
+    /// detection), preserving the audit trail.
+    ///
     /// # Errors
     ///
     /// Returns `Problem` if the employee ID format is invalid
     pub fn validate_employee_id(&self, employee_id: &str) -> Result<(), Problem> {
-        self.inner.validate_employee_id(employee_id)
+        let result = self.inner.validate_employee_id(employee_id);
+        if self.emit_events {
+            result.emit_event("identifiers.organizational.employee_id", employee_id);
+        }
+        result
     }
 
     /// Validate student ID format
+    ///
+    /// When observe events are enabled, a validation failure is emitted as a
+    /// WARNING event (or CRITICAL if the primitive surfaces a security
+    /// detection), preserving the audit trail.
     ///
     /// # Errors
     ///
     /// Returns `Problem` if the student ID format is invalid
     pub fn validate_student_id(&self, student_id: &str) -> Result<(), Problem> {
-        self.inner.validate_student_id(student_id)
+        let result = self.inner.validate_student_id(student_id);
+        if self.emit_events {
+            result.emit_event("identifiers.organizational.student_id", student_id);
+        }
+        result
     }
 
     /// Validate badge number format
+    ///
+    /// When observe events are enabled, a validation failure is emitted as a
+    /// WARNING event (or CRITICAL if the primitive surfaces a security
+    /// detection), preserving the audit trail.
     ///
     /// # Errors
     ///
     /// Returns `Problem` if the badge number format is invalid
     pub fn validate_badge_number(&self, badge_number: &str) -> Result<(), Problem> {
-        self.inner.validate_badge_number(badge_number)
+        let result = self.inner.validate_badge_number(badge_number);
+        if self.emit_events {
+            result.emit_event("identifiers.organizational.badge_number", badge_number);
+        }
+        result
     }
 
     // =========================================================================

--- a/crates/octarine/src/observe/mod.rs
+++ b/crates/octarine/src/observe/mod.rs
@@ -316,6 +316,10 @@ pub use types::{Event, EventContext, EventType, Severity, TenantId, UserId};
 // Problem types with consistent API
 pub use problem::{Problem, ProblemExt, Result};
 
+// Inspection-time event dispatch for `Result<T, Problem>` — internal to the
+// crate, consumed by Layer-3 builders to re-emit audit events (issue #409/#683).
+pub(crate) use problem::EmitProblemEvent;
+
 // Context management (for advanced use)
 pub use context::{
     TenantContext, clear_tenant, get_tenant, is_development, is_production, set_tenant, tenant_id,

--- a/crates/octarine/src/observe/problem/emit.rs
+++ b/crates/octarine/src/observe/problem/emit.rs
@@ -1,0 +1,39 @@
+//! Inspection-time event dispatch for `Result<T, Problem>`.
+//!
+//! Counterpart to [`ProblemExt`](super::ProblemExt) (construct-time dispatch):
+//! this restores the audit trail Layer-1 constructors previously emitted as a
+//! side effect (issue #409), now that Layer 1 uses the event-free constructor
+//! trait. Layer-3 wrappers call `result.emit_event(op, input)`, gated on the
+//! builder's `emit_events` flag, to re-emit the event the primitive no longer
+//! does.
+
+use super::Problem;
+use crate::observe;
+
+/// Emit the observability event a failed `Result` warrants, keyed by the
+/// [`Problem`] variant (the single source of the severity policy):
+///
+/// - [`Problem::PermissionDenied`] — a security detection (injection/override
+///   attempt) → CRITICAL.
+/// - [`Problem::Validation`] / [`Problem::Conversion`] — benign user-input
+///   errors (empty, too long, bad chars, reserved names) → WARNING.
+/// - `Ok(_)` and all other variants → no event.
+pub(crate) trait EmitProblemEvent {
+    /// Dispatch the event for this result's error, if any. `operation` is the
+    /// audit operation name; `input` is echoed into the message as `(input: …)`.
+    fn emit_event(&self, operation: &str, input: &str);
+}
+
+impl<T> EmitProblemEvent for Result<T, Problem> {
+    fn emit_event(&self, operation: &str, input: &str) {
+        match self {
+            Err(Problem::PermissionDenied(reason)) => {
+                observe::critical(operation, format!("{reason} (input: {input})"));
+            }
+            Err(Problem::Validation(reason) | Problem::Conversion(reason)) => {
+                observe::warn(operation, format!("{reason} (input: {input})"));
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/octarine/src/observe/problem/mod.rs
+++ b/crates/octarine/src/observe/problem/mod.rs
@@ -6,6 +6,9 @@
 // Core implementation (internal only)
 mod create;
 
+// Inspection-time event dispatch for `Result<T, Problem>` (internal only)
+mod emit;
+
 // Type definitions
 mod types;
 
@@ -23,6 +26,9 @@ pub(in crate::observe) use builder::shortcuts;
 
 // Public exports - carefully selected for external use
 pub use types::{Problem, Result};
+
+// Inspection-time event dispatch — internal to the crate (Layer-3 builders).
+pub(crate) use emit::EmitProblemEvent;
 
 /// Observability-enabled constructors for [`Problem`].
 ///


### PR DESCRIPTION
## Summary

Follow-up to #409 / PR #682. That refactor moved Layer-1 `Problem` constructors to an event-free trait — correct per the layer architecture, but it also silenced the **Warning-level** events that `Problem::Validation` / `Problem::Conversion` used to dispatch as a construction side effect. #682 restored the CRITICAL security events; this PR restores the missing Warning parity.

Across the L3 identifier builders whose `emit_events` flag gates observability (`database`, `environment`, `generic`, `metrics`, `organizational`), benign validation/conversion failures (empty input, too long, bad characters, reserved names) produced **no observability event at all**.

### Approach

Rather than patch or duplicate the identifiers-local `emit_security_event` free function, the Problem→event-severity mapping is lifted into a single crate-internal extension trait:

- **New `EmitProblemEvent`** trait on `Result<T, Problem>` in `observe/problem/emit.rs` — the *inspection-time* counterpart to the existing *construct-time* `ProblemExt`, co-located with it so the severity policy lives in one place. Call sites read `result.emit_event(op, input)`.
- Dispatch by variant: `PermissionDenied` → CRITICAL (unchanged), `Validation` / `Conversion` → WARNING (restored).
- Wired into all five builders (gated on `emit_events`); the old `emit_security_event` free function is removed (no deprecated alias — pre-1.0 policy).

## Test plan

- Rewrote the `layer_isolation` regression test to be **event-type-aware**: a benign `GenericBuilder` failure must emit a `Warning` event, must **not** escalate to a `SystemError` (CRITICAL) security event, and `silent()` must stay silent. Added a `count_with_marker_of_type` helper.
- Full crate lib tests: **7875 passed / 0 failed**; identifier builder module: 305 passed; `layer_isolation`: 4/4.
- Integration tests + doctests: all pass. `clippy --all-targets --all-features`: clean on changed files. rustdoc `-D warnings`: clean.

> Note: verification was run via the `1.97.0` toolchain because the pinned `1.95.0` in this environment is missing its `cargo` component (a known local issue); results match what CI's toolchain will produce.

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)