### PR TITLE
docs(claude): make audit-agent grep paths layout-agnostic (#670)

### DIFF
--- a/.claude/agents/audit-octarine-identifiers/audit-octarine-identifiers.md
+++ b/.claude/agents/audit-octarine-identifiers/audit-octarine-identifiers.md
@@ -43,13 +43,21 @@ partial error.
 ## The Complete Identifier Chain
 
 ```text
-1. Detection fn     primitives/identifiers/{domain}/detection/    is_{type}()
-2. Validation fn    primitives/identifiers/{domain}/validation/   validate_{type}()
-3. Sanitization fn  primitives/identifiers/{domain}/sanitization/ sanitize_{type}() or redact_{type}()
-4. Prim builder     primitives/identifiers/{domain}/builder/      delegation methods
-5. Public builder   identifiers/builder/{domain}.rs               wrapped methods + observe
-6. Shortcuts        identifiers/shortcuts/                        convenience functions
+1. Detection fn     primitives/identifiers/{domain}/detection[.rs|/]    is_{type}()
+2. Validation fn    primitives/identifiers/{domain}/validation[.rs|/]   validate_{type}()
+3. Sanitization fn  primitives/identifiers/{domain}/sanitization[.rs|/] sanitize_{type}() or redact_{type}()
+4. Prim builder     primitives/identifiers/{domain}/builder[.rs|/]      delegation methods
+5. Public builder   identifiers/builder/{domain}[.rs|/]                 wrapped methods + observe
+6. Shortcuts        identifiers/shortcuts/{domain}.rs                   convenience functions
 ```
+
+**Mixed layout (`[.rs|/]`):** the identifier tree uses BOTH flat files and
+split directories at each node. Of the 18 builder-bearing domains, 13 are flat
+(`detection.rs`, `builder.rs`) and 5 split into directories (`detection/`,
+`builder/`): `government`, `location`, `network`, `personal`, `token`.
+`identifiers/shortcuts/` is always a per-domain directory. See "Layout-Agnostic
+File Resolution" below — a rule that names only one form silently returns zero
+matches for the other.
 
 ## Workflow
 
@@ -63,15 +71,40 @@ partial error.
 5. Track findings with sequential IDs (`octarine-identifiers-001`, ...)
 6. Return a single JSON result
 
+## Layout-Agnostic File Resolution (CRITICAL)
+
+The Grep tool passes its `path` argument to ripgrep verbatim — an embedded `*`
+is NOT glob-expanded and a missing directory errors out. Because domains mix
+flat files and split directories (see above), **never Grep a bare
+`{domain}/detection/` path** — it returns zero matches for the 13 flat domains,
+a false negative that reads as "no violations."
+
+Instead, **resolve files with the Glob tool first, then Grep the resolved
+list.** Each node needs TWO Glob patterns to cover both forms:
+
+```text
+Glob "crates/octarine/src/primitives/identifiers/{domain}/detection.rs"     # flat
+Glob "crates/octarine/src/primitives/identifiers/{domain}/detection/*.rs"   # split
+```
+
+The single `*` before `detection/` matches exactly one path segment, so the
+split pattern does NOT leak the nested `builder/detection.rs`. Apply the same
+flat-`.rs` + split-`/*.rs` pair to every `detection`, `validation`,
+`sanitization`, and `builder` node named in the rules below.
+
 ## Scanning Rules
 
 ### octarine-identifiers/missing-validation (severity: high)
 
-For each `is_{type}` detection function, check for corresponding `validate_{type}`:
+For each `is_{type}` detection function, check for corresponding
+`validate_{type}`. Resolve both nodes with the flat + split Glob pair
+(see "Layout-Agnostic File Resolution"), then Grep the resolved files:
 
 ```text
-Grep pattern="pub fn is_" path="crates/octarine/src/primitives/identifiers/{domain}/detection/"
-Grep pattern="pub fn validate_" path="crates/octarine/src/primitives/identifiers/{domain}/validation/"
+# detection: Glob {domain}/detection.rs AND {domain}/detection/*.rs
+Grep pattern="pub fn is_" path="<each resolved detection file>"
+# validation: Glob {domain}/validation.rs AND {domain}/validation/*.rs
+Grep pattern="pub fn validate_" path="<each resolved validation file>"
 ```
 
 Exception: Simple boolean helpers like `is_test_email()` or `is_reserved_ip()`.
@@ -83,19 +116,25 @@ Flag only types that are PII or sensitive data.
 
 ### octarine-identifiers/missing-builder-method (severity: high)
 
-For each `is_{type}` detection function, check the primitives builder:
+For each `is_{type}` detection function, check the primitives builder. Resolve
+the builder node with the flat + split Glob pair, then Grep the resolved files:
 
 ```text
-Grep pattern="fn is_{type}" path="crates/octarine/src/primitives/identifiers/{domain}/builder/"
+# builder: Glob {domain}/builder.rs AND {domain}/builder/*.rs
+Grep pattern="fn is_{type}" path="<each resolved builder file>"
 ```
 
 ### octarine-identifiers/missing-public-builder-method (severity: high)
 
-For each primitives builder method, check the public builder:
+For each primitives builder method, check the public builder. The public
+builder is ALSO mixed-layout: most domains are a flat `{domain}.rs`, but
+`government/` and `token/` are directories. Resolve both forms with the Glob
+pair, then Grep the resolved files:
 
 ```text
+# Glob identifiers/builder/{domain}.rs AND identifiers/builder/{domain}/*.rs
 Grep pattern="fn is_{type}\|fn validate_{type}\|fn redact_{type}" \
-  path="crates/octarine/src/identifiers/builder/{domain}.rs"
+  path="<each resolved public builder file>"
 ```
 
 ### octarine-identifiers/missing-shortcut (severity: medium)
@@ -127,11 +166,15 @@ Grep pattern="pub(\(crate\) )?fn (has_|contains_|check_|verify_|ensure_|remove_)
 
 ### octarine-identifiers/inheritance-arrow-violation (severity: high)
 
-Detection must NOT import from validation or sanitization:
+Detection must NOT import from validation or sanitization. Resolve every
+domain's detection node with the flat + split Glob pair across all domains,
+then Grep the resolved files:
 
 ```text
+# Glob identifiers/*/detection.rs AND identifiers/*/detection/*.rs
+#   (the single * before detection/ excludes the nested builder/detection.rs)
 Grep pattern="use (super::validation|super::sanitization)" \
-  path="crates/octarine/src/primitives/identifiers/*/detection/"
+  path="<each resolved detection file>"
 ```
 
 ### octarine-identifiers/missing-type-variant (severity: medium)

--- a/.claude/agents/audit-octarine-observe/audit-octarine-observe.md
+++ b/.claude/agents/audit-octarine-observe/audit-octarine-observe.md
@@ -47,6 +47,19 @@ Every builder in these directories wraps primitives with observe:
 - `crates/octarine/src/security/*/builder*`
 - `crates/octarine/src/crypto/*/builder*`
 
+**Builders are mixed-layout — resolve via the Glob tool, never a literal Grep
+`path`.** Some are a flat `builder.rs`, others a `builder/` directory (e.g.
+`data/paths/builder/` splits across many files). A Grep `path` with an embedded
+`*` is not glob-expanded, so passing `data/*/builder*` verbatim errors or
+returns nothing. Discover builder files with the Glob tool using BOTH forms:
+
+```text
+Glob "crates/octarine/src/{data,security,crypto}/*/builder.rs"    # flat
+Glob "crates/octarine/src/{data,security,crypto}/*/builder/*.rs"  # split
+Glob "crates/octarine/src/identifiers/builder/*.rs"               # flat domains
+Glob "crates/octarine/src/identifiers/builder/*/*.rs"             # dir domains (government, token)
+```
+
 Each must include:
 
 1. Metric name definitions (`define_metrics!` or `MetricName::new`)
@@ -58,7 +71,9 @@ Each must include:
 ## Workflow
 
 1. Parse the manifest
-2. Identify all Layer 3 builder files by path pattern
+2. Identify all Layer 3 builder files via the Glob tool using both the flat
+   `builder.rs` and split `builder/*.rs` patterns above — not a literal Grep
+   `path` (which would miss directory-form builders like `data/paths/builder/`)
 3. For each builder, check the categories below
 4. Extract all metric name string literals using
    `Grep pattern='"[a-z]+\.[a-z]+\.'` and verify they follow the

--- a/.claude/agents/audit-octarine-visibility/audit-octarine-visibility.md
+++ b/.claude/agents/audit-octarine-visibility/audit-octarine-visibility.md
@@ -98,8 +98,13 @@ Identify non-mod.rs, non-core.rs files in `builder/` directories. Check for:
 
 ### shortcut-bypasses-builder (severity: high)
 
+Shortcuts are mixed-layout: most modules keep a flat `shortcuts.rs`, but
+`identifiers/shortcuts/` is a per-domain directory. A `glob="shortcuts.rs"`
+misses the directory form, so use a brace glob that catches both:
+
 ```text
-Grep pattern="crate::primitives::" path="crates/octarine/src/" glob="shortcuts.rs"
+Grep pattern="crate::primitives::" path="crates/octarine/src/" \
+  glob="{**/shortcuts.rs,**/shortcuts/*.rs}"
 ```
 
 Shortcuts must use the builder, not import from primitives directly.

--- a/.claude/skills/octarine-identifier-checklist/SKILL.md
+++ b/.claude/skills/octarine-identifier-checklist/SKILL.md
@@ -51,7 +51,8 @@ Every identifier type requires ALL applicable steps.
 9. **Public builder** — `identifiers/builder/{domain}.rs`
    - Wraps primitives builder + adds observe (metrics, events, timing)
 
-10. **Shortcuts** — `identifiers/shortcuts.rs`
+10. **Shortcuts** — `identifiers/shortcuts/{domain}.rs`
+    (`identifiers/shortcuts/` is a per-domain directory, not a flat file)
     - `pub fn is_{type}(v: &str) -> bool { {Domain}Builder::new().is_{type}(v) }`
     - `pub fn validate_{type}(v: &str) -> Result<(), Problem> { ... }`
 

--- a/.claude/skills/octarine-identifier-checklist/implementation-template.md
+++ b/.claude/skills/octarine-identifier-checklist/implementation-template.md
@@ -180,7 +180,8 @@ impl {Domain}Builder {
 
 ### Step 10: Shortcuts
 
-In `crates/octarine/src/identifiers/shortcuts.rs`:
+In `crates/octarine/src/identifiers/shortcuts/{domain}.rs`
+(`identifiers/shortcuts/` is a per-domain directory):
 
 ```rust
 pub fn is_{type}(value: &str) -> bool {
@@ -198,7 +199,9 @@ pub fn redact_{type}(value: &str) -> String {
 
 ### Step 11: PII Registration (if PII)
 
-In `crates/octarine/src/identifiers/types/core.rs`, add variant:
+In `crates/octarine/src/primitives/identifiers/types/core.rs`, add variant
+(the primitives enum is the source of truth; the Layer 3
+`identifiers/types/core.rs` merely re-exports it — do not edit that one):
 
 ```rust
 pub enum IdentifierType {
@@ -262,31 +265,43 @@ Then wire up in parent `mod.rs` files:
 
 ## Verification Commands
 
-After implementation, verify completeness:
+After implementation, verify completeness. The identifier tree is mixed-layout:
+`{domain}/detection` (and `validation`, `builder`) is a flat `.rs` for 13
+domains but a directory for 5 (`government`, `location`, `network`, `personal`,
+`token`). Each `grep -r` below names BOTH forms so it works regardless of the
+domain's layout (a nonexistent path is silently skipped by `grep -r`):
 
 ```bash
 # Check all detection functions have corresponding validation
-grep -r "pub fn is_" crates/octarine/src/primitives/identifiers/{domain}/detection/
-grep -r "pub fn validate_" crates/octarine/src/primitives/identifiers/{domain}/validation/
+grep -rs "pub fn is_" \
+  crates/octarine/src/primitives/identifiers/{domain}/detection.rs \
+  crates/octarine/src/primitives/identifiers/{domain}/detection/
+grep -rs "pub fn validate_" \
+  crates/octarine/src/primitives/identifiers/{domain}/validation.rs \
+  crates/octarine/src/primitives/identifiers/{domain}/validation/
 
 # Check primitives builder coverage
-grep -r "pub fn is_\|pub fn validate_\|pub fn redact_" \
+grep -rs "pub fn is_\|pub fn validate_\|pub fn redact_" \
+  crates/octarine/src/primitives/identifiers/{domain}/builder.rs \
   crates/octarine/src/primitives/identifiers/{domain}/builder/
 
-# Check public builder coverage
-grep -r "pub fn is_\|pub fn validate_\|pub fn redact_" \
-  crates/octarine/src/identifiers/builder/{domain}.rs
+# Check public builder coverage (flat {domain}.rs OR {domain}/ directory)
+grep -rs "pub fn is_\|pub fn validate_\|pub fn redact_" \
+  crates/octarine/src/identifiers/builder/{domain}.rs \
+  crates/octarine/src/identifiers/builder/{domain}/
 
-# Check shortcuts coverage
-grep -r "pub fn is_\|pub fn validate_\|pub fn redact_" \
-  crates/octarine/src/identifiers/shortcuts.rs | grep {type}
+# Check shortcuts coverage (shortcuts/ is a per-domain directory)
+grep -rs "pub fn is_\|pub fn validate_\|pub fn redact_" \
+  crates/octarine/src/identifiers/shortcuts/{domain}.rs | grep {type}
 
 # Check for naming violations
 grep -rn "pub fn \(has_\|contains_\|check_\|verify_\|ensure_\|remove_\)" \
   crates/octarine/src/
 
 # Check for inheritance arrow violations (detection importing validation)
-grep -r "use.*validation\|use.*sanitization" \
+# Covers both {domain}/detection.rs and {domain}/detection/*.rs
+grep -rs "use.*validation\|use.*sanitization" \
+  crates/octarine/src/primitives/identifiers/*/detection.rs \
   crates/octarine/src/primitives/identifiers/*/detection/
 
 # Run tests


### PR DESCRIPTION
Closes #670.

## Problem

The identifier source tree is **mixed-layout**: of 18 builder-bearing domains, 13 are flat (`detection.rs`, `builder.rs`) and 5 split into directories (`government`, `location`, `network`, `personal`, `token`). Several audit-agent scanning rules and two skill docs hard-coded a single layout, so a rule naming only one form **silently returned zero matches for the other** — a false negative that reads as "no violations."

Compounding it: the Grep tool passes `path` to ripgrep verbatim (no `*` expansion), and ripgrep anchors slash-containing globs to cwd — so a bare-basename glob like `detection.rs` also leaks the nested `builder/detection.rs` in split domains.

## Fix

Adopt **Glob-tool-first resolution** with a flat-`.rs` + split-`/*.rs` pattern pair (the single `*` before the node dir excludes `builder/`), matching the convention already used in `audit-octarine-visibility.md`.

- **audit-octarine-identifiers**: new *Layout-Agnostic File Resolution* section; rewrote `missing-validation`, `missing-builder-method`, `missing-public-builder-method` (now catches the `government/`/`token/` directory public builders), and `inheritance-arrow-violation`; annotated the Complete Identifier Chain table.
- **audit-octarine-visibility**: `shortcut-bypasses-builder` now uses `glob="{**/shortcuts.rs,**/shortcuts/*.rs}"` to catch the `identifiers/shortcuts/` directory.
- **audit-octarine-observe**: builder discovery must go through the Glob tool covering both flat `builder.rs` and split `builder/*.rs` (e.g. `data/paths/builder/`).
- **octarine-identifier-checklist SKILL + template**: `shortcuts.rs` → `shortcuts/{domain}.rs`; corrected the `IdentifierType` variant path to `primitives/identifiers/types/core.rs` (L3 is a re-export); verification `grep` block now names both flat and split paths.

`octarine-pii-bridge/SKILL.md` already referenced `types/core.rs` and `types/mod.rs` from an earlier partial fix — no change needed.

## Verification

- `just lint-md` → clean (112 files), `just spell` → clean.
- Glob smoke check: `ls */detection.rs */detection/*.rs | grep -c builder` → `0` (flat + split both resolve, no `builder/` leak).
- Docs-only change; no Rust source touched.

_Follow-up to #406, surfaced by that PR's adversarial pre-PR review._

🤖 Generated with [Claude Code](https://claude.com/claude-code)