### PR TITLE
test(primitives): fix flaky cache cleanup test under parallel load

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -20,7 +20,7 @@
 - [Worktree submodule blocks commits](project_worktree_submodule_hooks.md) — fresh worktree commits fail lefthook 127 (`containers/bin/fix-*.sh not found`); run `git submodule update --init --force --checkout containers`
 - [Zed replaces ENTRYPOINT](project_zed_entrypoint_recover.md) — Zed devcontainers skip first-startup hooks (codegraph index, OP secrets); postStartCommand must lead with `recover-entrypoint &&`, never index codegraph from post-create.sh
 - [crypto::secrets mlock stub + SecureMap leaks keys](project_crypto_secrets_mlock_stub.md) — mlock is a no-op stub (no real syscall, unsafe forbidden); SecureMap logs keys in cleartext & Layer-3 wrappers log on construct. Use Layer-1 `PrimitiveLockedSecret` + `blake3_hex` for keyed PII.
-- [Flaky test_cache_cleanup](project_flaky_cache_cleanup_test.md) — collections/cache/lru.rs timing test flakes under parallel load; passes in isolation, treat as pre-existing not a regression
+- [Fixed flaky test_cache_cleanup](project_flaky_cache_cleanup_test.md) — collections/cache/lru.rs expiry test flaked under parallel load (single-call-vs-accumulate race); fixed 2026-07-16 by accumulating cleanup_expired count
 - [L3 merge authority](feedback_l3_merge_authority.md) — at L3 auto-merge golem PRs once green+clean+mergeable (squash+delete-branch), without asking; reversed the old "humans merge" rule on 2026-07-15
 - [Golem launch level bug](project_golem_launch_level_bug.md) — golem-launch.sh hardcodes --level 4, drops any --level arg; every golem runs L4. File against workflow plugin.
 - [Identifier mixed layout](project_identifier_mixed_layout.md) — identifier tree mixes flat .rs and split dirs; audit-agent grep rules must resolve Glob-first (flat + split pattern pair), not a bare dir path

--- a/.claude/memory/project_flaky_cache_cleanup_test.md
+++ b/.claude/memory/project_flaky_cache_cleanup_test.md
@@ -1,6 +1,6 @@
 ---
 name: project_flaky_cache_cleanup_test
-description: test_cache_cleanup in collections/cache/lru.rs is timing-flaky under parallel load
+description: test_cache_cleanup in collections/cache/lru.rs WAS timing-flaky under parallel load; fixed 2026-07-16
 metadata:
   node_type: memory
   type: project
@@ -8,16 +8,24 @@ metadata:
 ---
 
 `primitives::collections::cache::lru::tests::test_cache_cleanup`
-(`crates/octarine/src/primitives/collections/cache/lru.rs:416`) is a
-timing-based expiry test that flakes under `just test` when the runner is
-under load (e.g. after fd exhaustion / heavy parallel linking) — fails with
-"Timed out waiting for 5 entries to expire (got 0, len 0)". It passes reliably
-in isolation (`just test-filter test_cache_cleanup`).
+(`crates/octarine/src/primitives/collections/cache/lru.rs`) used to flake under
+full-parallel load (`just test`, `just release` preflight — no retries there)
+with "Timed out waiting for 5 entries to expire (got 0, len 0)", while passing in
+isolation.
 
-**Why:** hard timing assertion on TTL expiry, the exact anti-pattern
-`octarine-test-resilience` warns about.
+**Root cause (now understood):** the 5 entries are inserted at slightly different
+instants, so under load they expire *piecemeal* across several `cleanup_expired()`
+calls (one removes 3, the next 2). The test demanded a **single** call return
+exactly 5, which never happened — the cache drained to empty without any one call
+seeing 5. Not a timing-threshold problem; a single-call-vs-accumulate race.
 
-**How to apply:** if a `/next-issue` full-suite run fails ONLY on this test,
-confirm it passes in isolation and treat it as pre-existing flake, not a
-regression from your change. Candidate for a poll-with-timeout fix under its
-own issue. Related: [[project_ci_macos_cache_poisoning]].
+**Fix (2026-07-16):** accumulate the removed count across poll iterations
+(`expired += cache.cleanup_expired()` until `>= 5`) instead of requiring one call
+to return 5 — `octarine-test-resilience` Rule 6 (measure the total delta).
+Verified 10× in isolation + full-workspace `cargo nextest` (8477/8477) under the
+same contention that failed the release. Shipped on branch
+`fix/flaky-cache-cleanup-test`.
+
+**How to apply:** this specific flake should no longer recur. If it does, the
+`cleanup_expired` accumulation loop is the place to look. Related:
+[[project_ci_macos_cache_poisoning]].

--- a/crates/octarine/src/primitives/collections/cache/lru.rs
+++ b/crates/octarine/src/primitives/collections/cache/lru.rs
@@ -405,22 +405,28 @@ mod tests {
 
         assert_eq!(cache.len(), 5);
 
-        // Poll until all entries expire (cleanup_expired sees them as stale).
+        // Poll until all entries expire. The 5 entries are inserted at slightly
+        // different instants, so under load they can expire piecemeal across
+        // several cleanup_expired() calls (one call removes 3, the next 2, etc.).
+        // Accumulate the removed count rather than requiring a single call to
+        // return all 5 — otherwise the cache can drain to empty without any one
+        // call ever seeing exactly 5 (Rule 6: measure the total delta).
         let deadline = Instant::now() + Duration::from_secs(5);
-        let expired = loop {
-            let count = cache.cleanup_expired();
-            if count == 5 {
-                break count;
+        let mut expired = 0;
+        while expired < 5 {
+            expired += cache.cleanup_expired();
+            if expired >= 5 {
+                break;
             }
             if Instant::now() > deadline {
                 panic!(
-                    "Timed out waiting for 5 entries to expire (got {}, len {})",
-                    count,
+                    "Timed out waiting for 5 entries to expire (removed {}, len {})",
+                    expired,
                     cache.len()
                 );
             }
             std::thread::sleep(Duration::from_millis(10));
-        };
+        }
         assert_eq!(expired, 5);
         assert_eq!(cache.len(), 0);
     }


### PR DESCRIPTION
## Summary

Fixes the flaky `test_cache_cleanup` (`primitives::collections::cache::lru`) that **blocked cutting v0.3.0-beta.6** — `just release` preflight runs `cargo nextest` with no retries, and this test flakes under full-parallel load.

**Root cause:** the test inserts 5 entries then polls `cleanup_expired()`, breaking only when a *single* call returns exactly 5. The entries are inserted at slightly different instants, so under load they expire piecemeal across several cleanup calls (one removes 3, the next 2). No single call ever returns 5 — the cache drains to empty and the poll times out with `got 0, len 0`. A single-call-vs-accumulate race, not a timing threshold.

**Fix:** accumulate the removed count across poll iterations until it reaches 5 (`octarine-test-resilience` Rule 6 — measure the total delta) instead of requiring one call to return all 5. Production `cleanup_expired()` is unchanged.

Also refreshes the `project_flaky_cache_cleanup_test` memory note from "accepted pre-existing flake" to "fixed, with root cause".

## Test plan

- 10× in isolation — all green
- Full-workspace `cargo nextest --workspace --all-features` — **8477/8477 passed**, under the exact contention that failed the release preflight

Closes #704